### PR TITLE
Jinja and Werkzeug dependancies are included in Flask

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,9 +86,7 @@ setup_args = dict(
         'emeraldtree>=0.10.0',  # xml processing
         'feedgen==0.9.*',  # Atom feed
         'flatland>=0.8',  # form handling
-        'Jinja2>=2.7',  # template engine
         'pygments>=1.4',  # src code / text file highlighting
-        'Werkzeug>=1.0.0',  # wsgi toolkit
         'whoosh>=2.7.0',  # needed for indexed search
         'pdfminer3',  # pdf -> text/plain conversion
         'passlib>=1.6.0',  # strong password hashing (1.6 needed for consteq)


### PR DESCRIPTION
Flask already depends from Jinja and Werkzeug.

As the constraints about Jinja and Werkzeug allow latest versions, they are unecessary. So it's probably better to depend only on Flask.