### PR TITLE
replace py.test by pytest

### DIFF
--- a/_ui_tests/README.txt
+++ b/_ui_tests/README.txt
@@ -39,7 +39,7 @@ Instructions
 
 1. Open a terminal
 2. Change into the directory of this README
-3. Execute 'py.test -v -s'
+3. Execute 'pytest -v -s'
 
 If any tests fail, screenshots will be generated in the current directory 
 with names corresponding to the test class name and method name.
@@ -52,7 +52,7 @@ Pre-requisite:
 
 1. Open a terminal
 2. Change into the directory of this README
-3. Execute 'xfvb-run py.test -v -s'
+3. Execute 'xfvb-run pytest -v -s'
 
 Configuration
 -------------

--- a/_ui_tests/conftest.py
+++ b/_ui_tests/conftest.py
@@ -2,8 +2,8 @@
 # License: GNU GPL v3 (or any later version), see LICENSE.txt for details.
 
 """
-Contains events called by py.test during the life-cycle of the test suite
-This module is automatically loaded by py.test, which looks for a file
+Contains events called by pytest during the life-cycle of the test suite
+This module is automatically loaded by pytest, which looks for a file
 of this name
 """
 
@@ -21,8 +21,8 @@ def pytest_runtest_makereport(item, call):
     - item: the method called
     - call: an object of type CallInfo, which has two properties, of which
       excinfo contains info about any exception that got thrown by the method
-    This method is called automatically by py.test.  The name of the method
-    is used by py.test to locate it, and decide when to call it
+    This method is called automatically by pytest.  The name of the method
+    is used by pytest to locate it, and decide when to call it
     This specific method instance is used to take a screenshot whenever a test
     fails, ie whenever the method throws an exception
     """

--- a/_ui_tests/test_subitems.py
+++ b/_ui_tests/test_subitems.py
@@ -58,7 +58,7 @@ class TestSubitems:
         self.driver.quit()
 
 if __name__ == '__main__':
-    # This lets us run the test directly, without using py.test
+    # This lets us run the test directly, without using pytest
     # This is useful for example for being able to call help, eg
     # 'help(driver)', or 'help(driver.find_element_by_id("f_submit"))'
     testSubitems = TestSubitems()

--- a/docs/devel/development.rst
+++ b/docs/devel/development.rst
@@ -365,7 +365,7 @@ The translated version of "somestring" can be accessed in the JavaScript code by
 Testing
 =======
 
-We use py.test for automated testing. It is currently automatically installed
+We use pytest for automated testing. It is currently automatically installed
 into your virtualenv as a dependency.
 
 Running the tests
@@ -374,14 +374,14 @@ To run all the tests, the easiest way is to do::
 
     ./m tests  # windows:  m tests
 
-To run selected tests, activate your virtual env and invoke py.test from the
+To run selected tests, activate your virtual env and invoke pytest from the
 toplevel directory::
 
-    py.test --pep8  # run all tests, including pep8 checks
-    py.test -rs  # run all tests and output information about skipped tests
-    py.test -k somekeyword  # run the tests matching somekeyword only
-    py.test --pep8 -k pep8  # runs pep8 checks only
-    py.test sometests.py  # run the tests contained in sometests.py
+    pytest --pep8  # run all tests, including pep8 checks
+    pytest -rs  # run all tests and output information about skipped tests
+    pytest -k somekeyword  # run the tests matching somekeyword only
+    pytest --pep8 -k pep8  # runs pep8 checks only
+    pytest sometests.py  # run the tests contained in sometests.py
 
 Tests output
 ------------
@@ -397,7 +397,7 @@ If something goes wrong, you will also see tracebacks in stdout/stderr.
 
 Writing tests
 -------------
-Writing tests with `py.test` is easy and has little overhead. Just
+Writing tests with `pytest` is easy and has little overhead. Just
 use the `assert` statements.
 
 For more information, please read: http://pytest.org/

--- a/src/moin/conftest.py
+++ b/src/moin/conftest.py
@@ -25,7 +25,7 @@ from moin._tests import wikiconfig
 from moin.storage import create_simple_mapping
 
 
-# exclude some directories from py.test test discovery, pathes relative to this file
+# exclude some directories from pytest test discovery, pathes relative to this file
 collect_ignore = [
     'static',  # same
     '../wiki',  # no tests there

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ setenv =
     PYTHONHASHSEED = 0
     # needed so that lxml can build from source (e.g. on pypy):
     CFLAGS = -I/usr/include/libxml2
-commands = py.test -rs --pyargs {posargs:moin}
+commands = pytest -rs --pyargs {posargs:moin}
 
 [testenv:flake8]
 changedir =


### PR DESCRIPTION
This PR fixes #912.

I runned `tox` on python 3.7 and it still work ('1644 passed, 29 skipped, 1 xfailed, 2 warnings").
Flake8 passed too.