### PR TITLE
show similar item names on item create, fixes #109

### DIFF
--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -17,7 +17,6 @@
 
 import os
 import re
-import difflib
 import time
 import uuid
 import mimetypes
@@ -61,14 +60,13 @@ from moin.forms import (OptionalText, RequiredText, URL, YourEmail,
                         Tags, Natural, Hidden, MultiSelect, Enum, Subscriptions, Quicklinks, RadioChoice,
                         validate_name, NameNotValidError)
 from moin.items import (BaseChangeForm, Item, NonExistent, NameNotUniqueError, MissingParentError,
-                        FieldNotUniqueError, get_itemtype_specific_tags, CreateItemForm)
+                        FieldNotUniqueError, get_itemtype_specific_tags, CreateItemForm, find_matches)
 from moin.items.content import content_registry, conv_serialize
 from moin.items.ticket import AdvancedSearchForm, render_comment_data
 from moin import user, utils
 from moin.constants.keys import *  # noqa
 from moin.constants.namespaces import *  # noqa
 from moin.constants.itemtypes import ITEMTYPE_DEFAULT, ITEMTYPE_TICKET, ITEMTYPE_USERPROFILE
-from moin.constants.chartypes import CHARS_UPPER, CHARS_LOWER
 from moin.constants.contenttypes import *  # noqa
 from moin.constants.rights import SUPERUSER
 from moin.utils import crypto, rev_navigation, close_file, show_time
@@ -2601,7 +2599,7 @@ def similar_names(item_name):
     except AccessDenied:
         abort(403)
     fq_name = split_fqname(item_name)
-    start, end, matches = findMatches(fq_name)
+    start, end, matches = find_matches(fq_name)
     keys = sorted(matches.keys())
     # TODO later we could add titles for the misc ranks:
     # 8 item_name
@@ -2621,128 +2619,6 @@ def similar_names(item_name):
                            item_name=item_name,  # XXX no item
                            fqname=split_fqname(item_name),
                            fq_names=fq_names)
-
-
-def findMatches(fq_name, s_re=None, e_re=None):
-    """ Find similar item names.
-
-    :param fq_name: fqname to match
-    :param s_re: start re for wiki matching
-    :param e_re: end re for wiki matching
-    :rtype: tuple
-    :returns: start word, end word, matches dict
-    """
-    query = Term(WIKINAME, app.cfg.interwikiname)
-    metas = flaskg.storage.search_meta(query, idx_name=LATEST_REVS, limit=None)
-    fq_names = {fqname for meta in metas for fqname in meta[FQNAMES] if FQNAMES in meta}
-    if fq_name in fq_names:
-        fq_names.remove(fq_name)
-    # Get matches using wiki way, start and end of word
-    start, end, matches = wikiMatches(fq_name, fq_names, start_re=s_re, end_re=e_re)
-    # Get the best 10 close matches
-    close_matches = {}
-    found = 0
-    for fqname in closeMatches(fq_name, fq_names):
-        if fqname not in matches:
-            # Skip fqname already in matches
-            close_matches[fqname] = 8
-            found += 1
-            # Stop after 10 matches
-            if found == 10:
-                break
-    # Finally, merge both dicts
-    matches.update(close_matches)
-    return start, end, matches
-
-
-def wikiMatches(fq_name, fq_names, start_re=None, end_re=None):
-    """
-    Get fqnames that starts or ends with same word as this fq_name.
-
-    Matches are ranked like this:
-        4 - item is subitem of fq_name
-        3 - match both start and end
-        2 - match end
-        1 - match start
-
-    :param fq_name: fqname to match
-    :param fq_names: list of fqnames
-    :param start_re: start word re (compile regex)
-    :param end_re: end word re (compile regex)
-    :rtype: tuple
-    :returns: start, end, matches dict
-    """
-    if start_re is None:
-        start_re = re.compile('([{0}][{1}]+)'.format(CHARS_UPPER, CHARS_LOWER))
-    if end_re is None:
-        end_re = re.compile('([{0}][{1}]+)$'.format(CHARS_UPPER, CHARS_LOWER))
-
-    # If we don't get results with wiki words matching, fall back to
-    # simple first word and last word, using spaces.
-    item_name = fq_name.value
-    words = item_name.split()
-    match = start_re.match(item_name)
-    if match:
-        start = match.group(1)
-    else:
-        start = words[0]
-
-    match = end_re.search(item_name)
-    if match:
-        end = match.group(1)
-    else:
-        end = words[-1]
-
-    matches = {}
-    subitem = item_name + '/'
-
-    # Find any matching item names and rank by type of match
-    for fqname in fq_names:
-        name = fqname.value
-        if name.startswith(subitem):
-            matches[fqname] = 4
-        else:
-            if name.startswith(start):
-                matches[fqname] = 1
-            if name.endswith(end):
-                matches[fqname] = matches.get(name, 0) + 2
-
-    return start, end, matches
-
-
-def closeMatches(fq_name, fq_names):
-    """ Get close matches.
-
-    Return all matching fqnames with rank above cutoff value.
-
-    :param fq_name: fqname to match
-    :param fq_names: list of fqnames
-    :rtype: list
-    :returns: list of matching item names, sorted by rank
-    """
-    if not fq_names:
-        return []
-    # Match using case insensitive matching
-    # Make mapping from lower item names to fqnames.
-    lower = {}
-    for fqname in fq_names:
-        name = fqname.value
-        key = name.lower()
-        if key in lower:
-            lower[key].append(fqname)
-        else:
-            lower[key] = [fqname]
-    # Get all close matches
-    item_name = fq_name.value
-    all_matches = difflib.get_close_matches(item_name.lower(), list(lower.keys()),
-                                            n=len(lower), cutoff=0.6)
-
-    # Replace lower names with original names
-    matches = []
-    for name in all_matches:
-        matches.extend(lower[name])
-
-    return matches
 
 
 @frontend.route('/+sitemap/<itemname:item_name>')

--- a/src/moin/templates/modify_select_contenttype.html
+++ b/src/moin/templates/modify_select_contenttype.html
@@ -1,9 +1,11 @@
 {#
-    Renders a web page filled with content type choices. Thses include:
+    Renders a web page filled with content type choices. These include:
         * Markup items ( MoinMoin, Creole, Markdown, ...)
         * Other text (plain, diff, ...)
         * Images (SVG, PNG, ...)
         * etc
+
+    Displays links to existing items with similar names.
 #}
 
 {% extends theme("layout.html") %}
@@ -26,4 +28,15 @@
             </tr>
         {% endfor %}
     </table>
+
+    {% if similar_names %}
+        <div>
+            <p>{{ _("Before creating a new item, review these existing items with similar names:") }}<p>
+            <ol>
+                {% for name in similar_names %}
+                    <li><a href="{{ url_for('frontend.show_item', item_name=name) }}">{{ name }}</a></li>
+                {% endfor %}
+            </ol>
+        </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
had to move findMatches, etc from frontend/views.py to items/init.py
to avoid circular import

renamed findMatches to more conventional find_matches