### PR TITLE
fix rst_in.py failure due to failed import of pytest

### DIFF
--- a/src/moin/converter/rst_in.py
+++ b/src/moin/converter/rst_in.py
@@ -18,7 +18,6 @@ Works with docutils version 0.5 (2008-06-25) or higher.
 from __future__ import absolute_import, division
 
 import re
-import pytest
 import docutils
 
 from werkzeug import url_encode, url_decode
@@ -36,14 +35,11 @@ from moin.constants.contenttypes import CHARSET
 
 from ._util import allowed_uri_scheme, decode_data, normalize_split_text
 
-# ### TODO: try block (do not crash if we don't have docutils)
-pytest.importorskip('docutils')
 from docutils import nodes, utils, writers, core
 from docutils.parsers.rst import Parser
 from docutils.nodes import reference, literal_block
 from docutils.parsers import rst
 from docutils.parsers.rst import directives, roles
-# ####
 
 from moin import log
 logging = log.getLogger(__name__)


### PR DESCRIPTION
pytest.importorskip('docutils') seems obsolete, if no docutils, many tests should fail