### PR TITLE
Fix missing space in german translation.

### DIFF
--- a/src/moin/translations/de/LC_MESSAGES/messages.po
+++ b/src/moin/translations/de/LC_MESSAGES/messages.po
@@ -214,8 +214,8 @@ msgstr "Der Account für %(username)s wurde erstellt."
 #: src/moin/apps/admin/views.py:131
 #, python-format
 msgid "%(username)s has been sent a password recovery email."
-msgstr "Eine E-Mail zur Wiederherstellung des Passwortes wurde an" 
-" %(username)s gesendet."
+msgstr "Eine E-Mail zur Wiederherstellung des Passwortes wurde an " 
+"%(username)s gesendet."
 
 #: src/moin/apps/admin/views.py:133
 #, python-format

--- a/src/moin/translations/de/LC_MESSAGES/messages.po
+++ b/src/moin/translations/de/LC_MESSAGES/messages.po
@@ -215,7 +215,7 @@ msgstr "Der Account für %(username)s wurde erstellt."
 #, python-format
 msgid "%(username)s has been sent a password recovery email."
 msgstr "Eine E-Mail zur Wiederherstellung des Passwortes wurde an" 
-"%(username)s gesendet."
+" %(username)s gesendet."
 
 #: src/moin/apps/admin/views.py:133
 #, python-format


### PR DESCRIPTION
Currently, the E-Mail Password-Reset-Notification is missing a space:
Trying to recover the password of UserName leads to:

    Eine E-Mail zur Wiederherstellung des Passwortes wurde anUserName gesendet.

This PR changes this to:

    Eine E-Mail zur Wiederherstellung des Passwortes wurde an UserName gesendet.

TL;DR:
Fix missing space