### PR TITLE
Remove deprecated encode_keys parm from werkzeug.urls.url_encode

### DIFF
--- a/src/moin/converters/image_in.py
+++ b/src/moin/converters/image_in.py
@@ -40,7 +40,7 @@ class Converter:
                 query_keys.update(url_decode(query.query))
             attrib = arguments.keyword
 
-        query = url_encode(query_keys, charset=CHARSET, encode_keys=True)
+        query = url_encode(query_keys, charset=CHARSET)
 
         attrib.update({
             moin_page.type_: str(self.input_type),

--- a/src/moin/converters/mediawiki_in.py
+++ b/src/moin/converters/mediawiki_in.py
@@ -643,7 +643,7 @@ class Converter(ConverterMacro):
         parsed_args = self.parse_args(link_args[1:])
         query = None
         if parsed_args.keyword:
-            query = url_encode(parsed_args.keyword, charset=CHARSET, encode_keys=True, sort=True)
+            query = url_encode(parsed_args.keyword, charset=CHARSET, sort=True)
         # Take the last of positional parameters as link_text(caption)
         if parsed_args.positional:
             link_text = parsed_args.positional.pop()
@@ -662,7 +662,7 @@ class Converter(ConverterMacro):
                     if 'do' not in args:
                         # by default, we want the item's get url for transclusion of raw data:
                         args['do'] = 'get'
-                    query = url_encode(args, charset=CHARSET, encode_keys=True, sort=True)
+                    query = url_encode(args, charset=CHARSET, sort=True)
                     target = Iri(scheme='wiki.local', path=object_item, query=query, fragment=None)
                     text = object_item
                 else:

--- a/src/moin/converters/moinwiki_in.py
+++ b/src/moin/converters/moinwiki_in.py
@@ -852,7 +852,7 @@ class Converter(ConverterMacro):
             attrib[html.alt] = object_text
         if object_item is not None:
             # img tag
-            query = url_encode(query_keys, charset=CHARSET, encode_keys=True)
+            query = url_encode(query_keys, charset=CHARSET)
             # TODO: moin 1.9 needed this for an attached file; move functionality to scripts/migration/moin/import19.py
             att = 'attachment:'
             if object_item.startswith(att):


### PR DESCRIPTION
Parameter encode_keys was related to unicode and ignored since python 3.x.

Prepare for Werkzeug 2.x and related to #1109.