### PR TITLE
docbook_in: add td -> table-cell

### DIFF
--- a/src/moin/converter/_tests/test_docbook_in.py
+++ b/src/moin/converter/_tests/test_docbook_in.py
@@ -230,7 +230,6 @@ class TestConverter(Base):
         '/page/body/div/table[./table-header/table-row[table-cell="a1"]][./table-footer/table-row[table-cell="f1"]][./table-body/table-row[table-cell/table/table-body/table-row[table-cell="s1"]]]'),
     ]
 
-    @pytest.mark.skip('broken, please fix')
     @pytest.mark.parametrize('input,xpath', data)
     def test_table(self, input, xpath):
         self.do(input, xpath)

--- a/src/moin/converter/docbook_in.py
+++ b/src/moin/converter/docbook_in.py
@@ -1008,7 +1008,7 @@ class Converter(object):
 
     def visit_docbook_entry(self, element, depth):
         """
-        <td> --> <table-cell>
+        <entry> --> <table-cell>
         """
         attrib = {}
         rowspan = element.get('morerows')
@@ -1020,6 +1020,20 @@ class Converter(object):
                 attrib[moin_page.number_columns_spanned] = unicode(1 + int(colspan))
         except ValueError:
             pass
+        return self.new_copy(moin_page.table_cell,
+                             element, depth, attrib=attrib)
+
+    def visit_docbook_td(self, element, depth):
+        """
+        <td> --> <table-cell>
+        """
+        attrib = {}
+        rowspan = element.get('rowspan')
+        colspan = element.get('colspan')
+        if rowspan:
+            attrib[moin_page.number_rows_spanned] = rowspan
+        if colspan:
+            attrib[moin_page.number_columns_spanned] = colspan
         return self.new_copy(moin_page.table_cell,
                              element, depth, attrib=attrib)
 


### PR DESCRIPTION
similar code for entry -> table-cell exists, but td was missing.

fixes #626.