### PR TITLE
pytest: use latest version < 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ HTML/
 .settings
 .DS_Store
 .cache/
+.pytest_cache/
 .idea/
 .sqlite
 *.orig

--- a/MoinMoin/storage/stores/_tests/conftest.py
+++ b/MoinMoin/storage/stores/_tests/conftest.py
@@ -89,15 +89,18 @@ def make_store(request):
     return store
 
 
-def pytest_funcarg__bst(request):
+@pytest.fixture
+def bst(request):
     return make_store(request)
 
 
-def pytest_funcarg__fst(request):
+@pytest.fixture
+def fst(request):
     return make_store(request)
 
 
-def pytest_funcarg__store(request):
+@pytest.fixture
+def store(request):
     store = make_store(request)
     storename, kind = request.param
     if kind == 'FileStore':

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,11 +39,11 @@ output_dir = MoinMoin/translations/
 [compile_catalog]
 directory = MoinMoin/translations/
 
-[pytest]
+[tool:pytest]
 # Note: we need pytest-pep8 >= 1.0.4 to make pep8maxlinelength work, but that
 # needs a pytest >= 2.3, so, we can't use that until our test work with that.
 #pep8maxlinelength = 120
-norecursedirs = .hg _build tmp* env* dlc wiki support
+norecursedirs = .git _build tmp* env* dlc wiki support
 minversion = 2.0
 pep8ignore =
  *.py E124  # closing bracket does not match visual indentation (behaves strange!?)

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup_args = dict(
         'Jinja2>=2.7',  # template engine
         'pygments>=1.4',  # src code / text file highlighting
         'Werkzeug>=0.11.2',  # wsgi toolkit
-        'pytest<2.7',  # pytest is needed by unit tests (only tested with 2.5 and 2.6)
+        'pytest<3.0',  # unit tests
         'pytest-pep8<1.1',  # coding style checker (only tested with 1.0.x)
         'whoosh>=2.7.0',  # needed for indexed search
         'sphinx>=1.1',  # needed to build the docs


### PR DESCRIPTION
also: fix some deprecated stuff, exclude .git directory