### PR TITLE
Issue 1087 whoosh  index  fields  defined  in  wrong  dict

### DIFF
--- a/src/moin/storage/middleware/indexing.py
+++ b/src/moin/storage/middleware/indexing.py
@@ -375,12 +375,6 @@ class IndexingMiddleware:
             TRASH: BOOLEAN(stored=True),
             # data (content), converted to text/plain and tokenized
             CONTENT: TEXT(stored=True, spelling=True),
-            # refers to another item ticket using itemid, TODO move to ticket_fields?
-            REFERS_TO: ID(stored=True),
-            # meta field to differentiate ticket elements referring to an item, TODO move to ticket_fields?
-            ELEMENT: ID(stored=True),
-            # reply to comment, used only by tickets, TODO move to ticket_fields?
-            REPLY_TO: ID(stored=True),
         }
 
         latest_revs_fields = {
@@ -418,6 +412,9 @@ class IndexingMiddleware:
             SEVERITY: NUMERIC(stored=True),
             PRIORITY: NUMERIC(stored=True),
             ASSIGNED_TO: ID(stored=True),
+            REPLY_TO: ID(stored=True),
+            REFERS_TO: ID(stored=True),
+            ELEMENT: ID(stored=True),
             SUPERSEDED_BY: ID(stored=True),
             DEPENDS_ON: ID(stored=True),
             CLOSED: BOOLEAN(stored=True),

--- a/src/moin/storage/middleware/indexing.py
+++ b/src/moin/storage/middleware/indexing.py
@@ -345,8 +345,6 @@ class IndexingMiddleware:
             BACKENDNAME: ID(stored=True),
             # MTIME from revision metadata (converted to UTC datetime)
             MTIME: DATETIME(stored=True),
-            # blog publish time from metadata (converted to UTC datetime), TODO: move to blog_entry_fields?
-            PTIME: DATETIME(stored=True),
             # ITEMTYPE from metadata, always matched exactly hence ID
             ITEMTYPE: ID(stored=True),
             # tokenized CONTENTTYPE from metadata
@@ -427,6 +425,8 @@ class IndexingMiddleware:
         latest_revs_fields.update(**ticket_fields)
 
         blog_entry_fields = {
+            # blog publish time from metadata (converted to UTC datetime)
+            PTIME: DATETIME(stored=True),
         }
         latest_revs_fields.update(**blog_entry_fields)
 


### PR DESCRIPTION
This PR just updates some fields defined in `IndexingMiddleware` class. Basically, there are some fields defined in `common_fields` that should be in `ticket_fields` and `blog_entry_fields`. 

Fields moved to `ticket_fields`: `REPLY_TO`, `REFERS_TO` and `ELEMENT`

Fields moved to `blog_entry_fields`:  `PTIME`

Closes #1087  