### PR TITLE
MonthCalendar: optimize performance using index search

### DIFF
--- a/src/moin/macros/MonthCalendar.py
+++ b/src/moin/macros/MonthCalendar.py
@@ -222,7 +222,7 @@ class Macro(MacroInlineBase):
 
         # get list of calendar items for given month
         item_month = "{:s}/{:4d}-{:02d}-".format(parmpagename[0], year, month)
-        date_results = search_names(item_month)
+        date_results = search_names(item_month, limit=100)
 
         r7 = range(7)
 

--- a/src/moin/macros/MonthCalendar.py
+++ b/src/moin/macros/MonthCalendar.py
@@ -80,10 +80,6 @@ import calendar
 from datetime import datetime
 import re
 
-from whoosh.query import Term, Prefix, And
-
-from flask import current_app as app
-from flask import g as flaskg
 from flask import request
 
 from moin.i18n import _
@@ -92,8 +88,7 @@ from moin.utils import paramparser
 from moin.utils.iri import Iri
 from moin.utils.tree import moin_page
 from moin.utils.tree import xlink
-from moin.constants.keys import NAME, NAME_EXACT, WIKINAME, LATEST_REVS  # noqa
-
+from moin.storage.middleware.indexing import search_names
 
 calendar.setfirstweekday(calendar.MONDAY)
 
@@ -176,21 +171,6 @@ def parseargs(args, defpagename, defyear, defmonth, defoffset, defheight6, defan
     parmpagename = re.split(r'\*', parmpagename)
 
     return parmpagename, parmyear, parmmonth, parmoffset, parmheight6, parmanniversary
-
-
-def search_names(name_prefix):
-    """ get list of item_names beginning with name_prefix """
-
-    idx_name = LATEST_REVS
-    terms = [Prefix(NAME_EXACT, name_prefix)]
-    terms.append(Term(WIKINAME, app.cfg.interwikiname))
-    q = And(terms)
-    with flaskg.storage.indexer.ix[idx_name].searcher() as searcher:
-        results = searcher.search(q, limit=100)
-        result_names = []
-        for result in results:
-            result_names += result[NAME]
-    return result_names
 
 
 class Macro(MacroInlineBase):

--- a/src/moin/macros/MonthCalendar.py
+++ b/src/moin/macros/MonthCalendar.py
@@ -139,7 +139,8 @@ def build_dom_calendar_table(rows, head=None, caption=None, cls=None):
 
             # cell with link to calendar
             else:
-                table_a = moin_page.a(attrib={xlink.href: Iri(cell_addr)}, children=[cell])
+                iri = Iri(scheme='wiki', path='/' + cell_addr)
+                table_a = moin_page.a(attrib={xlink.href: iri}, children=[cell])
                 table_cell = moin_page.table_cell(children=[table_a])
                 table_cell.attrib[moin_page('class')] = cell_class
             table_row.append(table_cell)
@@ -199,6 +200,7 @@ class Macro(MacroInlineBase):
         # find page name of current page
         # to be able to use it as a default page name
         this_page = request.path[1:]
+
         if this_page.startswith('+modify/'):
             this_page = this_page.split('/', 1)[1]
 

--- a/src/moin/storage/middleware/indexing.py
+++ b/src/moin/storage/middleware/indexing.py
@@ -63,7 +63,7 @@ from whoosh.fields import Schema, TEXT, ID, IDLIST, NUMERIC, DATETIME, KEYWORD, 
 from whoosh.writing import AsyncWriter
 from whoosh.qparser import QueryParser, MultifieldParser, RegexPlugin, PseudoFieldPlugin
 from whoosh.qparser import WordNode
-from whoosh.query import Every, Term
+from whoosh.query import And, Every, Prefix, Term
 from whoosh.sorting import FieldFacet
 
 from moin.constants.keys import *  # noqa
@@ -161,6 +161,26 @@ def parent_names(names):
         if len(parent_tail) == 2:
             parents.add(parent_tail[0])
     return parents
+
+
+def search_names(name_prefix):
+    """
+    get list of item names beginning with name_prefix
+
+    :param name_prefix: item NAME prefix
+    :return: parent names list
+    """
+
+    idx_name = LATEST_REVS
+    terms = [Prefix(NAME_EXACT, name_prefix)]
+    terms.append(Term(WIKINAME, app.cfg.interwikiname))
+    q = And(terms)
+    with flaskg.storage.indexer.ix[idx_name].searcher() as searcher:
+        results = searcher.search(q, limit=100)
+        result_names = []
+        for result in results:
+            result_names += result[NAME]
+    return result_names
 
 
 def backend_to_index(meta, content, schema, wikiname, backend_name):

--- a/src/moin/storage/middleware/indexing.py
+++ b/src/moin/storage/middleware/indexing.py
@@ -163,12 +163,13 @@ def parent_names(names):
     return parents
 
 
-def search_names(name_prefix):
+def search_names(name_prefix, limit=None):
     """
     get list of item names beginning with name_prefix
 
     :param name_prefix: item NAME prefix
-    :return: parent names list
+    :param limit: limit number of search results
+    :return: item names list
     """
 
     idx_name = LATEST_REVS
@@ -176,10 +177,8 @@ def search_names(name_prefix):
     terms.append(Term(WIKINAME, app.cfg.interwikiname))
     q = And(terms)
     with flaskg.storage.indexer.ix[idx_name].searcher() as searcher:
-        results = searcher.search(q, limit=100)
-        result_names = []
-        for result in results:
-            result_names += result[NAME]
+        results = searcher.search(q, limit=limit)
+        result_names = [result[NAME][0] for result in results]
     return result_names
 
 


### PR DESCRIPTION
This is just an example how to optimize macro runtime mentioned in #1222. 
Requires more discussion before merging. The search_names() function should be moved to another module for reusability.
Reduces runtime from 14 seconds to 3 seconds in a real example for a one year calendar.