### PR TITLE
test for cli load and save, #1387

### DIFF
--- a/src/moin/cli/_tests/__init__.py
+++ b/src/moin/cli/_tests/__init__.py
@@ -14,6 +14,7 @@ import sys
 from typing import List, Union
 from warnings import warn
 
+from moin._tests import get_dirs
 from moin import log
 
 logging = log.getLogger(__name__)
@@ -105,6 +106,8 @@ def _is_eval_safe(s: str) -> bool:
                     pass
                 if DATETIME_RE.fullmatch(s):
                     safe = True
+                if s in {'True', 'False'}:
+                    safe = True
         if not safe:
             return False
     return True
@@ -132,3 +135,8 @@ def read_index_dump_latest_revs(out: str):
             warn(f'invalid line in stdout of moin index-dump: {repr(line.strip())}')
             continue
         item[line[0:space_index]] = eval(v_str)
+
+
+def getBackupPath(backup_name):
+    _, artifact_base_dir = get_dirs('')
+    return artifact_base_dir / backup_name

--- a/src/moin/cli/_tests/conftest.py
+++ b/src/moin/cli/_tests/conftest.py
@@ -29,7 +29,7 @@ from time import sleep
 from typing import List
 
 from moin._tests import check_connection, get_dirs
-from moin.cli._tests import run
+from moin.cli._tests import run, getBackupPath
 from moin.cli._tests.scrapy.moincrawler.items import CrawlResult
 from moin import log
 try:
@@ -86,6 +86,16 @@ def load_help(index_create):
 @pytest.fixture(scope="package")
 def welcome(index_create):
     return run(['moin', 'welcome'])
+
+
+@pytest.fixture(scope="package")
+def save_all(load_help, welcome):
+    return run(['moin', 'save', '-a', '-f', getBackupPath('backup.moin')])
+
+
+@pytest.fixture(scope="package")
+def save_default(welcome):
+    return run(['moin', 'save', '-b', 'default', '-f', getBackupPath('backup_default.moin')])
 
 
 def get_crawl_server_log_path():
@@ -188,7 +198,7 @@ def crawl_results(request, artifact_dir) -> List[CrawlResult]:
 @pytest.fixture(scope="package")
 def server_crawl_log(crawl_results):
     if not settings.DO_CRAWL:
-        logging.warn('using existing server-crawl.log')
+        logging.warning('using existing server-crawl.log')
     return get_crawl_server_log_path()
 
 

--- a/src/moin/cli/_tests/data/Corrupt.data
+++ b/src/moin/cli/_tests/data/Corrupt.data
@@ -1,0 +1,1 @@
+Home page

--- a/src/moin/cli/_tests/data/Corrupt.meta
+++ b/src/moin/cli/_tests/data/Corrupt.meta
@@ -1,0 +1,25 @@
+{
+  "action": "SAVE",
+  "address": "127.0.0.1",
+  "comment": "",
+  "contenttype": "text/x.moin.wiki;charset=utf-8",
+  "dataid": "e6d61e2849874f4c902cea71c5c7bf5b",
+  "externallinks": [],
+  "itemid": "cbd6fc46f88740acbc1dca90bb1eb8f3",
+  "itemlinks": [],
+  "itemtransclusions": [],
+  "itemtype": "default",
+  "mtime": 1680444037,
+  "name": [
+    "Home"
+  ],
+  "name_old": [],
+  "namespace": "",
+  "rev_number": 1,
+  "revid": "7ed018d7ceda49409e18b8efb914f5ff",
+  "sha1": "9521dba25709a79ede4a34b50471419774c41099",
+  "size": 8,
+  "summary": "",
+  "tags": [],
+  "wikiname": "MyMoinMoin"
+}

