### PR TITLE
update for werkzeug 1.0

### DIFF
--- a/contrib/wsgi/profiler.py
+++ b/contrib/wsgi/profiler.py
@@ -18,7 +18,7 @@
     @copyright: 2008 MoinMoin:FlorianKrupicka,
     @license: GNU GPL, see COPYING for details.
 """
-from werkzeug import get_current_url
+from werkzeug.wsgi import get_current_url
 
 from moin import log
 logging = log.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup_args = dict(
         'flatland>=0.8',  # form handling
         'Jinja2>=2.7',  # template engine
         'pygments>=1.4',  # src code / text file highlighting
-        'Werkzeug<1.0.0',  # wsgi toolkit TODO: fix cannot import cached_property #951
+        'Werkzeug>=1.0.0',  # wsgi toolkit
         'whoosh>=2.7.0',  # needed for indexed search
         'pdfminer3',  # pdf -> text/plain conversion
         'passlib>=1.6.0',  # strong password hashing (1.6 needed for consteq)

--- a/src/moin/apps/serve/_tests/test_serve.py
+++ b/src/moin/apps/serve/_tests/test_serve.py
@@ -19,5 +19,5 @@ class TestServe:
         with app.test_client() as c:
             rv = c.get(url_for('serve.files', name="DoesntExist"))
             assert rv.status == '404 NOT FOUND'
-            assert rv.headers['Content-Type'] == 'text/html'
+            assert rv.headers['Content-Type'] == 'text/html; charset=utf-8'
             assert b'<!DOCTYPE HTML' in rv.data

--- a/src/moin/auth/http.py
+++ b/src/moin/auth/http.py
@@ -55,7 +55,8 @@ class HTTPAuthMoin(BaseAuth):
             logging.debug("user: {0!r}".format(u))
 
         if not u or not u.valid:
-            from werkzeug import Response, abort
+            from werkzeug import Response
+            from werkzeug.exceptions import abort
             response = Response(_('Please log in first.'), 401,
                                 {'WWW-Authenticate': 'Basic realm="{0}"'.format(self.realm)})
             abort(response)


### PR DESCRIPTION
This PR fixes few `import` and updates a test for compatibility with Werkzeug 1.0 release.

The tests are green (runned on python3.7) and I tried basic actions on the local server (with `./m run`): modifying a page, updating the same page and updating a file.