### PR TITLE
Raise Babel version, allow no-break space and upd year in test data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup_args = dict(
         'setuptools_scm',  # magically cares for version and packaged files
     ],
     install_requires=[
-        'Babel<2.11.0',  # internationalization support
+        'Babel>=2.10.0',  # internationalization support
         'blinker>=1.1',  # event signalling (e.g. for change notification trigger)
         'docutils>=0.18.1',  # reST markup processing
         'Markdown>=3.4.1',  # Markdown markup processing

--- a/src/moin/macros/_tests/test_Date.py
+++ b/src/moin/macros/_tests/test_Date.py
@@ -1,4 +1,5 @@
 # Copyright: 2011 Prashant Kumar <contactprashantat AT gmail DOT com>
+# Copyright: 2023 MoinMoin Project
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -18,19 +19,19 @@ from moin.utils.show_time import format_date_time, format_date
 class TestMacroDateTimeBase:
     def test_parse_time(self):
         MacroDateTimeBase_obj = MacroDateTimeBase()
-        test_time_args = '2011-08-07T11:11:11+0533'
+        test_time_args = '2023-08-07T11:11:11+0533'
         ts = MacroDateTimeBase_obj.parse_time(test_time_args)
-        expected = 1312695491.0
+        expected = 1691386691.0
         assert ts == expected
 
         result = format_date_time(datetime.utcfromtimestamp(ts))
-        expected = '2011-08-07 05:38:11z'
+        expected = '2023-08-07 05:38:11z'
         assert result == expected
 
         flaskg.user.valid = True  # show_time creates ISO 8601 dates if user is not logged in
         result = format_date_time(datetime.utcfromtimestamp(ts))
-        expected = 'Aug 7, 2011, 5:38:11 AM'  # comma after year was added in recent CLDR
-        assert result == expected
+        expected = ['Aug 7, 2023, 5:38:11\u202fAM', 'Aug 7, 2023, 5:38:11 AM', ]  # TODO: remove 2nd entry later
+        assert result in expected
 
         with pytest.raises(ValueError):
             # things after next 10,000 years can't be predicted
@@ -51,18 +52,18 @@ class TestMacro:
         test_time = format_date(datetime.utcfromtimestamp(test_time))
         assert result == test_time
 
-        arguments = ['2011-08-07T11:11:11+0533', 'argument2']
+        arguments = ['2023-08-07T11:11:11+0533', 'argument2']
         result = macro_obj.macro('content', arguments, 'page_url', 'alternative')
-        expected = 'Aug 7, 2011'
+        expected = 'Aug 7, 2023'
         assert result == expected
 
         flaskg.user.timezone = 'UTC'
         flaskg.user.iso_8601 = True
         result = macro_obj.macro('content', arguments, 'page_url', 'alternative')
-        expected = '2011-08-07z'
+        expected = '2023-08-07z'
         assert result == expected
 
         flaskg.user.timezone = 'US/Arizona'
         result = macro_obj.macro('content', arguments, 'page_url', 'alternative')
-        expected = '2011-08-07'
+        expected = '2023-08-07'
         assert result == expected

--- a/src/moin/macros/_tests/test_DateTime.py
+++ b/src/moin/macros/_tests/test_DateTime.py
@@ -1,4 +1,5 @@
 # Copyright: 2011 Prashant Kumar <contactprashantat AT gmail DOT com>
+# Copyright: 2023 MoinMoin Project
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -27,14 +28,14 @@ def test_Macro():
     test_time = format_date_time(datetime.utcfromtimestamp(test_time))
     assert test_time == result
 
-    arguments = ['2011-08-07T11:11:11', 'argument2']
+    arguments = ['2023-08-07T11:11:11', 'argument2']
     result = macro_obj.macro('content', arguments, 'page_url', 'alternative')
-    expected = 'Aug 7, 2011, 11:11:11 AM'  # comma after year was added in recent CLDR
-    assert result == expected
+    expected = ['Aug 7, 2023, 11:11:11\u202fAM', 'Aug 7, 2023, 11:11:11 AM', ]  # TODO: remove 2nd entry later
+    assert result in expected
 
     flaskg.user.valid = False
     result = macro_obj.macro('content', arguments, 'page_url', 'alternative')
-    expected = '2011-08-07 11:11:11z'
+    expected = '2023-08-07 11:11:11z'
     assert result == expected
 
     arguments = ['incorrect_argument']

--- a/src/moin/utils/_tests/test_show_time.py
+++ b/src/moin/utils/_tests/test_show_time.py
@@ -61,9 +61,9 @@ class TestShowTime:
         formatted_date = show_time.format_date(utc_dt=0)
         assert formatted_date == 'Dec 31, 1969'
         formatted_time = show_time.format_time(utc_dt=0)
-        assert formatted_time == '5:00:00 PM'
+        assert formatted_time in ['5:00:00\u202fPM', '5:00:00 PM', ]  # TODO: 2nd string can be removed in future
         formatted_date_time = show_time.format_date_time(utc_dt=0)
-        assert formatted_date_time == 'Dec 31, 1969, 5:00:00 PM'
+        assert formatted_date_time in ['Dec 31, 1969, 5:00:00\u202fPM', 'Dec 31, 1969, 5:00:00 PM', ]  # TODO: ditto
 
 
 coverage_modules = ['moin.utils.show_time']


### PR DESCRIPTION
Fixes #1370.