--- a/src/moin/cli/_tests/test_serialization.py
+++ b/src/moin/cli/_tests/test_serialization.py
@@ -1,0 +1,118 @@
+# Copyright: 2023 MoinMoin project
+# License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
+
+"""
+MoinMoin - moin.cli.maint.serialization tests
+"""
+
+import json
+import os
+from pathlib import Path
+import pytest
+import sys
+
+from moin._tests import get_dirs
+from moin.cli._tests import run, assert_p_succcess, read_index_dump_latest_revs, getBackupPath
+from moin.constants.keys import NAME, MTIME, CONTENT, BACKENDNAME, NAMESPACE
+from moin import log
+
+logging = log.getLogger(__name__)
+
+
+def test_save_all(artifact_dir, save_all):
+    assert_p_succcess(save_all)
+    assert getBackupPath('backup.moin').exists()
+
+
+def load(restore_dir, backup_name, artifact_dir, args=None):
+    restore_dir.mkdir()
+    os.chdir(restore_dir)
+    try:
+        for command in (['moin', 'create-instance'],
+                        ['moin', 'index-create'],
+                        ['moin', 'load', '-f', getBackupPath(backup_name)] + (args if args else []),
+                        ['moin', 'index-build']):
+            p = run(command)
+            assert_p_succcess(p)
+    finally:
+        os.chdir(artifact_dir)  # insure we return to archive_dir for other tests
+
+
+@pytest.mark.xfail(sys.platform == "win32", reason='#1402 svg file line ending causes bad size metadata')
+def test_load_all(artifact_dir, save_all):
+    restore_dir = Path(artifact_dir / 'restore_all')
+    load(restore_dir, 'backup.moin', artifact_dir)
+
+
+def test_save_default_ns(artifact_dir, save_default):
+    assert_p_succcess(save_default)
+    assert getBackupPath('backup_default.moin').exists()
+
+
+def test_load_default_ns(artifact_dir, save_default):
+    moin_dir, _ = get_dirs('')
+    welcome_dir = moin_dir / 'src' / 'moin' / 'help' / 'welcome'
+    expected_metas = {}
+    for data_fn in welcome_dir.glob('*.meta'):
+        with open(data_fn) as f:
+            meta = json.load(f)
+            if meta[NAMESPACE] != '':
+                continue
+            name = meta[NAME][0]
+            expected_metas[name] = meta
+    restore_dir = Path(artifact_dir / 'restore_default')
+    load(restore_dir, 'backup_default.moin', artifact_dir)
+    os.chdir(restore_dir)
+    try:
+        index_dump = run(['moin', 'index-dump', '--no-truncate'])
+        metas = {}
+        contents = {}
+        items = read_index_dump_latest_revs(index_dump.stdout.decode())
+        for item in items:
+            name = item[NAME][0]
+            content = item.pop(CONTENT)
+            metas[name] = item
+        assert set(expected_metas.keys()) == set(metas.keys())
+        for name, meta in metas.items():
+            expected_meta = expected_metas[name]
+            for k, v in meta.items():
+                if k in expected_meta:
+                    if k == MTIME:
+                        continue  # load replaces all mtimes
+                    expected_v = expected_meta[k]
+                    assert expected_v == v, f'key {k} {name}.meta = {repr(expected_v)} index-dump = {repr(v)}'
+        for name, content in contents.items():
+            with open(welcome_dir / f'{name}.data') as f:
+                expected_content = f.read()
+                assert expected_content, content
+    finally:
+        os.chdir(artifact_dir)  # insure we return to archive_dir for other tests
+
+
+def test_load_new_ns(artifact_dir, save_default):
+    restore_dir = Path(artifact_dir / 'restore_new_ns')
+    load(restore_dir, 'backup_default.moin', artifact_dir, ['-o', '', '-n', 'help-en'])
+    os.chdir(restore_dir)
+    try:
+        index_dump = run(['moin', 'index-dump', '--no-truncate'])
+        items = list(read_index_dump_latest_revs(index_dump.stdout.decode()))
+        assert 1 == len(items)
+        item = items[0]
+        assert ['Home'] == item[NAME]
+        assert 'help-en' == item[BACKENDNAME]
+    finally:
+        os.chdir(artifact_dir)  # insure we return to archive_dir for other tests
+
+
+@pytest.mark.xfail(reason='#1402 backups are unusable if metadata is corrupted')
+def test_load_corrupt(artifact_dir2, index_create2):
+    moin_dir, _ = get_dirs('cli')
+    data_dir = moin_dir / 'src' / 'moin' / 'cli' / '_tests' / 'data'
+    # item-put below errors out without the -o, see moin.storage.backends.stores.store
+    p = run(['moin', 'item-put', '-m', data_dir / 'Corrupt.meta', '-d', data_dir / 'Corrupt.data', '-o'])
+    assert_p_succcess(p)
+    backup_name = 'backup_corrupt.moin'
+    p = run(['moin', 'save', '-b', 'default', '-f', getBackupPath(backup_name)])
+    assert_p_succcess(p)
+    restore_dir = Path(artifact_dir2 / 'restore_new_ns')
+    load(restore_dir, backup_name, artifact_dir2)

--- a/src/moin/cli/maint/modify_item.py
+++ b/src/moin/cli/maint/modify_item.py
@@ -26,6 +26,11 @@ from moin import log, help as moin_help
 logging = log.getLogger(__name__)
 
 
+def _get_path_to_help(subdir=''):
+    help_path = os.path.dirname(moin_help.__file__)
+    return os.path.normpath(os.path.join(help_path, subdir))
+
+
 @click.group(cls=FlaskGroup, create_app=create_app)
 def cli():
     pass
