### PR TITLE
quickinstall.py: remove recursive log file open

### DIFF
--- a/quickinstall.py
+++ b/quickinstall.py
@@ -748,15 +748,8 @@ if __name__ == '__main__':
 
             elif args == ['quickinstall.py', '--FirstCall']:
                 # we are in a subprocess call after "python quickinstall.py" or  "./m quickinstall"
-                orig_stdout = sys.stdout
-                orig_stderr = sys.stderr
-                with open(QUICKINSTALL, 'a') as messages:
-                    sys.stdout = messages
-                    sys.stderr = messages
-                    QuickInstall(os.path.dirname(os.path.realpath(args[0])))()
-                    copy_config_files()
-                    sys.stdout = orig_stdout
-                    sys.stderr = orig_stderr
+                QuickInstall(os.path.dirname(os.path.realpath(args[0])))()
+                copy_config_files()
 
             else:
                 # we have some simple command like "./m css" that does not update virtualenv


### PR DESCRIPTION
When quickinstall.py is run with parameter --FirstCall the redirect of stdout and stderr is already done. No need for a second redirect to the same logfile. Obviously this is a problem with Ubuntu 22.04 LTS desktop version.

Tested with Ubuntu 22.04 desktop and Debian 11 Server version. Please assist with tests on Windows.