### PR TITLE
Replace Jinja2.Markup with markupsafe.Markup

### DIFF
--- a/src/moin/apps/feed/views.py
+++ b/src/moin/apps/feed/views.py
@@ -14,7 +14,7 @@ from flask import current_app as app
 from flask import g as flaskg
 
 from feedgen.feed import FeedGenerator
-from jinja2 import Markup
+from markupsafe import Markup
 
 from whoosh.query import Term, And
 

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -42,7 +42,7 @@ from flask_theme import get_themes_list
 from flatland import Form
 from flatland.validation import Validator
 
-from jinja2 import Markup
+from markupsafe import Markup
 
 import pytz
 from babel import Locale

--- a/src/moin/auth/__init__.py
+++ b/src/moin/auth/__init__.py
@@ -139,7 +139,7 @@ from werkzeug.utils import redirect
 from flask import url_for, session, request
 from flask import g as flaskg
 from flask import current_app as app
-from jinja2 import Markup
+from markupsafe import Markup
 
 from moin import user
 from moin.i18n import _

--- a/src/moin/items/__init__.py
+++ b/src/moin/items/__init__.py
@@ -32,7 +32,7 @@ from flask import request, Response, redirect, abort, url_for, flash
 from flatland import Form
 from flatland.validation import Validator
 
-from jinja2 import Markup
+from markupsafe import Markup
 
 from whoosh.query import Term, Prefix, And, Or, Not
 

--- a/src/moin/items/ticket.py
+++ b/src/moin/items/ticket.py
@@ -42,7 +42,7 @@ from flask import request, abort, redirect, url_for
 from flask import g as flaskg
 from flask import current_app as app
 
-from jinja2 import Markup
+from markupsafe import Markup
 
 from whoosh.query import Term, And
 

--- a/src/moin/utils/forms.py
+++ b/src/moin/utils/forms.py
@@ -6,7 +6,7 @@
 """
 
 
-from jinja2 import Markup
+from markupsafe import Markup
 import werkzeug.datastructures
 
 from flatland import AdaptationError, Scalar


### PR DESCRIPTION
'jinja2.Markup' is deprecated and will be removed in Jinja 3.1. Import 'markupsafe.Markup' instead.

Prepare for Jinja2 >= 3.0 and related to #1109.