### PR TITLE
Use sphinx-rtd-theme >= 1.2.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # see #1333 ReadTheDocs build failed
 docutils>=0.18.1
 sphinx>=5.3.0
-sphinx-rtd-theme==1.2.0rc3
+sphinx-rtd-theme>=1.2.0


### PR DESCRIPTION
sphinx-rtd-theme 1.2.0 is released now. 
Fixes #1333.