### PR TITLE
markdown embedded HTML markup must be enclosed in P tags, not DIV tags

### DIFF
--- a/src/moin/converters/_tests/test_markdown_in.py
+++ b/src/moin/converters/_tests/test_markdown_in.py
@@ -67,6 +67,23 @@ class TestConverter:
         self.do(input, output)
 
     data = [
+        ('<em>Emphasis</em>',
+         '<div><p><emphasis>Emphasis</emphasis></p></div>'),
+        ('<i>Italic</i>',
+         '<div><p><emphasis>Italic</emphasis></p></div>'),
+        ('<u>underline</u>',
+         '<div><p><u>underline</u></p></div>'),
+        ('<del>deleted</del>',
+         '<div><p><del>deleted</del></p></div>'),
+        ('<hr>',
+         '<div><p><separator html:class="moin-hr3" /></p></div>'),
+    ]
+
+    @pytest.mark.parametrize('input,output', data)
+    def test_html_extension(self, input, output):
+        self.do(input, output)
+
+    data = [
         ('http://moinmo.in/',
          '<p>http://moinmo.in/</p>'),
         ('\\[escape](yo)',

--- a/src/moin/converters/markdown_in.py
+++ b/src/moin/converters/markdown_in.py
@@ -483,15 +483,12 @@ class Converter:
         Allow embedded raw HTML markup per https://daringfireball.net/projects/markdown/syntax#html
         This replaces the functionality of RawHtmlPostprocessor in .../markdown/postprocessors.py.
 
-        In addition to users being able to insert raw HTML into markdown items,
-        some markdown extensions output raw HTML strings (e.g. fenced_code outputs "<pre><code>...").
-
-        To prevent hackers from exploiting raw HTML, the strings of safe HTML is converted to
+        To prevent hackers from exploiting raw HTML, the strings of safe HTML are converted to
         tree nodes by using the html_in.py converter.
         """
         try:
-            # we enclose plain text and block tags with DIV-tags
-            p_text = html_in_converter('<div>%s</div>' % text)
+            # we enclose plain text and span tags with P-tags
+            p_text = html_in_converter('<p>%s</p>' % text)
             # discard page and body tags
             return p_text[0][0]
         except AssertionError:


### PR DESCRIPTION
the DIV tags cause paragraph spacing issues and sometimes break tables