### PR TITLE
ItemPageList updates per request

### DIFF
--- a/contrib/sample/MoinWikiMacros.data
+++ b/contrib/sample/MoinWikiMacros.data
@@ -321,7 +321,7 @@ An unordered list links for all descendents of the "Foo/Bar" item, using
 the un-cameled text of each decendent's name, using a '-' character between
 blocks of letters and blocks of numbers.
 
-<<ItemPageList("Foo/Bar", display="UnCameled", numsep='-')>>
+<<ItemPageList(item="Foo/Bar", display="UnCameled", numsep='-')>>
 }}}
 
 '''Result:'''
@@ -341,7 +341,7 @@ An unordered list links for all descendents of the "Foo/Bar" item, using
 the un-cameled text of each decendent's name, using a '-' character between
 blocks of letters and blocks of numbers.
 
-<<ItemPageList("Foo/Bar", display="UnCameled", numsep='-')>>
+<<ItemPageList(item="Foo/Bar", display="UnCameled", numsep='-')>>
 
 === RandomItem ===
 

--- a/contrib/sample/MoinWikiMacros.data
+++ b/contrib/sample/MoinWikiMacros.data
@@ -301,47 +301,138 @@ Pages starting with "ma":
 
 <<PagenameList(ma)>>
 
+
+
 === ItemPageList ===
+
+All of the examples below search for descendents under the top-level "OtherTextItems"
+item, the only sample item that contains descendents.
+
+The only parameter variation not illustrated is the the "UnCameled" display option to
+use a separator character between blocks of letters and blocks of numbers.  This
+variation is not illustrated because none of the sample descendents contain that
+pattern.
+
+
+===== The "ordered" parameter =====
+
 
 '''Markup:'''
 
 {{{
-An unordered list of links for all descendents of the top-level item, using
-the full name of each decendents:
+All items as an unordered list (the default):
 
-<<ItemPageList()>>
+<<ItemPageList(item="OtherTextItems")>>
 
-An ordered list of links for all descendents of the "Foo/Bar" item begining
-with the letter 'A' and containing the substring "abc", using the full name
-of each decendents:
+All items as an ordered list:
 
-<<ItemPageList(item="Foo/Bar", startswith="A", regex="abc", ordered='True')>>
-
-An unordered list links for all descendents of the "Foo/Bar" item, using
-the un-cameled text of each decendent's name, using a '-' character between
-blocks of letters and blocks of numbers.
-
-<<ItemPageList(item="Foo/Bar", display="UnCameled", numsep='-')>>
+<<ItemPageList(item="OtherTextItems" ordered="True")>>
 }}}
 
 '''Result:'''
 
-An unordered list of links for all descendents of the top-level item, using
-the full name of each decendents:
+All items as an unordered list (the default):
 
-<<ItemPageList()>>
+<<ItemPageList(item="OtherTextItems")>>
 
-An ordered list of links for all descendents of the "Foo/Bar" item begining
-with the letter 'A' and containing the substring "abc", using the full name
-of each decendents:
+All items as an ordered list:
 
-<<ItemPageList(item="Foo/Bar", startswith="A", regex="abc", ordered='True')>>
+<<ItemPageList(item="OtherTextItems", ordered="True")>>
 
-An unordered list links for all descendents of the "Foo/Bar" item, using
-the un-cameled text of each decendent's name, using a '-' character between
-blocks of letters and blocks of numbers.
 
