### PR TITLE
fix several deprecationWarnings

### DIFF
--- a/src/moin/auth/__init__.py
+++ b/src/moin/auth/__init__.py
@@ -133,7 +133,9 @@
     name of the authentication method.
 """
 
-from werkzeug import redirect, abort, url_quote, url_quote_plus
+from werkzeug.exceptions import abort
+from werkzeug.urls import url_quote, url_quote_plus
+from werkzeug.utils import redirect
 from flask import url_for, session, request
 from flask import g as flaskg
 from flask import current_app as app

--- a/src/moin/converters/image_in.py
+++ b/src/moin/converters/image_in.py
@@ -9,7 +9,7 @@ Convert image to <object> tag for the DOM Tree.
 
 from emeraldtree import ElementTree as ET
 
-from werkzeug import url_encode, url_decode
+from werkzeug.urls import url_encode, url_decode
 
 from moin.constants.contenttypes import CHARSET
 from moin.utils.iri import Iri

--- a/src/moin/converters/mediawiki_in.py
+++ b/src/moin/converters/mediawiki_in.py
@@ -12,7 +12,7 @@ MoinMoin - Media Wiki input converter
 import re
 from html.entities import name2codepoint
 
-from werkzeug import url_encode
+from werkzeug.urls import url_encode
 
 from moin.constants.contenttypes import CHARSET
 from moin.constants.misc import URI_SCHEMES

--- a/src/moin/converters/moinwiki_in.py
+++ b/src/moin/converters/moinwiki_in.py
@@ -11,7 +11,7 @@ MoinMoin - Moin Wiki input converter
 import re
 
 from flask import request
-from werkzeug import url_encode
+from werkzeug.urls import url_encode
 
 from moin.constants.contenttypes import CHARSET
 from moin.constants.misc import URI_SCHEMES

--- a/src/moin/items/content.py
+++ b/src/moin/items/content.py
@@ -38,7 +38,7 @@ from flatland import Form, String
 
 from jinja2 import Markup
 
-from werkzeug import is_resource_modified
+from werkzeug.http import is_resource_modified
 
 from whoosh.query import Term, And
 

--- a/src/moin/storage/middleware/indexing.py
+++ b/src/moin/storage/middleware/indexing.py
@@ -53,7 +53,7 @@ import shutil
 import datetime
 import time
 
-from collections import Mapping
+from collections.abc import Mapping
 
 from flask import request
 from flask import g as flaskg

--- a/src/moin/utils/diff_html.py
+++ b/src/moin/utils/diff_html.py
@@ -9,7 +9,7 @@
 
 import difflib
 
-from werkzeug import escape
+from werkzeug.utils import escape
 
 from moin.i18n import _, L_, N_
 

--- a/src/moin/utils/interwiki.py
+++ b/src/moin/utils/interwiki.py
@@ -6,7 +6,7 @@
     MoinMoin - interwiki support code
 """
 
-from werkzeug import url_quote
+from werkzeug.urls import url_quote
 
 from flask import current_app as app
 from flask import url_for

--- a/src/moin/utils/send_file.py
+++ b/src/moin/utils/send_file.py
@@ -24,7 +24,9 @@ import mimetypes
 from time import time
 from zlib import adler32
 
-from werkzeug import Headers, wrap_file, url_quote
+from werkzeug.datastructures import Headers
+from werkzeug.urls import url_quote
+from werkzeug.wsgi import wrap_file
 from flask import current_app, request
 
 

--- a/src/moin/wikiutil.py
+++ b/src/moin/wikiutil.py
@@ -251,7 +251,7 @@ def anchor_name_from_text(text):
     valid ID/name, it will return it without modification (identity
     transformation).
     """
-    quoted = werkzeug.url_quote_plus(text, charset='utf-7', safe=':')
+    quoted = werkzeug.urls.url_quote_plus(text, charset='utf-7', safe=':')
     res = quoted.replace('%', '.').replace('+', '_')
     if not res[:1].isalpha():
         return 'A{0}'.format(res)


### PR DESCRIPTION
This PR fixes several `DeprecationWarning` shown when `tox` runs. They are fixed by updating the `import`.

There are still two DeprecationWarnings which can not be fixed this way: one DeprecationWarning is in `flask_theme` dependancy and the other one is about `werkzeug.contrib.atom` module which will be removed in Werkzeug 1.0.