### PR TITLE
remove unused salt param, we never used a non-default value

### DIFF
--- a/src/moin/user.py
+++ b/src/moin/user.py
@@ -491,7 +491,7 @@ class User(object):
                 data[ENC_PASSWORD] = recomputed_hash
         return password_correct, bool(recomputed_hash)
 
-    def set_password(self, password, is_encrypted=False, salt=None):
+    def set_password(self, password, is_encrypted=False):
         """
         Set or update the password (hash) stored for this user.
 
@@ -502,14 +502,12 @@ class User(object):
                              "encrypted" (hashed) before getting stored.
                              if True, the already "encrypted" password hash is given in param
                              password and will be stored "as is" - this is mainly useful for tests.
-        :param salt: if None (default), passlib will generate and use a random salt.
-                     Otherwise, the given salt will be used - this is mainly useful for tests.
         """
         if not password:
             # invalidate the pw hash
             password = ''
         elif not is_encrypted:
-            password = self._cfg.cache.pwd_context.hash(password, salt=salt)
+            password = self._cfg.cache.pwd_context.hash(password)
         self.profile[ENC_PASSWORD] = password
         # Invalidate all other browser sessions except this one.
         session['user.session_token'] = self.generate_session_token(False)


### PR DESCRIPTION
this should fix the DeprecationWarning about giving additional params
to .hash(). we do not use this for tests.

fixes #657.