### PR TITLE
fix Atom feed when feed includes revision

### DIFF
--- a/src/moin/apps/feed/views.py
+++ b/src/moin/apps/feed/views.py
@@ -77,7 +77,8 @@ def atom(item_name):
                 if previous_revid is not None:
                     # HTML diff for subsequent revisions
                     previous_rev = item[previous_revid]
-                    content = hl_item.content._render_data_diff_atom(previous_rev, this_rev)
+                    content = hl_item.content._render_data_diff_atom(previous_rev, this_rev,
+                                                                     fqname=this_rev.item.fqname)
                 else:
                     # full html rendering for new items
                     content = render_template('atom.html', get='first_revision', rev=this_rev,

--- a/src/moin/items/content.py
+++ b/src/moin/items/content.py
@@ -902,9 +902,9 @@ class Text(Binary):
         new_text = self.data_storage_to_internal(newfile.read())
         return text_diff(old_text.splitlines(), new_text.splitlines())
 
-    def _render_data_diff_atom(self, oldrev, newrev):
+    def _render_data_diff_atom(self, oldrev, newrev, fqname=None):
         """ renders diff in HTML for atom feed """
-        return self._render_data_diff_html(oldrev, newrev, 'diff_text_atom.html')
+        return self._render_data_diff_html(oldrev, newrev, 'diff_text_atom.html', fqname=fqname)
 
     def _render_data_diff(self, oldrev, newrev, rev_links={}, fqname=None):
         return self._render_data_diff_html(oldrev, newrev, 'diff_text.html', rev_links=rev_links, fqname=fqname)


### PR DESCRIPTION
When the Atom feed includes diff with a previous revision, an exception is raised because `fqname` 
is not defined (see https://github.com/moinwiki/moin/issues/1015).
This patch adds the `fqname` parameter to `Text._render_data_diff_atom()` method (like `Text._render_data_diff_html()` and `Text._render_data_diff()` methods) and uses it.

Closes: https://github.com/moinwiki/moin/issues/1015