### PR TITLE
loading moin help-en docs makes default html item disappear: fixes #1357

### DIFF
--- a/src/moin/help/en/html.meta
+++ b/src/moin/help/en/html.meta
@@ -3,7 +3,7 @@
   "address": "None",
   "comment": "",
   "contenttype": "text/html;charset=utf-8",
-  "dataid": "b1163894203748a4a061465587923f30",
+  "dataid": "b1163894203748a4a061465587923fff",
   "externallinks": [
     "http://ckeditor.com",
     "http://localhost:8080/Home",


### PR DESCRIPTION
do `moin load-help -n en` to repair wiki instance