### PR TITLE
Replace deprecated werkzeug or flask escape with markupsafe

### DIFF
--- a/src/moin/converters/moinwiki_out.py
+++ b/src/moin/converters/moinwiki_out.py
@@ -14,7 +14,7 @@ import urllib.error
 from re import findall, sub
 
 from emeraldtree import ElementTree as ET
-from werkzeug.utils import unescape
+from markupsafe import Markup
 
 from moin.utils.tree import moin_page, xlink, xinclude, html
 from moin.utils.iri import Iri
@@ -513,7 +513,7 @@ class Converter:
                     elem = next(elem_it)
                 ret = "{0}\n{1}\n}}}}}}\n".format(ret, ' '.join(elem.itertext()))
                 return ret
-        return unescape(elem.get(moin_page.alt, '')) + "\n"
+        return Markup.unescape(elem.get(moin_page.alt, '')) + "\n"
 
     def open_moinpage_inline_part(self, elem):
         ret = self.open_moinpage_part(elem)

--- a/src/moin/items/_tests/test_Content.py
+++ b/src/moin/items/_tests/test_Content.py
@@ -10,9 +10,7 @@
 import pytest
 from io import BytesIO
 
-from flask import Markup
-
-from werkzeug.utils import escape
+from markupsafe import Markup, escape
 
 from moin.utils import diff_html
 

--- a/src/moin/items/content.py
+++ b/src/moin/items/content.py
@@ -32,11 +32,11 @@ from operator import attrgetter
 
 from flask import current_app as app
 from flask import g as flaskg
-from flask import request, url_for, Response, abort, escape
+from flask import request, url_for, Response, abort
 
 from flatland import Form, String
 
-from jinja2 import Markup
+from markupsafe import Markup, escape
 
 from werkzeug.http import is_resource_modified
 

--- a/src/moin/utils/diff_html.py
+++ b/src/moin/utils/diff_html.py
@@ -9,7 +9,7 @@
 
 import difflib
 
-from werkzeug.utils import escape
+from markupsafe import escape
 
 
 def indent(line):
@@ -71,12 +71,12 @@ def diff(old, new):
         if charobj.ratio() < 0.5:
             # Insufficient similarity.
             if leftpane:
-                leftresult = """<span>{0}</span>""".format(indent(escape(leftpane)))
+                leftresult = """<span>{0}</span>""".format(indent(str(escape(leftpane))))
             else:
                 leftresult = ''
 
             if rightpane:
-                rightresult = """<span>{0}</span>""".format(indent(escape(rightpane)))
+                rightresult = """<span>{0}</span>""".format(indent(str(escape(rightpane))))
             else:
                 rightresult = ''
         else:
@@ -91,8 +91,8 @@ def diff(old, new):
                 if thismatch[1] - charlast[1] != 0:
                     rightresult += """<span>{0}</span>""".format(indent(
                         escape(rightpane[charlast[1]:thismatch[1]])))
-                leftresult += escape(leftpane[thismatch[0]:thismatch[0] + thismatch[2]])
-                rightresult += escape(rightpane[thismatch[1]:thismatch[1] + thismatch[2]])
+                leftresult += str(escape(leftpane[thismatch[0]:thismatch[0] + thismatch[2]]))
+                rightresult += str(escape(rightpane[thismatch[1]:thismatch[1] + thismatch[2]]))
                 charlast = (thismatch[0] + thismatch[2], thismatch[1] + thismatch[2])
 
         leftpane = '<br>'.join([indent(x) for x in leftresult.splitlines()])


### PR DESCRIPTION
Prepare for werkzeug >= 2.1 and related to #1109.

escape and unescape have been removed in werkzeug 2.1, see 
https://werkzeug.palletsprojects.com/en/2.2.x/changes/#version-2-1-0

It is recommended to use markupsafe instead. This results in some new challenges because strings will be converted to type Markup.

 