-<<ItemPageList(item="Foo/Bar", display="UnCameled", numsep='-')>>
+===== The "startswith" parameter =====
+
+Search for when the descendent's name begins with the letter 'P'.  Note that using
+the "startswith" parameter is more efficient than the equivalent "regex" expression:
+
+'''Markup:'''
+
+{{{
+<<ItemPageList(item="OtherTextItems", startswith="P")>>
+}}}
+
+'''Result:'''
+
+<<ItemPageList(item="OtherTextItems", startswith="P")>>
+
+
+===== The "regex" parameter =====
+
+'''Markup:'''
+
+{{{
+Those items containing the string "Text" anywhere in the full path name:
+
+<<ItemPageList(item="OtherTextItems", regex="Text")>>
+
+Those items containing the string "Text" only in the descendent's name:
+
+<<ItemPageList(item="OtherTextItems", regex="^.*/.*Text")>>
+
+Those items containing a vowel as the 3rd-to-last character:
+
+<<ItemPageList(item="OtherTextItems", regex="(?i)[aeiou].{2}$")>>
+}}}
+
+'''Result:'''
+
+Those items containing the string "Text" anywhere in the full path name:
+
+<<ItemPageList(item="OtherTextItems", regex="Text")>>
+
+Those items containing the string "Text" only in the descendent's name:
+
+<<ItemPageList(item="OtherTextItems", regex="^.*/.*Text")>>
+
+Those items containing a vowel as the 3rd-to-last character:
+
+<<ItemPageList(item="OtherTextItems", regex="(?i)[aeiou].{2}$")>>
+
+
+===== The "display" parameter =====
+
+All of the following examples display just the "PlainText" item.
+
+'''Markup:'''
+
+{{{
+Displayed using "FullPath" (the default, see examples above):
+
+<<ItemPageList(item="OtherTextItems", regex="PlainText", display="FullPath")>>
+
+Displayed using "FullPath":
+
+<<ItemPageList(item="OtherTextItems", regex="PlainText", display="ChildPath")>>
+
+Displayed using "ChildName":
+
+<<ItemPageList(item="OtherTextItems", regex="PlainText", display="ChildName")>>
+
+Displayed using "UnCameled":
+
+<<ItemPageList(item="OtherTextItems", regex="PlainText", display="UnCameled")>>
+}}}
+
+'''Result:'''
+
+Displayed using "FullPath":
+
+<<ItemPageList(item="OtherTextItems", regex="PlainText", display="FullPath")>>
+
+Displayed using "FullPath":
+
+<<ItemPageList(item="OtherTextItems", regex="PlainText", display="ChildPath")>>
+
+Displayed using "ChildName":
+
+<<ItemPageList(item="OtherTextItems", regex="PlainText", display="ChildName")>>
+
+Displayed using "UnCameled":
+
+<<ItemPageList(item="OtherTextItems", regex="PlainText", display="UnCameled")>>
+
+
+
 
 === RandomItem ===
 

--- a/contrib/sample/MoinWikiMacros.data
+++ b/contrib/sample/MoinWikiMacros.data
@@ -308,11 +308,6 @@ Pages starting with "ma":
 All of the examples below search for descendents under the top-level "OtherTextItems"
 item, the only sample item that contains descendents.
 
-The only parameter variation not illustrated is the the "UnCameled" display option to
-use a separator character between blocks of letters and blocks of numbers.  This
-variation is not illustrated because none of the sample descendents contain that
-pattern.
-
 
 ===== The "ordered" parameter =====
 

--- a/contrib/sample/MoinWikiMacros.data
+++ b/contrib/sample/MoinWikiMacros.data
@@ -305,32 +305,70 @@ Pages starting with "ma":
 
 === ItemPageList ===
 
-All of the examples below search for descendents under the top-level "OtherTextItems"
-item, the only sample item that contains descendents.
+This section is partitioned into subsections, one for each ItemPageList parameter.
+
+Most of the examples below search for descendents under the top-level "OtherTextItems"
+item, the only sample-wiki item that contains a significant number of descendents.
 
 
-===== The "ordered" parameter =====
+===== The "item" parameter =====
 
 
 '''Markup:'''
 
 {{{
-All items as an unordered list (the default):
+The default is the current page:
 
-<<ItemPageList(item="OtherTextItems")>>
+<<ItemPageList()>>
 
-All items as an ordered list:
+An empty string gives the wiki root:
+
+<<ItemPageList(item="")>>
+
+An item that does not exist (potentially due to ACLs) produces a warning:
+
+<<ItemPageList(item="DoesNotExist")>>
+
+An item that has no children (potentially due to ACLs) produces a message stating so:
+
+<<ItemPageList(item="Home/subitem")>>
+}}}
+
+'''Result:'''
+
+The default is the current page:
+
+<<ItemPageList()>>
+
+An empty string gives the wiki root:
+
+<<ItemPageList(item="")>>
+
+An item that does not exist (potentially due to ACLs) produces a warning:
+
+<<ItemPageList(item="DoesNotExist")>>
+
+An item that has no children (potentially due to ACLs) produces a message stating so:
+
+<<ItemPageList(item="Home/subitem")>>
+
+
+===== The "ordered" parameter =====
+
+Lists are unordered (ordered="False") by default (see above for examples).
+
+'''Markup:'''
+
+{{{
+
+An ordered list:
 
 <<ItemPageList(item="OtherTextItems" ordered="True")>>
 }}}
 
 '''Result:'''
 
-All items as an unordered list (the default):
-
-<<ItemPageList(item="OtherTextItems")>>
-
-All items as an ordered list:
+An ordered list:
 
 <<ItemPageList(item="OtherTextItems", ordered="True")>>
 

