### PR TITLE
shebang targets python3 for quickinstall.py

### DIFF
--- a/quickinstall.py
+++ b/quickinstall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Copyright: 2013 MoinMoin:BastianBlank
 # Copyright: 2013-2018 MoinMoin:RogerHaase
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.


### PR DESCRIPTION
`quickinstall.py` has executable rights (`-rwxr-xr-x`) so it's easy to think the script has to be run directly.
With this patch, `./quickinstall` will run the right interpreter if python is a link to python2.