### PR TITLE
CLI: update docs and comments

### DIFF
--- a/docs/admin/backup.rst
+++ b/docs/admin/backup.rst
@@ -39,8 +39,7 @@ Selective Restore
 To restore all software and configuration files to their original
 place, create an empty wiki first::
 
- moin index-create -s -i  # -s = create new storage
-                          # -i = create new index
+ moin index-create
 
 To load the backup file into your empty wiki, run::
 

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -53,13 +53,8 @@ moin index-create
 -----------------
 Creates an empty but valid index.
 
-**Note:** the moin WSGI application needs an index to successfully start up.
-As the moin index-* script commands are also based on the moin WSGI application,
-this can lead to a chicken and egg problem. To solve this, the moin command has
-a ``-i`` (``--index-create``) option that will trigger index creation on startup.
-
-Additionally, if the storage is also non-existent yet, one might also need
-``-s`` (``--storage-create``) to create an empty storage on startup.
+**Note:** the moin WSGI application needs an index and storage to successfully start up.
+Please see command moin create-instance.
 
 moin index-build
 ----------------
@@ -107,8 +102,7 @@ If your wiki is fresh and empty
 -------------------------------
 Use::
 
-    moin index-create --storage-create --index-create
-    moin index-create -s -i  # same, but shorter
+    moin index-create
 
 Storage and index are now initialized and both empty.
 
@@ -120,7 +114,7 @@ If your wiki has data and is shut down
 If index needs a rebuild for some reason, e.g. index lost, index damaged,
 incompatible upgrade, etc., use::
 
-    moin index-create -i
+    moin index-create
     moin index-build  # can take a while...
 
 
@@ -128,7 +122,7 @@ If your wiki has data and should stay online
 --------------------------------------------
 Use::
 
-     moin index-create -i --tmp
+     moin index-create --tmp
      moin index-build --tmp  # can take a while...
      moin index-update --tmp  # should be quicker, make sure we have 99.x%
      # better shut down the wiki now or at least make sure it is not changed
@@ -164,7 +158,7 @@ wiki configs could look like:
 
 Now do the initial index building::
 
-     moin index-create -i  # create an empty index
+     moin index-create  # create an empty index
      # now add the indexes from both other wikis:
      moin index-build  # with Sales wiki configuration
      moin index-build  # with Engineering wiki configuration

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -70,21 +70,21 @@ storage and the index:
 
 ::
 
- moin index-create -s -i
+ moin index-create
 
 If you don't want to start with an empty wiki, but rather play with some
 sample content we provide, load it into your wiki and rebuild the indexes:
 
 ::
 
- moin load-sample
+ moin load-sample # deprecated
  moin index-build
 
 Or, if you have a moin 1.9.x wiki, convert it to moin 2:
 
 ::
 
