### PR TITLE
Fix PageList migration to use only regexp arguments

### DIFF
--- a/src/moin/scripts/migration/moin19/macros/PageList.py
+++ b/src/moin/scripts/migration/moin19/macros/PageList.py
@@ -17,14 +17,19 @@ def convert_page_list_macro_to_item_list(node):
     The moin1.0 PageList macro used to pass all arguments to the FullSearch
     macro, so they were essentially all treated as regular expression search queries.
     After conversion to the ItemList macro, the argument will be a simple "regex" argument.
+    To make sure all available pages are searched (not only subpages of the current page)
+    the item parameter is set to empty string (item="").
 
     Example conversions:
 
-    | PageList macro (moin1.9)       | ItemList macro (moin2)           |
-    |--------------------------------|----------------------------------|
-    | <<PageList()>>                 | <<ItemList()>>                   |
-    | <<PageList(SomeSubPage)>>      | <<ItemList(regex="SomeSubPage")>> |
-    | <<PageList(regex:Rnd[^abc]+)>> | <<ItemList(regex="Rnd[^abc]+")>> |
+    | PageList macro (moin1.9)       | ItemList macro (moin2)            |
+    |--------------------------------|-----------------------------------|
+    | <<PageList>>                   | <<ItemList(item="")>>             |
+    | <<PageList()>>                 | <<ItemList(item="")>>             |
+    | <<PageList(SomeSubPage)>>      | <<ItemList(item="",               |
+    |                                |            regex="SomeSubPage")>> |
+    | <<PageList(regex:Rnd[^abc]+)>> | <<ItemList(item="",               |
+    |                                |            regex="Rnd[^abc]+")>>  |
 
     :param node: the DOM node matching the PageList macro content type
     :type node: emeraldtree.tree.Element
@@ -44,7 +49,12 @@ def convert_page_list_macro_to_item_list(node):
         # strip the "regex:" prefix if necessary
         args_intermediate = re.sub(r'^regex:', '', args_before)
         # wrap argument in new keyword argument "regex"
-        args_after = 'regex="{}"'.format(args_intermediate)
+        args_after = 'item="",regex="{}"'.format(args_intermediate)
+    else:
+        # PageList macros without arguments used to show every
+        # available page in the wiki, so it's converted to an
+        # ItemList macro with an empty string item parameter
+        args_after = 'item=""'
 
     for elem in node.iter_elements():
         if elem.tag.name == 'arguments':

--- a/src/moin/scripts/migration/moin19/macros/_tests/test_PageList.py
+++ b/src/moin/scripts/migration/moin19/macros/_tests/test_PageList.py
@@ -1,0 +1,34 @@
+import pytest
+
+from moin.converters.moinwiki19_in import ConverterFormat19
+
+from moin.scripts.migration.moin19 import import19
+from moin.scripts.migration.moin19.macro_migration import migrate_macros
+from moin.scripts.migration.moin19.macros import PageList
+
+from moin.utils import paramparser
+from moin.utils.tree import moin_page
+
+
+@pytest.mark.parametrize('legacy_macro,expected_args', [
+    ("<<PageList>>", ''),
+    ("<<PageList(regex:InterestingPage/*)>>", 'regex="InterestingPage/*"'),
+    ("<<PageList(Calendar/2014-08-22/)>>", 'regex="Calendar/2014-08-22/"'),
+    ("<<PageList(regex:SecondCalendar/2011[^/]*$)>>", 'regex="SecondCalendar/2011[^/]*$"'),
+    ("<<PageList(^WikiPageAboutRegularExpressions/*)>>", 'regex="^WikiPageAboutRegularExpressions/*"'),
+    ("<<PageList(regex:ArticleCollection/[^/]*)>>", 'regex="ArticleCollection/[^/]*"'),
+])
+def test_macro_conversion(legacy_macro, expected_args):
+    converter = ConverterFormat19()
+    dom = converter(legacy_macro, import19.CONTENTTYPE_MOINWIKI)
+    migrate_macros(dom)  # in-place conversion
+
+    body = list(dom)[0]
+    part = list(body)[0]
+
+    assert part.get(moin_page.content_type) == 'x-moin/macro;name=ItemList'
+    assert part.get(moin_page.alt) == "<<ItemList({})>>".format(expected_args)
+
+    if len(list(part)) > 0:
+        arguments = list(part)[0]
+        assert list(arguments)[0] == expected_args

--- a/src/moin/scripts/migration/moin19/macros/_tests/test_PageList_migration.py
+++ b/src/moin/scripts/migration/moin19/macros/_tests/test_PageList_migration.py
@@ -11,12 +11,13 @@ from moin.utils.tree import moin_page
 
 
 @pytest.mark.parametrize('legacy_macro,expected_args', [
-    ("<<PageList>>", ''),
-    ("<<PageList(regex:InterestingPage/*)>>", 'regex="InterestingPage/*"'),
-    ("<<PageList(Calendar/2014-08-22/)>>", 'regex="Calendar/2014-08-22/"'),
-    ("<<PageList(regex:SecondCalendar/2011[^/]*$)>>", 'regex="SecondCalendar/2011[^/]*$"'),
-    ("<<PageList(^WikiPageAboutRegularExpressions/*)>>", 'regex="^WikiPageAboutRegularExpressions/*"'),
-    ("<<PageList(regex:ArticleCollection/[^/]*)>>", 'regex="ArticleCollection/[^/]*"'),
+    ("<<PageList>>", 'item=""'),
+    ("<<PageList()>>", 'item=""'),
+    ("<<PageList(regex:InterestingPage/*)>>", 'item="",regex="InterestingPage/*"'),
+    ("<<PageList(Calendar/2014-08-22/)>>", 'item="",regex="Calendar/2014-08-22/"'),
+    ("<<PageList(regex:SecondCalendar/2011[^/]*$)>>", 'item="",regex="SecondCalendar/2011[^/]*$"'),
+    ("<<PageList(^WikiPageAboutRegularExpressions/*)>>", 'item="",regex="^WikiPageAboutRegularExpressions/*"'),
+    ("<<PageList(regex:ArticleCollection/[^/]*)>>", 'item="",regex="ArticleCollection/[^/]*"'),
 ])
 def test_macro_conversion(legacy_macro, expected_args):
     converter = ConverterFormat19()


### PR DESCRIPTION
The moin-1.9 PageList macro passed all arguments to the FullSearch macro which basically means all arguments were handled as regular expressions. This Pull Request fixes the PageList macro migration to only use regular expression arguments for the converted ItemList macro. It also fixes a typo in the converted macro and adds some basic testing for the migration procedure.