### PR TITLE
generate Atom feed with feedgen library instead of Flask

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup_args = dict(
         'Flask-Script>=2.0.5',  # scripting support
         'Flask-Theme>=0.3.3',  # theme support
         'emeraldtree>=0.10.0',  # xml processing
+        'feedgen==0.9.*',  # Atom feed
         'flatland>=0.8',  # form handling
         'Jinja2>=2.7',  # template engine
         'pygments>=1.4',  # src code / text file highlighting

--- a/src/moin/apps/feed/views.py
+++ b/src/moin/apps/feed/views.py
@@ -15,7 +15,7 @@ from flask import request, Response
 from flask import current_app as app
 from flask import g as flaskg
 
-from werkzeug.contrib.atom import AtomFeed
+from feedgen.feed import FeedGenerator
 from jinja2 import Markup
 
 from whoosh.query import Term, And
@@ -57,7 +57,11 @@ def atom(item_name):
             title = "{0}".format(app.cfg.sitename)
         else:
             title = "{0} - {1}".format(app.cfg.sitename, item_name)
-        feed = AtomFeed(title=title, feed_url=request.url, url=request.host_url)
+        feed = FeedGenerator()
+        feed.id(request.url)
+        feed.title(title)
+        feed.link(href=request.host_url)
+        feed.link(href=request.url, rel='self')
         query = Term(WIKINAME, app.cfg.interwikiname)
         if item_name:
             query = And([query, Term(NAME_EXACT, item_name), ])
@@ -96,13 +100,13 @@ def atom(item_name):
                 feed_title = "{0}".format(author.get(NAME, ''))
             if not item_name:
                 feed_title = "{0} - {1}".format(name, feed_title)
-            feed.add(title=feed_title, title_type='text',
-                     summary=content, summary_type=content_type,
-                     author=author,
-                     url=url_for_item(name, rev=this_revid, _external=True),
-                     updated=datetime.fromtimestamp(rev.meta[MTIME]),
-            )
-        content = feed.to_string()
+            feed_entry = feed.add_entry()
+            feed_entry.id(url_for_item(name, rev=this_revid, _external=True))
+            feed_entry.title(feed_title)
+            feed_entry.summary(content)
+            feed_entry.author({'name': author.get(NAME, '')})
+            feed_entry.link(href=url_for_item(name, rev=this_revid, _external=True))
+        content = feed.atom_str(pretty=True).decode("utf-8")
         # Hack to add XSLT stylesheet declaration since AtomFeed doesn't allow this
         content = content.split("\n")
         content.insert(1, render_template('atom.html', get='xml'))


### PR DESCRIPTION
This PR uses feedgen library to generation Atom feed.

I checked the tests pass with `tox --recreate` for python 3.7 . The previous output (generated with `werkzeug.contrib.atom.AtomFeed()`) is more or less the same with feedgen output in feed test.
 
I failed to run moinmoin so I did not see the real output.

Closes: #850