### PR TITLE
update import for compatibility with Werkzeug 1.0+

### DIFF
--- a/src/moin/_tests/test_wikiutil.py
+++ b/src/moin/_tests/test_wikiutil.py
@@ -14,7 +14,7 @@ from flask import current_app as app
 from moin.constants.chartypes import CHARS_SPACES
 from moin import wikiutil
 
-from werkzeug import MultiDict
+from werkzeug.datastructures import MultiDict
 
 
 class TestCleanInput:

--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -10,7 +10,7 @@ from io import BytesIO
 
 from flask import url_for
 from flask import g as flaskg
-from werkzeug import ImmutableMultiDict, FileStorage
+from werkzeug.datastructures import ImmutableMultiDict, FileStorage
 
 from moin.apps.frontend import views
 from moin import user

--- a/src/moin/items/_tests/test_Content.py
+++ b/src/moin/items/_tests/test_Content.py
@@ -12,7 +12,7 @@ from io import BytesIO
 
 from flask import Markup
 
-from werkzeug import escape
+from werkzeug.utils import escape
 
 from moin.utils import diff_html
 

--- a/src/moin/storage/backends/fileserver.py
+++ b/src/moin/storage/backends/fileserver.py
@@ -17,7 +17,7 @@ import os
 import errno
 import stat
 from io import BytesIO
-from werkzeug import url_quote, url_unquote
+from werkzeug.urls import url_quote, url_unquote
 
 from moin.constants.keys import NAME, ITEMID, REVID, MTIME, SIZE, CONTENTTYPE, HASH_ALGORITHM
 from . import BackendBase


### PR DESCRIPTION
This PR fixes `ImportError` raised by `tox`if the Werkzeug dependancy is updated to v. 1.0.

It's necessary to update the Werkzeug library but this patch is not enough: it does not fix https://github.com/moinwiki/moin/issues/1020 for example.