-  moin import19 -d <path to 1.9 wiki/data> -s -i
+  moin import19 -d <path to 1.9 wiki/data>
 
 If you want to load English help for editors (replace en with your wiki's preferred language):
 
@@ -99,7 +99,7 @@ Now try your new wiki using the builtin python-based web server:
 
 ::
 
- moin moin  # visit the URL it shows in the log output
+ moin run  # visit the URL it shows in the log output
 
 For production, please use a real web server like apache or nginx.
 

--- a/docs/admin/requirements.rst
+++ b/docs/admin/requirements.rst
@@ -20,7 +20,7 @@ Servers
 
 For moin2, you can use any server compatible with WSGI:
 
-* the builtin server (used by the "moin moin" command) is recommended for
+* the builtin server (used by the "moin run" command) is recommended for
   desktop wikis, testing, debugging, development, adhoc-wikis, etc.
 * apache with mod_wsgi is recommended for bigger/busier wikis.
 * other WSGI-compatible servers or middlewares are usable
@@ -30,7 +30,7 @@ For moin2, you can use any server compatible with WSGI:
 
 
 .. caution:: When using the built-in server for public wikis (not recommended), use
-        "moin moin -D -R" to turn off the werkzeug debugger and auto reloader.
+        "moin run --no-debugger --no-reload" to turn off the werkzeug debugger and auto reloader.
         See the Werkzeug docs for more information.
 
 

--- a/docs/admin/serve.rst
+++ b/docs/admin/serve.rst
@@ -20,10 +20,11 @@ Running the built-in server
 Run the moin built-in server as follows::
 
  # easiest for debugging (single-process, single-threaded server):
- moin moin
+ moin run
 
  # or, if you need another configuration file, ip address, or port:
- moin --config /path/to/wikiconfig.py moin --host 1.2.3.4 --port 7777
+ MOINCFG='/path/to/wikiconfig.py'
+ moin run --host 1.2.3.4 --port 7777
 
 While the moin server is starting up, you will see some log output, for example::
 
@@ -53,12 +54,12 @@ Using the built-in server for production
 ----------------------------------------
 
 .. caution:: Using the built-in server for public wikis is not recommended. Should you
- wish to do so, turn off the werkzeug debugger and auto reloader by passing the
- -d and -r flags. The wikiconfig.py settings of `DEBUG = False` and `TESTING = False` are
- ignored by the built-in server. You must use the -d and -r flags.
+ wish to do so, turn off the werkzeug debugger and auto reloader by passing the --debugger
+ and --reload flags. The wikiconfig.py settings of `DEBUG = False` and `TESTING = False` are
+ ignored by the built-in server.
  See Werkzeug docs for more information.::
 
- moin moin --host 0.0.0.0 --port 80 -D -R
+ moin run --host 0.0.0.0 --port 80 --debugger --reload
 
 
 External Web Server (advanced)

--- a/docs/devel/development.rst
+++ b/docs/devel/development.rst
@@ -226,7 +226,7 @@ moin2 is a WSGI application and uses:
 
 * flask as framework
 
-  - flask-script for command line scripts
+  - flask cli and click for command line interface
   - flask-babel / babel / pytz for i18n/l10n
   - flask-theme for theme switching
   - flask-caching as cache storage abstraction

--- a/docs/intro/features.rst
+++ b/docs/intro/features.rst
@@ -154,6 +154,6 @@ Technologies
 ============
 * html5, css, javascript with jquery, svg
 * python
-* flask, flask-caching, flask-babel, flask-theme, flask-script
+* flask, flask-caching, flask-babel, flask-theme, click
 * whoosh, werkzeug, pygments, flatland, blinker, babel, emeraldtree
 * sqlalchemy (supports all popular SQL DBMS), sqlite, kyoto tycoon/cabinet

--- a/docs/man/moin.rst
+++ b/docs/man/moin.rst
@@ -3,20 +3,19 @@
 Moin Command Line Interface
 ===========================
 
-Moin2 has two command line interfaces. The newer interface, powered
+Moin2 has two command line interfaces. The first interface, powered
 by quickinstall.py and started by the **./m** command (**m** on windows),
-implements the most common functions used by desktop
-users and developers. This CLI is only available when moin is installed
-using git to clone a repository from https://github.com/moinwiki/moin
-or alternative.
+implements the most common functions used by developers.
+This CLI is only available when moin is installed using git to
+clone a repository from https://github.com/moinwiki/moin or alternative.
 
-The older interface, **moin**, is implemented by several Python scripts
-located in the /scripts/ directory. This interface targets wiki migration,
+The second interface, **moin**, is implemented by several Python scripts
+located in the /cli/ directory. This interface targets wiki migration,
 account creation and maintenance, and wiki maintenance.
 
 There is some overlap between the two interfaces. Several of the commands
-within the newer interface are implemented by wrapping one or more of the
-older interface commands to accomplish a task.
+within the first interface are implemented by wrapping one or more of the
+cli interface commands to accomplish a task.
 
 ./m Interface
 -------------
@@ -67,53 +66,42 @@ If you invoke :program:`moin` without any arguments, it will show a short quick 
 
 ::
 
-    usage: moin [-c CONFIG] [-i] [-s] [-?]
-                {help,moin,run,create-instance,index-create,index-build,index-update,index-destroy,index-move,index-optimize
-    ,index-dump,save,load,load-sample,dump-html,account-create,account-disable,account-password,maint-reduce-revisions,maint
-    -set-meta,item-get,item-put,load-help,dump-help,import19,shell,runserver}
-                ...
+    Usage: moin [OPTIONS] COMMAND [ARGS]...
 
-    positional arguments:
-      {help,moin,run,create-instance,index-create,index-build,index-update,index-destroy,index-move,index-optimize,index-dum
-    p,save,load,load-sample,dump-html,account-create,account-disable,account-password,maint-reduce-revisions,maint-set-meta,
-    item-get,item-put,load-help,dump-help,import19,shell,runserver}
-        help
-        moin                Runs the Flask development server i.e. app.run()
-        run                 Runs the Flask development server i.e. app.run()
-        create-instance
-        index-create
-        index-build
-        index-update
-        index-destroy
-        index-move
-        index-optimize
-        index-dump
-        save
-        load
-        load-sample
-        dump-html
-        account-create
-        account-disable
-        account-password
-        maint-reduce-revisions
-        maint-set-meta
-        item-get
-        item-put
-        load-help           Load an entire help namespace from distribution source.
-        dump-help           Save an entire help namespace to the distribution source.
-        import19
-        shell               Runs a Python shell inside Flask application context. :param banner: banner appearing at top
-                            of shell when started :param make_context: a callable returning a dict of variables used in
-                            the shell namespace. By default returns a dict consisting of just the app. :param use_ipython:
-                            use IPython shell if available, ignore if not. The IPython shell can be turned off in command
-                            line by passing the **--no-ipython** flag.
-        runserver           Runs the Flask development server i.e. app.run()
+      Moin extensions to the Flask CLI
 
-    options:
-      -c CONFIG, --config CONFIG
-      -i, --index-create
-      -s, --storage-create
-      -?, --help            show this help message and exit
+    Options:
+      --version  Show the flask version
+      --help     Show this message and exit.
+
+    Commands:
+      account-create          Create a user account
+      account-disable         Disable user accounts
+      account-password        Set user passwords
+      create-instance         Create wikiconfig and wiki instance directories...
+      dump-help               Dump a namespace of user help items to .data...
+      dump-html               Create a static HTML image of this wiki
+      help                    Quick help
+      import19                Import content and user data from a moin 1.9 wiki
+      index-build             Build the indexes
+      index-create            Create empty indexes
+      index-destroy           Destroy the indexes
+      index-dump              Dump the indexes in readable form to stdout
+      index-move              Move the indexes from the temporary to the...
+      index-optimize          Optimize the indexes
+      index-update            Update the indexes
+      item-get                Get an item revision from the wiki
+      item-put                Put an item revision into the wiki
+      load                    Deserialize a file into the backend; with...
+      load-help               Load a directory of help .data and .meta file...
+      load-sample             Load wiki sample items
+      maint-reduce-revisions  Remove all revisions but the last one from all...
+      maint-set-meta          Set meta data of a new revision
+      routes                  Show the routes for the app.
+      run                     Run a development server.
+      save                    Serialize the backend into a file
+      shell                   Run a shell in the app context.
+
 
 See also
 --------

--- a/src/moin/app.py
+++ b/src/moin/app.py
@@ -45,7 +45,7 @@ if os.getcwd() not in sys.path and '' not in sys.path:
 
 def create_app(config=None, create_index=False, create_storage=False):
     """
-    simple wrapper around create_app_ext() for flask-script
+    simple wrapper around create_app_ext()
     """
     return create_app_ext(flask_config_file=config,
                           create_index=create_index,

--- a/src/moin/config/wikiconfig.py
+++ b/src/moin/config/wikiconfig.py
@@ -51,9 +51,9 @@ class Config(DefaultConfig):
         pip install moin
         moin create-instance --path <mywiki>
         cd <mywiki>
-        moin index-create -s -i                                 # creates empty wiki, OR
-        moin import19 -s -i --data_dir <path to 1.9 wiki/data>  # import 1.9 data, OR
-        moin index-create; moin load-sample; moin index-build   # creates wiki with sample data
+        moin index-create                                      # creates empty wiki, OR
+        moin import19 --data_dir <path to 1.9 wiki/data>       # import 1.9 data, OR
+        moin index-create; moin load-sample; moin index-build  # creates wiki with sample data
     to create this structure:
 
         <myvenv>/               # virtualenv root, moin installed in site-packages below include/


### PR DESCRIPTION
Updated documentation after migration from flask-script to cli, see #729.

Most changes have been made in `docs/man/moin.rst`.
I am aware that there are different opinions which cli interface is the better or newer one. Removed the words newer and older. For me the ./m interface is needed by developers and the moin cli is the only interface for normal wiki users. Hope this change is ok.
 