### PR TITLE
remove Extra MetaData (JSON) from modify view, fixes #700

### DIFF
--- a/src/moin/forms.py
+++ b/src/moin/forms.py
@@ -133,12 +133,6 @@ class ValidName(Validator):
         if state is None:
             # incoming request is from +usersettings#personal; apps/frontend/views.py will validate changes to user names
             return True
-        # Make sure that the other meta is valid before validating the name.  TODO: prove the try below is always redundant and remove it.
-        try:
-            if not element.parent.parent['extra_meta_text'].valid:
-                return False
-        except AttributeError:
-            pass
         try:
             validate_name(state['meta'], state[ITEMID])
         except NameNotValidError as e:

--- a/src/moin/items/__init__.py
+++ b/src/moin/items/__init__.py
@@ -579,7 +579,6 @@ class Item:
         ModifyForm.
         """
         meta_form = BaseMetaForm
-        extra_meta_text = JSON.using(label=L_("Extra MetaData (JSON)")).with_properties(rows=ROWS_META, cols=COLS)
         meta_template = 'modify_meta.html'
 
         def _load(self, item):
@@ -598,7 +597,6 @@ class Item:
             self['meta_form'].set(meta, policy='duck')
             for k in list(self['meta_form'].field_schema_mapping.keys()) + IMMUTABLE_KEYS:
                 meta.pop(k, None)
-            self['extra_meta_text'].set(item.meta_dict_to_text(meta))
             self['content_form']._load(item.content)
 
         def _dump(self, item):
@@ -616,7 +614,6 @@ class Item:
             # e.g. we get PARENTID in here
             meta = item.meta_filter(item.prepare_meta_for_modify(item.meta))
             meta.update(self['meta_form'].value)
-            meta.update(item.meta_text_to_dict(self['extra_meta_text'].value))
             data, contenttype_guessed = self['content_form']._dump(item.content)
             comment = self['comment'].value
             return meta, data, contenttype_guessed, comment

--- a/src/moin/templates/modify.html
+++ b/src/moin/templates/modify.html
@@ -68,9 +68,6 @@
             {{ data_editor(form['content_form'], item_name) }}
             {% set may_admin = user.may.admin(fqname) %}
             {{ meta_editor(form['meta_form'], may_admin) }}
-            <dl>
-                {{ forms.render(form['extra_meta_text']) }}
-            </dl>
         {{ gen.form.close() }}
     </div>
 

--- a/src/moin/themes/basic/templates/modify.html
+++ b/src/moin/themes/basic/templates/modify.html
@@ -54,13 +54,6 @@
                         <div class="col-md-6">
                             {{ basic_meta_editor(form['meta_form']) }}
                         </div>
-                        {% set field = form['extra_meta_text'] %}
-                        <div class="col-md-6">
-                            <div class="form-group">
-                                {{ gen.label(field) }}
-                                {{ gen.textarea(field, rows=field.properties.rows|string, cols=field.properties.cols|string, class='form-control') }}
-                            </div>
-                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
users should not be allowed to change these meta data fields:
item_id, itemtype, contenttype, namespace, or rev_number