### PR TITLE
update FileStorage import for Werkzeug 1.0 compatibility

### DIFF
--- a/src/moin/utils/forms.py
+++ b/src/moin/utils/forms.py
@@ -7,7 +7,7 @@
 
 
 from jinja2 import Markup
-import werkzeug
+import werkzeug.datastructures
 
 from flatland import AdaptationError, Scalar
 from flatland.out.markup import Generator
@@ -107,6 +107,6 @@ class FileStorage(Scalar):
     """Schema element for Werkzeug FileStorage instances."""
 
     def adapt(self, value):
-        if not isinstance(value, (type(None), werkzeug.FileStorage)):
+        if not isinstance(value, (type(None), werkzeug.datastructures.FileStorage)):
             raise AdaptationError
         return value


### PR DESCRIPTION
This PR fixes an import to a version compatible with Werkzeug 1.0+.
It's necessary but not enough to update moin2 to Werkzeug 1.0+: after merging this PR and https://github.com/moinwiki/moin/pull/1021, if you update to Werkzeug 1.0, some unittests fail due to change into Werkzeug.

Closes: https://github.com/moinwiki/moin/issues/1020
