### PR TITLE
Revert "fix #792, traceback when modified ACL denies read access to c…

### DIFF
--- a/src/moin/storage/middleware/protecting.py
+++ b/src/moin/storage/middleware/protecting.py
@@ -153,17 +153,6 @@ class ProtectingMiddleware(object):
             if rev.allows(READ) or rev.allows(PUBREAD):
                 yield rev
 
-    def search_bypass_ACL(self, q, idx_name=LATEST_REVS, **kw):
-        """
-        For use by notifications to produce diff, prevents traceback when editor changes ACLs
-        removing read permission for self.
-        """
-        for rev in self.indexer.search(q, idx_name, **kw):
-            rev = ProtectedRevision(self, rev)
-            if not (rev.allows(READ) or rev.allows(PUBREAD)):
-                logging.warning('User {0} updated {1} ACL removing read permission for self'.format(self.user.name[0], rev.fqname.value))
-            yield rev
-
     def search_page(self, q, idx_name=LATEST_REVS, pagenum=1, pagelen=10, **kw):
         for rev in self.indexer.search_page(q, idx_name, pagenum, pagelen, **kw):
             rev = ProtectedRevision(self, rev)

--- a/src/moin/utils/notifications.py
+++ b/src/moin/utils/notifications.py
@@ -194,7 +194,9 @@ def get_item_last_revisions(app, fqname):
     """
     terms = [Term(WIKINAME, app.cfg.interwikiname), Term(fqname.field, fqname.value), ]
     query = And(terms)
-    return list(flaskg.storage.search_bypass_ACL(query, idx_name=ALL_REVS, sortedby=[MTIME], reverse=True, limit=2))
+    return list(
+        flaskg.storage.search(query, idx_name=ALL_REVS, sortedby=[MTIME],
+                              reverse=True, limit=2))
 
 
 @item_modified.connect_via(ANY)
@@ -214,7 +216,6 @@ def send_notifications(app, fqname, **kwargs):
         content_diff = notification.get_content_diff()
     except Exception:
         # current user has likely corrupted an item or fixed a corrupted item
-        # or changed ACL and removed read access for himself
         # if current item is corrupt, another exception will occur in a downstream script
         content_diff = [u'- ' + _('An error has occurred, the current or prior revision of this item may be corrupt.')]
     meta_diff = notification.get_meta_diff()


### PR DESCRIPTION
…urrent user"

This reverts commit 594a4d6ffa98b32e6cfe33214ddf7d52c24ee0bb.

causes "access denied" after user successfully creates and saves home page