### PR TITLE
Home.meta: remove obsolet parentid

### DIFF
--- a/src/moin/help/welcome/Home.meta
+++ b/src/moin/help/welcome/Home.meta
@@ -19,7 +19,6 @@
   ],
   "name_old": [],
   "namespace": "",
-  "parentid": "737bba88b59b407c9efe917eaf81a6bf",
   "rev_number": 1,
   "revid": "be7556a9a778481c938ff656fe230c9d",
   "sha1": "59f6c196b7ff2db96cc620154e7c9addf46c33a4",


### PR DESCRIPTION
The welcome page also had an invalid parentid causing the `'server overload or corrupt index'` error in `src/moin/storage/middleware/indexing.py:120` as mentioned in #1375. The feed using http://localhost:5000/+feed/atom is now running without complaints.