### PR TITLE
Add shebang line to `./m` on non-windows

### DIFF
--- a/quickinstall.py
+++ b/quickinstall.py
@@ -279,7 +279,7 @@ def create_m():
             f.write(':: {0}\n\n@{1} quickinstall.py %* --help\n'.format(WIN_INFO, sys.executable))
     else:
         with open('m', 'w') as f:
-            f.write('# {0}\n\n{1} quickinstall.py $* --help\n'.format(NIX_INFO, sys.executable))
+            f.write('#!/bin/sh\n# {0}\n\n{1} quickinstall.py $* --help\n'.format(NIX_INFO, sys.executable))
             os.fchmod(f.fileno(), 0775)
 
 


### PR DESCRIPTION
Add shebang line to `./m` on non-windows. Fixes #846 

This prevents it from failing when using non-bash shells.