### PR TITLE
configure flask_caching to get rid of warning

### DIFF
--- a/MoinMoin/app.py
+++ b/MoinMoin/app.py
@@ -145,7 +145,8 @@ def create_app_ext(flask_config_file=None, flask_config_dict=None,
     app.register_blueprint(serve, url_prefix='/+serve')
     clock.stop('create_app register')
     clock.start('create_app flask-cache')
-    cache = Cache()
+    # the 'simple' caching uses a dict and is not thread safe according to the docs.
+    cache = Cache(config={'CACHE_TYPE': 'simple'})
     cache.init_app(app)
     app.cache = cache
     clock.stop('create_app flask-cache')


### PR DESCRIPTION
without configuring, it is disabled and whines about it (see the tests).

let's see if the 'simple' cache is good enough for development,
otherwise we'ld need to go to disk or silence the warning.