--- a/src/moin/macros/ItemPageList.py
+++ b/src/moin/macros/ItemPageList.py
@@ -61,6 +61,7 @@ import re
 from flask import request
 from flask import g as flaskg
 from moin.i18n import _, L_, N_
+from moin.utils.tree import moin_page
 from moin.utils.interwiki import split_fqname
 from moin.macros._base import MacroPageLinkListBase
 
@@ -113,8 +114,8 @@ class Macro(MacroPageLinkListBase):
 
         # test if item doesn't exist (potentially due to user's ACL, but that doesn't matter)
         if item != "": # why are we retaining this behavior from PagenameList?
-          if not flaskg.storage.get_item(**(split_fqname(item).query)):
-              raise LookupError(_('The specified item "%s" does not exist.' % item))
+            if not flaskg.storage.get_item(**(split_fqname(item).query)):
+                raise LookupError(_('The specified item "%s" does not exist.' % item))
 
         # process child pages
         children = self.get_item_names(item, startswith)
@@ -129,6 +130,10 @@ class Macro(MacroPageLinkListBase):
                     newlist.append(child)
             children = newlist
         if not children:
-            return _("This item has no accessible child pages.")
+            empty_list = moin_page.list(attrib={moin_page.item_label_generate: ordered and 'ordered' or 'unordered'})
+            item_body = moin_page.list_item_body(children=[_("<No matching pages were found>")])
+            item = moin_page.list_item(children=[item_body])
+            empty_list.append(item)
+            return empty_list
         return self.create_pagelink_list(children, ordered, display)
 

--- a/src/moin/macros/ItemPageList.py
+++ b/src/moin/macros/ItemPageList.py
@@ -41,11 +41,6 @@ Parameters:
             PageTitle : Use the title from the first header in the linked
                         page [*** NOT IMPLEMENTED YET ***]
 
-    numsep: Only if "display" is UnCameled, what separator string to use
-            between a block of letters (upper or lower) preceding a block
-            of numbers.  The default is the empty string.  Other likely
-            choices are space (' ') and dash ('-').
-
 Notes:
 
     All parameter values must be bracketed by matching quotes.  Singlequote
@@ -57,7 +52,7 @@ Notes:
 
 Example:
 
-    <<ItemPageList(item="Foo/Bar", ordered='True', display="UnCameled", numsep='')>>
+    <<ItemPageList(item="Foo/Bar", ordered='True', display="UnCameled")>>
 """
 
 import re
@@ -74,7 +69,6 @@ class Macro(MacroPageLinkListBase):
         regex = None
         ordered = False
         display = "FullPath"
-        numsep = ""
 
         # process input
         args = []
@@ -105,8 +99,6 @@ class Macro(MacroPageLinkListBase):
                     raise ValueError('value "ordered" must be "True" or "False".')
             elif key == "display":
                 display = val  # let 'create_pagelink_list' throw an exception if needed
-            elif key == "numsep":
-                numsep = val
             else:
                 raise ValueError('unrecognized key "%s".' % key)
 
@@ -128,4 +120,4 @@ class Macro(MacroPageLinkListBase):
             children = newlist
         if not children:
             return "This page has no children."
-        return self.create_pagelink_list(children, ordered, display, numsep)
+        return self.create_pagelink_list(children, ordered, display)

--- a/src/moin/macros/ItemPageList.py
+++ b/src/moin/macros/ItemPageList.py
@@ -13,7 +13,7 @@ ItemPageList - Replaced by a list of links to a specified page's descendents.
 Parameters:
 
     item: the wiki item to select.  If no item is specified, then the
-          current page is used. 
+          current page is used.
 
     startswith: the substring the item's descendents must begin with.
                 If no value is specified, then no startswith-filtering
@@ -113,7 +113,7 @@ class Macro(MacroPageLinkListBase):
             item = request.path[1:]
 
         # test if item doesn't exist (potentially due to user's ACL, but that doesn't matter)
-        if item != "": # why are we retaining this behavior from PagenameList?
+        if item != "":  # why are we retaining this behavior from PagenameList?
             if not flaskg.storage.get_item(**(split_fqname(item).query)):
                 raise LookupError(_('The specified item "%s" does not exist.' % item))
 
@@ -136,4 +136,3 @@ class Macro(MacroPageLinkListBase):
             empty_list.append(item)
             return empty_list
         return self.create_pagelink_list(children, ordered, display)
-

--- a/src/moin/macros/ItemPageList.py
+++ b/src/moin/macros/ItemPageList.py
@@ -5,10 +5,9 @@
 ItemPageList - Replaced by a list of links to a specified page's descendents.
 
   Only items the user has access to are queryable.  If the specified item
-  does not exist, then it displays "Specified item does not exist.".
-
-  Only child pages the user has access to are returned.  If there are no
-  child pages to return, then it displays "Specified item has no children.".
+  has no children pages matching the filter, which may be due to filters or
+  access controls, the macro displays a list (to match context) containing a
+  single item having the string "<No matching pages were found>".
 
 Parameters:
 

--- a/src/moin/macros/_base.py
+++ b/src/moin/macros/_base.py
@@ -5,13 +5,13 @@
 MoinMoin - Macro base class
 """
 
