### PR TITLE
missing --upgrade in quickinstall.py, fixes #1250

### DIFF
--- a/quickinstall.py
+++ b/quickinstall.py
@@ -302,7 +302,7 @@ class Commands:
             packages.append('python-ldap')
         installer = 'pip install --upgrade '
         reqs = ['requirements.d/development.txt', 'requirements.d/docs.txt', ]
-        reqs_installer = 'pip install -r '
+        reqs_installer = 'pip install --upgrade -r '
         command = SEP.join(list(installer + x for x in packages) + list(reqs_installer + x for x in reqs))
         print('Installing {0}.'.format(', '.join(packages + reqs)))
         print('Output messages written to {0}.'.format(EXTRAS))


### PR DESCRIPTION
run "./m upgrade" after installing this patch to update sphinx to 4.5.0,
pytest to 7.1.2, tox to 3.25.0