### PR TITLE
Fix quickinstall not working if called with path

### DIFF
--- a/quickinstall.py
+++ b/quickinstall.py
@@ -740,7 +740,7 @@ if __name__ == '__main__':
             command()
 
         else:
-            if args == ['quickinstall.py']:
+            if (len(args) == 1 and  args[0].endswith('quickinstall.py')):
                 # user keyed "python quickinstall.py" instead of "./m quickinstall"
                 # run this same script (quickinstall.py) again in a subprocess to create the virtual env
                 command = getattr(commands, 'cmd_quickinstall')

--- a/quickinstall.py
+++ b/quickinstall.py
@@ -740,7 +740,7 @@ if __name__ == '__main__':
             command()
 
         else:
-            if (len(args) == 1 and  args[0].endswith('quickinstall.py')):
+            if (len(args) == 1 and args[0].endswith('quickinstall.py')):
                 # user keyed "python quickinstall.py" instead of "./m quickinstall"
                 # run this same script (quickinstall.py) again in a subprocess to create the virtual env
                 command = getattr(commands, 'cmd_quickinstall')


### PR DESCRIPTION
Instead of checking for exactly 'quickinstall.py', I'm now checking if exactly 1 argument was called that ends with quickinstall.py. This should include all relative paths. 

Note that being in the main folder seems to still be necessary, as e.g. calling ..\\..\quickinstall.py won't throw errors but won't work either, however this is not a result from this change (but was already this way before) and is likely much less relevant if users follow the quickinstall instructions.