### PR TITLE
Use os replace instead of werkzeug.posixemulation rename

### DIFF
--- a/src/moin/utils/filesys.py
+++ b/src/moin/utils/filesys.py
@@ -14,7 +14,7 @@ import time
 import errno
 from stat import S_ISDIR, ST_MODE, S_IMODE
 
-from werkzeug.posixemulation import rename
+from os import replace as rename
 
 from moin import log
 logging = log.getLogger(__name__)


### PR DESCRIPTION
werkzeug.posixemulation has been removed in werkzeug 2.0.0, see 
https://werkzeug.palletsprojects.com/en/2.2.x/changes/#version-2-0-0

Prepare for werkzeug >= 2.0 and related to https://github.com/moinwiki/moin/issues/1109.