### PR TITLE
Allow to run "./quickinstall.py" whithout any other arguments

### DIFF
--- a/quickinstall.py
+++ b/quickinstall.py
@@ -696,6 +696,11 @@ if __name__ == '__main__':
             choices.add(name)
     args = sys.argv[:]
 
+    if len(args) == 1:
+        # User run command as `./quickinstall` whithout any other arguments
+        command = getattr(commands, 'cmd_quickinstall')
+        command()
+
     if len(args) > 2 and args[-1] == '--help':
         # m and m.bat have trailing --help so "./m" comes across as "python quickinstall.py --help"
         # if user did "./m <option>" we have "python quickinstall.py <option> --help" then we can delete the --help and do <option>

--- a/quickinstall.py
+++ b/quickinstall.py
@@ -747,7 +747,6 @@ if __name__ == '__main__':
 
             else:
                 # we have some simple command like "./m css" that does not update virtualenv
-                print('lenght of args: ',len(args))
                 choice = 'cmd_%s' % args[1]
                 choice = choice.replace('-', '_')
                 if choice in choices:

--- a/quickinstall.py
+++ b/quickinstall.py
@@ -696,11 +696,6 @@ if __name__ == '__main__':
             choices.add(name)
     args = sys.argv[:]
 
-    if len(args) == 1:
-        # User run command as `./quickinstall` whithout any other arguments
-        command = getattr(commands, 'cmd_quickinstall')
-        command()
-
     if len(args) > 2 and args[-1] == '--help':
         # m and m.bat have trailing --help so "./m" comes across as "python quickinstall.py --help"
         # if user did "./m <option>" we have "python quickinstall.py <option> --help" then we can delete the --help and do <option>
@@ -709,6 +704,11 @@ if __name__ == '__main__':
     if (os.path.isfile('activate') or os.path.isfile('activate.bat')) and (len(args) == 2 and args[1] in ('-h', '--help')):
         # user keyed "./m", "./m -h", or "./m --help"
         print(help)
+    
+    elif len(args) == 1:
+        # User run command as `./quickinstall` whithout any other arguments
+        command = getattr(commands, 'cmd_quickinstall')
+        command()
 
     else:
         if not (os.path.isfile('m') or os.path.isfile('m.bat')):
@@ -747,6 +747,7 @@ if __name__ == '__main__':
 
             else:
                 # we have some simple command like "./m css" that does not update virtualenv
+                print('lenght of args: ',len(args))
                 choice = 'cmd_%s' % args[1]
                 choice = choice.replace('-', '_')
                 if choice in choices:


### PR DESCRIPTION
Whenever we ran `./quickinstall.py` without any arguments it should be the same as `python quickinstall.py`. But we got the following error:

```
Traceback (most recent call last):
  File "./quickinstall.py", line 746, in <module>
    choice = 'cmd_%s' % args[1]
IndexError: list index out of range
```

Added if statement to check if length of args equals to 1, then runs the default command.