-from werkzeug.exceptions import abort
-
-from moin.utils import iri
-from moin.utils.tree import moin_page, xlink
-from moin.items import Item
-from moin.storage.middleware.protecting import AccessDenied
 import re
+from moin.utils import iri
+from moin.items import Item
+from moin.i18n import _, L_, N_
+from werkzeug.exceptions import abort
+from moin.utils.tree import moin_page, xlink
+from moin.storage.middleware.protecting import AccessDenied
 
 
 class MacroBase(object):
@@ -114,9 +114,9 @@ class MacroPageLinkListBase(MacroBlockBase):
                 tempname = re.sub("([a-z0-9])([A-Z])", r"\g<1> \g<2>", pagename[index+1:])  # space before a cap char
                 linkname = re.sub("([a-zA-Z])([0-9])", r"\g<1> \g<2>", tempname)
             elif display == "PageTitle":
-                raise Exception("PageTitle isn't implemented yet.")
+                raise NotImplementedError(_('"PageTitle" is not implemented yet.'))
             else:
-                raise ValueError('unrecognized display value "%s".' % display)
+                raise KeyError(_('Unrecognized display value "%s".' % display))
 
             pagelink = moin_page.a(attrib={xlink.href: url}, children=[linkname])
             item_body = moin_page.list_item_body(children=[pagelink])

--- a/src/moin/macros/_base.py
+++ b/src/moin/macros/_base.py
@@ -126,7 +126,7 @@ class MacroPageLinkListBase(MacroBlockBase):
 
     def get_item_names(self, name='', startswith='', kind='files'):
         """
-        For the specified item, return the fullname of natching descndents.
+        For the specified item, return the fullname of matching descndents.
 
         Input:
 

--- a/src/moin/macros/_base.py
+++ b/src/moin/macros/_base.py
@@ -71,7 +71,7 @@ class MacroInlineOnlyBase(MacroBase):
 
 
 class MacroPageLinkListBase(MacroBlockBase):
-    def create_pagelink_list(self, pagenames, ordered=False, display="FullPath", numsep=""):
+    def create_pagelink_list(self, pagenames, ordered=False, display="FullPath"):
         """ Creates an ET with a list of pagelinks from a list of pagenames.
 
             Parameters:
@@ -94,10 +94,6 @@ class MacroPageLinkListBase(MacroBlockBase):
                                   blocks of lowercase characters or numbers and an
                                   uppercase character.
                       PageTitle : Use the title from the first header in the linked page
-
-              numsep: if display is UnCameled, what separator string to use
-                      between a block of letters (upper or lower) preceding
-                      a block of numbers.  Default is the empty string.
             """
 
         page_list = moin_page.list(attrib={moin_page.item_label_generate: ordered and 'ordered' or 'unordered'})
@@ -116,7 +112,7 @@ class MacroPageLinkListBase(MacroBlockBase):
             elif display == "UnCameled":
                 index = pagename.rfind('/')
                 tempname = re.sub("([a-z0-9])([A-Z])", r"\g<1> \g<2>", pagename[index+1:])  # space before a cap char
-                linkname = re.sub("([a-zA-Z])([0-9])", r"\g<1>%s\g<2>" % numsep, tempname)
+                linkname = re.sub("([a-zA-Z])([0-9])", r"\g<1> \g<2>", tempname)
             elif display == "PageTitle":
                 raise Exception("PageTitle isn't implemented yet.")
             else:


### PR DESCRIPTION
After merging the PR for issue #798, Roger suggested a number of improvements (e.g., removing the numsep parameter, translations, test for non-existence, etc.), all of which are addressed here.  Please take a look at the new sample/MoinWikiMacros page!

I'm waiting a couple more weeks before removing the <<PageNameList>> macro.

One remaining enhancement is to add filtering by tags as yet another filtering mechanism.
