### PR TITLE
Fix doctype in test_frontend.py for Werkzeug >= 2.1.2

### DIFF
--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -39,7 +39,10 @@ class TestFrontend:
                 assert rv.headers['Content-Type'] in content_types
                 if method == 'GET':
                     for item in data:
-                        assert item in rv_data
+                        if item == '<!doctype html':  # TODO: remove workaround when Werkzeug >= 2.1.2 is set
+                            assert item in str(rv_data).lower()
+                        else:
+                            assert item in rv_data
         return rv
 
     def _test_view_post(self, viewname, status='302 FOUND', content_types=('text/html; charset=utf-8', ), data=('<html>', '</html>'), form=None, viewopts=None):
@@ -175,7 +178,7 @@ class TestFrontend:
         self._test_view('frontend.orphaned_items')
 
     def test_quicklink_item(self):
-        self._test_view('frontend.quicklink_item', status='302 FOUND', viewopts=dict(item_name='DoesntExist'), data=['<!DOCTYPE HTML'])
+        self._test_view('frontend.quicklink_item', status='302 FOUND', viewopts=dict(item_name='DoesntExist'), data=['<!doctype html'])
 
     def test_subscribe_item(self):
         self._test_view('frontend.subscribe_item', status='404 NOT FOUND', viewopts=dict(item_name='DoesntExist'))
@@ -184,7 +187,7 @@ class TestFrontend:
         self._test_view('frontend.register')
 
     def test_verifyemail(self):
-        self._test_view('frontend.verifyemail', status='302 FOUND', data=['<!DOCTYPE HTML'])
+        self._test_view('frontend.verifyemail', status='302 FOUND', data=['<!doctype html'])
 
     def test_lostpass(self):
         self._test_view('frontend.lostpass')
@@ -196,16 +199,16 @@ class TestFrontend:
         self._test_view('frontend.login')
 
     def test_logout(self):
-        self._test_view('frontend.logout', status='302 FOUND', data=['<!DOCTYPE HTML'])
+        self._test_view('frontend.logout', status='302 FOUND', data=['<!doctype html'])
 
     def test_usersettings_notloggedin(self):
         # if a anon user visits usersettings view, he'll get redirected to the login view
-        self._test_view('frontend.usersettings', status='302 FOUND', data=['<!DOCTYPE HTML'])
+        self._test_view('frontend.usersettings', status='302 FOUND', data=['<!doctype html'])
 
     # TODO: implement test_usersettings_loggedin()
 
     def test_bookmark(self):
-        self._test_view('frontend.bookmark', status='302 FOUND', data=['<!DOCTYPE HTML'])
+        self._test_view('frontend.bookmark', status='302 FOUND', data=['<!doctype html'])
 
     def test_diffraw(self):
         # TODO another test with valid rev1 and rev2 url args and an existing item is needed

--- a/src/moin/apps/serve/_tests/test_serve.py
+++ b/src/moin/apps/serve/_tests/test_serve.py
@@ -20,4 +20,5 @@ class TestServe:
             rv = c.get(url_for('serve.files', name="DoesntExist"))
             assert rv.status == '404 NOT FOUND'
             assert rv.headers['Content-Type'] == 'text/html; charset=utf-8'
-            assert b'<!DOCTYPE HTML' in rv.data
+            # TODO: remove workaround when Werkzeug >= 2.1.2 is set (PR 1325)
+            assert '<!doctype html' in str(rv.data).lower()


### PR DESCRIPTION
doctype string has been changed to lowercase in Werkzeug 2.1.2, see 
https://github.com/pallets/werkzeug/pull/2391/files

The if statement in line 42 is a workaround to allow all versions and can be removed when 2.1.2 is minimum version in setup.py. 

Prepare for Werkzeug 2.x and related to #1109.
