### PR TITLE
creole_in: added a commented and failing test for issue #386

### DIFF
--- a/src/moin/converter/_tests/test_creole_in.py
+++ b/src/moin/converter/_tests/test_creole_in.py
@@ -269,6 +269,9 @@ class TestConverter(object):
          '<page><body><p>Text</p><list item-label-generate="unordered"><list-item><list-item-body>Item</list-item-body></list-item></list><table><table-body><table-row><table-cell>Item</table-cell></table-row></table-body></table></body></page>'),
         (u'Text\n|Item\nText',
          '<page><body><p>Text</p><table><table-body><table-row><table-cell>Item</table-cell></table-row></table-body></table><p>Text</p></body></page>'),
+        # TODO broken creole table parsing, see issue #386 - this is 1 table cell with some text and a link
+        # (u'| text [[http://localhost | link]] |',
+        #  '<page><body><table><table-body><table-row><table-cell>text <a xlink:href="http://localhost">link</a></table-cell></table-row></table-body></table></body></page>'),
     ]
 
     @pytest.mark.parametrize('input,output', data)

--- a/src/moin/converter/_tests/test_creole_in.py
+++ b/src/moin/converter/_tests/test_creole_in.py
@@ -269,9 +269,8 @@ class TestConverter(object):
          '<page><body><p>Text</p><list item-label-generate="unordered"><list-item><list-item-body>Item</list-item-body></list-item></list><table><table-body><table-row><table-cell>Item</table-cell></table-row></table-body></table></body></page>'),
         (u'Text\n|Item\nText',
          '<page><body><p>Text</p><table><table-body><table-row><table-cell>Item</table-cell></table-row></table-body></table><p>Text</p></body></page>'),
-        # TODO broken creole table parsing, see issue #386 - this is 1 table cell with some text and a link
-        # (u'| text [[http://localhost | link]] |',
-        #  '<page><body><table><table-body><table-row><table-cell>text <a xlink:href="http://localhost">link</a></table-cell></table-row></table-body></table></body></page>'),
+        (u'| text [[http://localhost | link]] |',
+         '<page><body><table><table-body><table-row><table-cell>text <a xlink:href="http://localhost">link</a> </table-cell></table-row></table-body></table></body></page>'),
     ]
 
     @pytest.mark.parametrize('input,output', data)

--- a/src/moin/converter/creole_in.py
+++ b/src/moin/converter/creole_in.py
@@ -545,7 +545,8 @@ class Converter(ConverterMacro):
             \|
             \s*
             (?P<cell_head> [=] )?
-            (?P<cell_text> [^|]+ )
+            # a table cells may contain links (which may contain |) or characters that are not |
+            (?P<cell_text> (\[\[.*?\]\]|[^|])+ )
             \s*
         )
     """


### PR DESCRIPTION
not sure how to build a better parsing regex.

the problem is that the table parser splits the table cells at `|`.

when the table cell contains link markup like `[[link_target | link_text]]`, the table parser should not split the cell at the `|` contained in there.