### PR TITLE
[#925] parse_quoted_separated_text(): add single quote to default quotes

### DIFF
--- a/src/moin/utils/paramparser.py
+++ b/src/moin/utils/paramparser.py
@@ -44,7 +44,7 @@ class ParserPrefix:
 
 def parse_quoted_separated_ext(args, separator=None, name_value_separator=None,
                                brackets=None, seplimit=0, multikey=False,
-                               prefixes=None, quotes='"'):
+                               prefixes=None, quotes='"\''):
     """
     Parses the given string according to the other parameters.
 


### PR DESCRIPTION
Implement issue #925.

No additional tests needed as the logic is already tested in `testExtendedParserQuoting()`.