@@ -146,8 +151,7 @@ def LoadHelp(namespace, path_to_help):
     """
     logging.info("Load help started")
     if path_to_help is None:
-        abspath_to_here = os.path.dirname(os.path.abspath(__file__))
-        path_to_help = os.path.abspath(os.path.join(abspath_to_here, '../../help/'))
+        path_to_help = _get_path_to_help()
     path_to_items = os.path.normpath(os.path.join(path_to_help, namespace))
     if not os.path.isdir(path_to_items):
         print('Abort: the {0} directory does not exist'.format(path_to_items))
@@ -184,8 +188,7 @@ def DumpHelp(namespace, path_to_help, crlf):
     logging.info("Dump help started")
     before_wiki()
     if path_to_help is None:
-        abspath_to_here = os.path.dirname(os.path.abspath(__file__))
-        path_to_help = os.path.abspath(os.path.join(abspath_to_here, '../../help/'))
+        path_to_help = _get_path_to_help()
     item_name = 'help-' + namespace
     # item_name is a namespace, we create a dummy item so we can get a list of files
     item = Item.create(item_name)
@@ -216,8 +219,7 @@ def LoadWelcome():
     Load a welcome page as initial home from distribution source.
     """
     logging.info("Load welcome page started")
-    help_path = os.path.dirname(moin_help.__file__)
-    path_to_items = os.path.normpath(os.path.join(help_path, 'welcome'))
+    path_to_items = _get_path_to_help('welcome')
     for name in ['Home', 'users-Home']:
         if app.storage.has_item(name):
             logging.warning('Item with name %s exists and will not be overwritten.', name)

--- a/src/moin/cli/maint/modify_item.py
+++ b/src/moin/cli/maint/modify_item.py
@@ -133,8 +133,9 @@ def PutItem(meta_file, data_file, overwrite):
 @cli.command('load-help', help='Load a directory of help .data and .meta file pairs into a wiki namespace')
 @click.option('--namespace', '-n', type=str, required=True,
               help='Namespace to be loaded: common, en, etc.')
-@click.option('--path_to_help', '--path', '-p', type=str, default='../../help/',
-              help='Override default input directory')
+@click.option('--path_to_help', '--path', '-p', type=str,
+              help='Override default output directory'
+                   '(default works in source directory - ../../help/ relative to src/moin/cli/maint)')
 def cli_LoadHelp(namespace, path_to_help):
     return LoadHelp(namespace, path_to_help)
 
@@ -144,8 +145,10 @@ def LoadHelp(namespace, path_to_help):
     Load an entire help namespace from distribution source.
     """
     logging.info("Load help started")
-    abspath_to_here = os.path.dirname(os.path.abspath(__file__))
-    path_to_items = os.path.normpath(os.path.join(abspath_to_here, path_to_help, namespace))
+    if path_to_help is None:
+        abspath_to_here = os.path.dirname(os.path.abspath(__file__))
+        path_to_help = os.path.abspath(os.path.join(abspath_to_here, '../../help/'))
+    path_to_items = os.path.normpath(os.path.join(path_to_help, namespace))
     if not os.path.isdir(path_to_items):
         print('Abort: the {0} directory does not exist'.format(path_to_items))
         return

--- a/src/moin/cli/maint/serialization.py
+++ b/src/moin/cli/maint/serialization.py
@@ -52,12 +52,12 @@ def open_file(filename, mode):
               help='Filename of the output file.')
 @click.option('--backends', '-b', type=str, required=False,
               help='Backend names to serialize (comma separated).')
-@click.option('--all-backends', '-a', default=False,
+@click.option('--all-backends', '-a', is_flag=True,
               help='Serialize all configured backends.')
 def Serialize(file=None, backends=None, all_backends=False):
     logging.info("Backup started")
     if file is None:
-        f = sys.stdout
+        f = sys.stdout.buffer
     else:
         f = open(file, "wb")
     with f as f:

--- a/src/moin/help/welcome/Home.meta
+++ b/src/moin/help/welcome/Home.meta
@@ -22,7 +22,7 @@
   "rev_number": 1,
   "revid": "be7556a9a778481c938ff656fe230c9d",
   "sha1": "59f6c196b7ff2db96cc620154e7c9addf46c33a4",
-  "size": 307,
+  "size": 324,
   "summary": "",
   "tags": [
     "Welcome"


### PR DESCRIPTION
xfail tests for #1402
fix for help/welcome/Home.meta size
altering --path parameter on load-help
    now works same as dump-help
changing -a to flag for save
    appears this is how it is expected to work in quickinstall.py
fix for save with no -f option use stdout.buffer to output binary data