### PR TITLE
belated conversion of datetimeformat to time_datetime on several views;

### DIFF
--- a/src/moin/apps/admin/templates/admin/trash.html
+++ b/src/moin/apps/admin/templates/admin/trash.html
@@ -22,7 +22,7 @@
                     <tr>
                         <td class="moin-wordbreak">{{ result.oldname|join(' | ') }}</td>
                         <td>{{ result.revid | shorten_id }}</td>
-                        <td>{{ result.mtime|datetimeformat }}</td>
+                        <td>{{ result.mtime|time_datetime }}</td>
                         <td class="moin-wordbreak">{{ utils.show_editor_info(result.editor)  }}</td>
                         <td class="moin-wordbreak">{{ result.comment }}</td>
                         <td><a href="{{ url_for('frontend.show_item', item_name=result.fqname) }}">{{ _('show') }}</a></td>

--- a/src/moin/templates/ajaxsearch.html
+++ b/src/moin/templates/ajaxsearch.html
@@ -68,7 +68,7 @@
                                 {% endif %}
                                 <tr class="moin-search-meta">
                                     <td>
-                                        <p class="info searchhitinfobar">{{ _("Revision: %(revid)s - %(size)s - %(mtime)s - %(type)s", type=(result['contenttype']|shorten_ctype), mtime=result['mtime']|datetimeformat, size=result['size']|filesizeformat, revid=result['revid']|shorten_id) }}</p>
+                                        <p class="info searchhitinfobar">{{ _("Revision: %(revid)s - %(size)s - %(mtime)s - %(type)s", type=(result['contenttype']|shorten_ctype), mtime=result['mtime']|time_datetime, size=result['size']|filesizeformat, revid=result['revid']|shorten_id) }}</p>
                                     </td>
                                 </tr>
                                 <tr>

--- a/src/moin/templates/blog/utils.html
+++ b/src/moin/templates/blog/utils.html
@@ -15,7 +15,7 @@
         <div class="moin-blog-entry-info">
             {% set publication_time = entry_item.meta['ptime'] or entry_item.meta['mtime'] %}
             {% if publication_time %}
-                {{ _("Published on") }} {{ publication_time|datetimeformat }}
+                {{ _("Published on") }} {{ publication_time|time_datetime }}
                 {{ _("by") }} {{ utils.editor_info(entry_item.meta) }}
             {% endif %}
         </div>

--- a/src/moin/templates/diff_text.html
+++ b/src/moin/templates/diff_text.html
@@ -18,7 +18,7 @@
             <a class="moin-button" href="{{ url_for('frontend.revert_item', item_name=item_name, rev=newrev.meta.revid) }}" title="{{ _('revert') }}">
                 {{ _('Revert to Revision') }}
                 {{ newrev.meta['rev_number'] or newrev.revid|shorten_id }} -
-                {{ newrev.meta.mtime|datetimeformat }}
+                {{ newrev.meta.mtime|time_datetime }}
             </a>
         </div>
         <div class="moin-float-fix"></div>

--- a/src/moin/templates/history.html
+++ b/src/moin/templates/history.html
@@ -172,7 +172,7 @@
                         <tfoot>
                             <tr>
                                 <td colspan="2">Bookmark is set to</td>
-                                <td>{{ bookmark_time|datetimeformat }}</td>
+                                <td>{{ bookmark_time|time_datetime }}</td>
                                 <td colspan="11"></td>
                             </tr>
                         </tfoot>

--- a/src/moin/templates/utils.html
+++ b/src/moin/templates/utils.html
@@ -15,7 +15,7 @@
                 {% if prior_mtime -%}
                     <a href="{{ url_for(view, item_name=fqname, rev=prior_rev) }}">
                         <span class="fa fa-arrow-left"></span>
-                        {{ _('older') }} {{ prior_mtime|datetimeformat }}
+                        {{ _('older') }} {{ prior_mtime|time_datetime }}
                     </a>
                 {%- else -%}
                     <span class="moin-disabled">{{ _('no older revision') }}</span>
@@ -24,12 +24,12 @@
             <li class="moin-rev-navigation-current">
                 {{ _('Revision ') }}
                 {{ item.meta.rev_number or current_rev | shorten_id }}:
-                {{ current_mtime|datetimeformat }}
+                {{ current_mtime|time_datetime }}
             </li>
             <li class="moin-rev-navigation-newer">
                 {% if next_mtime -%}
                     <a href="{{ url_for(view, item_name=fqname, rev=next_rev) }}">
-                        {{ _('newer') }} {{ next_mtime|datetimeformat }}
+                        {{ _('newer') }} {{ next_mtime|time_datetime }}
                         <span class="fa fa-arrow-right"></span>
                     </a>
                 {%- else -%}
@@ -412,7 +412,7 @@
             {{ _('Time') }}:
         </span>
         <span class="moin-diff-info-value">
-            {{ rev.meta.mtime|datetimeformat }}
+            {{ rev.meta.mtime|time_datetime }}
         </span>
     </div>
     <div>


### PR DESCRIPTION
consistent display of dates, see #831

user may choose iso 8601 formated dates in user settings