### PR TITLE
Update message catalog and German translations

### DIFF
--- a/src/moin/translations/MoinMoin.pot
+++ b/src/moin/translations/MoinMoin.pot
@@ -1,134 +1,134 @@
 # Translations template for moin.
-# Copyright (C) 2022 Moin Core Team, see http://moinmo.in/MoinCoreTeamGroup
+# Copyright (C) 2023 Moin Core Team, see http://moinmo.in/MoinCoreTeamGroup
 # This file is distributed under the same license as the moin project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: moin 2.0.0.dev1081+g3391d412.d20220226\n"
+"Project-Id-Version: moin 2.0.0.dev1395+gbbd6ce2e.d20230425\n"
 "Report-Msgid-Bugs-To: English <moin-user@python.org>\n"
-"POT-Creation-Date: 2022-02-26 21:10+0000\n"
+"POT-Creation-Date: 2023-04-25 16:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.12.1\n"
 
-#: src/moin/forms.py:94 src/moin/forms.py:168
+#: src/moin/forms.py:100 src/moin/forms.py:179
 msgid "No namespace field in the meta."
 msgstr ""
 
-#: src/moin/forms.py:98
+#: src/moin/forms.py:104
 msgid "The names in the name list must be unique."
 msgstr ""
 
-#: src/moin/forms.py:105
+#: src/moin/forms.py:112
 #, python-format
 msgid "Item names (%(invalid_names)s) must not start with '@' or '+'"
 msgstr ""
 
-#: src/moin/forms.py:112
+#: src/moin/forms.py:121
 #, python-format
 msgid ""
 "Item name (%(invalid_names)s) must not contain ',' characters. Create "
 "item with 1 name, use rename to create multiple names."
 msgstr ""
 
-#: src/moin/forms.py:120
+#: src/moin/forms.py:130
 #, python-format
 msgid "Item names (%(invalid_names)s) must not match with existing namespaces."
 msgstr ""
 
-#: src/moin/forms.py:131
+#: src/moin/forms.py:141
 #, python-format
 msgid "Item(s) named %(duplicate_names)s already exist."
 msgstr ""
 
-#: src/moin/forms.py:156
+#: src/moin/forms.py:167
 msgid "Invalid JSON."
 msgstr ""
 
-#: src/moin/forms.py:157
+#: src/moin/forms.py:168
 msgid "Itemid not a proper UUID"
 msgstr ""
 
-#: src/moin/forms.py:162
+#: src/moin/forms.py:173
 msgid "No ITEMID field"
 msgstr ""
 
-#: src/moin/forms.py:172
+#: src/moin/forms.py:183
 #, python-format
 msgid "%(_namespace)s is not a valid namespace."
 msgstr ""
 
-#: src/moin/forms.py:193
+#: src/moin/forms.py:204
 msgid "E-Mail"
 msgstr ""
 
-#: src/moin/forms.py:194
+#: src/moin/forms.py:205
 msgid "E-Mail address"
 msgstr ""
 
-#: src/moin/forms.py:196
+#: src/moin/forms.py:207
 msgid "Your E-Mail address"
 msgstr ""
 
-#: src/moin/forms.py:198
+#: src/moin/forms.py:209
 msgid "Password"
 msgstr ""
 
-#: src/moin/forms.py:259
+#: src/moin/forms.py:270
 msgid "This item doesn't exist."
 msgstr ""
 
-#: src/moin/forms.py:261
+#: src/moin/forms.py:272
 msgid "This item name is corrupt, delete and recreate."
 msgstr ""
 
-#: src/moin/config/default.py:351 src/moin/forms.py:271
+#: src/moin/config/default.py:352 src/moin/forms.py:282
 #: src/moin/templates/all.html:6 src/moin/templates/ticket/advanced.html:28
 #: src/moin/templates/tickets.html:20 src/moin/templates/tickets.html:62
 msgid "Tags"
 msgstr ""
 
-#: src/moin/forms.py:274
+#: src/moin/forms.py:285
 msgid "Names"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/userbrowser.html:18
-#: src/moin/forms.py:278 src/moin/templates/usersettings_forms.html:149
+#: src/moin/forms.py:289 src/moin/templates/usersettings_forms.html:149
 msgid "Subscriptions"
 msgstr ""
 
-#: src/moin/forms.py:282 src/moin/templates/usersettings_forms.html:133
+#: src/moin/forms.py:293 src/moin/templates/usersettings_forms.html:133
 #: src/moin/themes/basic/templates/layout.html:105
 msgid "Quick Links"
 msgstr ""
 
-#: src/moin/forms.py:284
+#: src/moin/forms.py:295
 msgid "Search Query"
 msgstr ""
 
-#: src/moin/forms.py:334
+#: src/moin/forms.py:345
 msgid "YYYY-MM-DD HH:MM:SS (example: 2013-12-31 23:59:59)"
 msgstr ""
 
-#: src/moin/forms.py:335
+#: src/moin/forms.py:346
 msgid "Please use the following format: YYYY-MM-DD HH:MM:SS"
 msgstr ""
 
-#: src/moin/forms.py:353
+#: src/moin/forms.py:364
 msgid "Invalid Reference."
 msgstr ""
 
-#: src/moin/forms.py:361
+#: src/moin/forms.py:372
 msgid "(None)"
 msgstr ""
 
-#: src/moin/user.py:68
+#: src/moin/user.py:72
 #, python-format
 msgid ""
 "Invalid user name '%(name)s'.\n"
@@ -136,45 +136,45 @@ msgid ""
 "space between words. Group page name is not allowed."
 msgstr ""
 
-#: src/moin/user.py:74
+#: src/moin/user.py:78
 msgid "This user name already belongs to somebody else."
 msgstr ""
 
-#: src/moin/user.py:83
+#: src/moin/user.py:87
 #, python-format
 msgid "Password not acceptable: %(msg)s"
 msgstr ""
 
-#: src/moin/user.py:89
+#: src/moin/user.py:93
 msgid ""
 "Please provide your email address. If you lose your login information, "
 "you can get it by email."
 msgstr ""
 
-#: src/moin/apps/admin/views.py:119 src/moin/user.py:95
+#: src/moin/apps/admin/views.py:119 src/moin/user.py:99
 msgid "This email already belongs to somebody else."
 msgstr ""
 
-#: src/moin/user.py:808
+#: src/moin/user.py:819
 #, python-format
 msgid "[%(sitename)s] Your wiki password recovery link"
 msgstr ""
 
-#: src/moin/user.py:824
+#: src/moin/user.py:835
 #, python-format
 msgid "[%(sitename)s] Please verify your email address"
 msgstr ""
 
-#: src/moin/apps/admin/views.py:52 src/moin/config/default.py:353
+#: src/moin/apps/admin/views.py:52 src/moin/config/default.py:354
 msgid "Admin"
 msgstr ""
 
-#: src/moin/apps/admin/views.py:58 src/moin/config/default.py:352
+#: src/moin/apps/admin/views.py:58 src/moin/config/default.py:353
 msgid "User"
 msgstr ""
 
-#: src/moin/apps/admin/views.py:80 src/moin/apps/frontend/views.py:1835
-#: src/moin/apps/frontend/views.py:2082
+#: src/moin/apps/admin/views.py:80 src/moin/apps/frontend/views.py:1850
+#: src/moin/apps/frontend/views.py:2099
 msgid "Username"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: src/moin/apps/admin/views.py:82 src/moin/apps/frontend/views.py:1839
-#: src/moin/apps/frontend/views.py:1865
+#: src/moin/apps/admin/views.py:82 src/moin/apps/frontend/views.py:1856
+#: src/moin/apps/frontend/views.py:1882
 msgid "Register"
 msgstr ""
 
@@ -289,7 +289,7 @@ msgstr ""
 msgid "Interwiki Names"
 msgstr ""
 
-#: src/moin/apps/admin/views.py:362 src/moin/converters/archive_in.py:63
+#: src/moin/apps/admin/views.py:362 src/moin/converters/archive_in.py:66
 #: src/moin/templates/history.html:51 src/moin/templates/mychanges.html:22
 #: src/moin/templates/utils.html:380
 msgid "Size"
@@ -299,48 +299,48 @@ msgstr ""
 msgid "Item name"
 msgstr ""
 
-#: src/moin/apps/admin/views.py:371
+#: src/moin/apps/admin/views.py:372
 msgid "Item Sizes"
 msgstr ""
 
-#: src/moin/apps/admin/views.py:385 src/moin/apps/admin/views.py:386
+#: src/moin/apps/admin/views.py:386 src/moin/apps/admin/views.py:387
 msgid "Trashed Items"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/user_acl_report.html:16
 #: src/moin/apps/admin/templates/admin/userbrowser.html:50
-#: src/moin/apps/admin/views.py:425
+#: src/moin/apps/admin/views.py:427
 msgid "User ACL Report"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/groupbrowser.html:4
 #: src/moin/apps/admin/templates/admin/index.html:7
 #: src/moin/apps/admin/templates/admin/userbrowser.html:17
-#: src/moin/apps/admin/views.py:449
+#: src/moin/apps/admin/views.py:451
 msgid "Groups"
 msgstr ""
 
-#: src/moin/apps/admin/views.py:491
+#: src/moin/apps/admin/views.py:492
 msgid "Item ACL Report"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/group_acl_report.html:16
 #: src/moin/apps/admin/templates/admin/groupbrowser.html:11
-#: src/moin/apps/admin/views.py:525
+#: src/moin/apps/admin/views.py:526
 msgid "Group ACL Report"
 msgstr ""
 
-#: src/moin/apps/admin/views.py:550
+#: src/moin/apps/admin/views.py:551
 #, python-format
 msgid "Failed! Not authorized.<br>Item: %(item_name)s<br>ACL: %(acl_rule)s"
 msgstr ""
 
-#: src/moin/apps/admin/views.py:552
+#: src/moin/apps/admin/views.py:554
 #, python-format
 msgid "Success! ACL saved.<br>Item: %(item_name)s<br>ACL: %(acl_rule)s"
 msgstr ""
 
-#: src/moin/apps/admin/views.py:554
+#: src/moin/apps/admin/views.py:557
 #, python-format
 msgid "Nothing changed, invalid ACL.<br>Item: %(item_name)s<br>ACL: %(acl_rule)s"
 msgstr ""
@@ -434,14 +434,14 @@ msgid "Number items:"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/item_acl_report.html:19
-#: src/moin/items/__init__.py:388
+#: src/moin/items/__init__.py:395
 msgid "ACL"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/item_acl_report.html:31
-#: src/moin/apps/frontend/views.py:2187 src/moin/apps/frontend/views.py:2197
-#: src/moin/apps/frontend/views.py:2208 src/moin/apps/frontend/views.py:2251
-#: src/moin/apps/frontend/views.py:2277 src/moin/apps/frontend/views.py:2289
+#: src/moin/apps/frontend/views.py:2198 src/moin/apps/frontend/views.py:2209
+#: src/moin/apps/frontend/views.py:2220 src/moin/apps/frontend/views.py:2263
+#: src/moin/apps/frontend/views.py:2290 src/moin/apps/frontend/views.py:2302
 msgid "Save"
 msgstr ""
 
@@ -455,7 +455,7 @@ msgid "Rev."
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/trash.html:14
-#: src/moin/converters/archive_in.py:63 src/moin/templates/history.html:50
+#: src/moin/converters/archive_in.py:66 src/moin/templates/history.html:50
 #: src/moin/templates/mychanges.html:21
 msgid "Timestamp"
 msgstr ""
@@ -466,7 +466,7 @@ msgid "Editor"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/trash.html:16
-#: src/moin/apps/frontend/views.py:690 src/moin/items/__init__.py:337
+#: src/moin/apps/frontend/views.py:682 src/moin/items/__init__.py:340
 #: src/moin/templates/mail/notification_main.html:24
 #: src/moin/templates/utils.html:396
 msgid "Comment"
@@ -479,22 +479,22 @@ msgid "Actions"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/trash.html:29
-#: src/moin/config/default.py:379
+#: src/moin/config/default.py:380
 msgid "Show"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/trash.html:34
-#: src/moin/config/default.py:389
+#: src/moin/config/default.py:390
 msgid "Highlight"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/trash.html:39
-#: src/moin/config/default.py:390
+#: src/moin/config/default.py:391
 msgid "Meta"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/trash.html:44
-#: src/moin/config/default.py:349 src/moin/config/default.py:381
+#: src/moin/config/default.py:350 src/moin/config/default.py:382
 #: src/moin/templates/all.html:5 src/moin/templates/global_history.html:59
 msgid "History"
 msgstr ""
@@ -505,7 +505,7 @@ msgid "Revert deleted item"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/trash.html:55
-#: src/moin/config/default.py:394 src/moin/templates/index.html:126
+#: src/moin/config/default.py:395 src/moin/templates/index.html:126
 msgid "Destroy"
 msgstr ""
 
@@ -573,7 +573,7 @@ msgid "Default Setting"
 msgstr ""
 
 #: src/moin/apps/admin/templates/admin/wikiconfighelp.html:14
-#: src/moin/items/__init__.py:1146
+#: src/moin/items/__init__.py:1166
 msgid "Default"
 msgstr ""
 
@@ -604,18 +604,18 @@ msgstr ""
 
 #: src/moin/apps/admin/templates/user/index_user.html:15
 #: src/moin/apps/admin/templates/user/index_user.html:17
-#: src/moin/apps/frontend/views.py:1440 src/moin/apps/frontend/views.py:1441
+#: src/moin/apps/frontend/views.py:1453 src/moin/apps/frontend/views.py:1454
 #: src/moin/templates/mychanges.html:11
 msgid "My Changes"
 msgstr ""
 
 #: src/moin/apps/admin/templates/user/index_user.html:19
-#: src/moin/apps/frontend/views.py:1743 src/moin/apps/frontend/views.py:1745
+#: src/moin/apps/frontend/views.py:1759 src/moin/apps/frontend/views.py:1761
 msgid "Wanted Items"
 msgstr ""
 
 #: src/moin/apps/admin/templates/user/index_user.html:20
-#: src/moin/apps/frontend/views.py:1760 src/moin/apps/frontend/views.py:1763
+#: src/moin/apps/frontend/views.py:1776 src/moin/apps/frontend/views.py:1779
 msgid "Orphaned Items"
 msgstr ""
 
@@ -638,536 +638,539 @@ msgstr ""
 msgid "all"
 msgstr ""
 
-#: src/moin/apps/feed/views.py:89
+#: src/moin/apps/feed/views.py:90
 msgid "MoinMoin feels unhappy."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:157
+#: src/moin/apps/frontend/views.py:159
 msgid "Global Views"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:173
+#: src/moin/apps/frontend/views.py:175
 msgid "search also in non-current revisions"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:174 src/moin/apps/frontend/views.py:202
+#: src/moin/apps/frontend/views.py:176 src/moin/apps/frontend/views.py:204
 #: src/moin/templates/lookup.html:6
 msgid "Lookup"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:433
+#: src/moin/apps/frontend/views.py:437
 #, python-format
 msgid "QueryError: invalid search term: %(search_term)s"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:441
+#: src/moin/apps/frontend/views.py:445
 #, python-format
 msgid "TermNotFound: field is not indexed: %(search_term)s"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:540 src/moin/apps/frontend/views.py:547
+#: src/moin/apps/frontend/views.py:532 src/moin/apps/frontend/views.py:539
 msgid "This item is deleted."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:543
+#: src/moin/apps/frontend/views.py:535
 msgid "This item revision is deleted."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:576
+#: src/moin/apps/frontend/views.py:568
 #, python-format
 msgid "Items with %(field)s %(value)s"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:685
+#: src/moin/apps/frontend/views.py:677
 msgid "New Content Type"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:690 src/moin/items/__init__.py:337
+#: src/moin/apps/frontend/views.py:682 src/moin/items/__init__.py:341
 msgid "Comment about your change"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:691 src/moin/items/__init__.py:338
+#: src/moin/apps/frontend/views.py:683 src/moin/items/__init__.py:343
 msgid "OK"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:737
+#: src/moin/apps/frontend/views.py:728
 msgid "Item conversion failed"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:772
+#: src/moin/apps/frontend/views.py:763
 msgid "Item converted successfully"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:799
-msgid "Error: nothing changed. Meta data validation failed."
-msgstr ""
-
-#: src/moin/apps/frontend/views.py:806 src/moin/items/__init__.py:344
+#: src/moin/apps/frontend/views.py:796 src/moin/items/__init__.py:349
 msgid "Target"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:806
+#: src/moin/apps/frontend/views.py:797
 msgid "The name of the target item"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:834
+#: src/moin/apps/frontend/views.py:826
 msgid "Delete all subitems listed below if checked:"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:839
+#: src/moin/apps/frontend/views.py:831
 msgid "Destroy all subitems listed below if checked:"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1024
+#: src/moin/apps/frontend/views.py:1018
 #, python-format
 msgid "Item '%(bad_name)s' does not exist."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1039
+#: src/moin/apps/frontend/views.py:1035
 #, python-format
 msgid "Access denied for a subitem of %(bad_name)s, check History for status."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1044
+#: src/moin/apps/frontend/views.py:1041
 #, python-format
 msgid "Access denied processing '%(bad_name)s'."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1233
+#: src/moin/apps/frontend/views.py:1230
 #, python-format
 msgid ""
 "File Successfully uploaded and renamed from %(bad_name)s to "
 "%(good_name)s. "
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1247
+#: src/moin/apps/frontend/views.py:1239
+#, python-format
+msgid ""
+"UnicodeDecodeError, upload failed, not a text file, nothing saved: "
+"'%(file_name)s'. Try changing the name."
+msgstr ""
+
+#: src/moin/apps/frontend/views.py:1258
 #, python-format
 msgid "File Successfully uploaded, existing file overwritten: '%(file_name)s'."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1253
+#: src/moin/apps/frontend/views.py:1264
 #, python-format
 msgid "Permission denied, upload failed: '%(file_name)s'."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1265
+#: src/moin/apps/frontend/views.py:1276
 #, python-format
 msgid "File Successfully uploaded: '%(item_name)s'."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1288
+#: src/moin/apps/frontend/views.py:1299
 msgid "Apply Filter"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1362
+#: src/moin/apps/frontend/views.py:1373
 msgid "Global Index of All Namespaces"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1364
+#: src/moin/apps/frontend/views.py:1375
 #, python-format
 msgid "Namespace '%(name)s' "
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1367
+#: src/moin/apps/frontend/views.py:1378
 #, python-format
 msgid "subitems '%(item_name)s'"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1368
+#: src/moin/apps/frontend/views.py:1379
 #, python-format
 msgid "Index of %(what)s"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1370
+#: src/moin/apps/frontend/views.py:1381
 #, python-format
 msgid "Index of subitems '%(item_name)s'"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1372 src/moin/config/default.py:350
+#: src/moin/apps/frontend/views.py:1383 src/moin/config/default.py:351
 #: src/moin/templates/index.html:220
 msgid "Global Index"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1409
+#: src/moin/apps/frontend/views.py:1420
 msgid "You must be logged in to see your changes."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1471
+#: src/moin/apps/frontend/views.py:1485
 #, python-format
 msgid "Items that are referred by '%(item_name)s'"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1513
+#: src/moin/apps/frontend/views.py:1527
 #, python-format
 msgid "Items which refer to '%(item_name)s'"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1671 src/moin/apps/frontend/views.py:1677
-#: src/moin/config/default.py:349
+#: src/moin/apps/frontend/views.py:1687 src/moin/apps/frontend/views.py:1693
+#: src/moin/config/default.py:350
 msgid "Global History"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1673
+#: src/moin/apps/frontend/views.py:1689
 msgid "Global History of All Namespaces"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1675
+#: src/moin/apps/frontend/views.py:1691
 #, python-format
 msgid "History of Namespace '%(namespace)s'"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1773 src/moin/apps/frontend/views.py:1798
+#: src/moin/apps/frontend/views.py:1789 src/moin/apps/frontend/views.py:1813
 #, python-format
 msgid "You must login to use this action: %(action)s."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1776
+#: src/moin/apps/frontend/views.py:1792
 msgid "A quicklink to this page could not be added for you."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1779
+#: src/moin/apps/frontend/views.py:1795
 msgid "Your quicklink to this page could not be removed."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1800
+#: src/moin/apps/frontend/views.py:1815
 msgid "You are not allowed to subscribe to an item you may not read."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1804
+#: src/moin/apps/frontend/views.py:1819
 msgid ""
 "Can't remove the subscription! You are subscribed to this page, but not "
 "by itemid."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1805
+#: src/moin/apps/frontend/views.py:1820
 msgid "Please edit the subscription in your settings."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1810
+#: src/moin/apps/frontend/views.py:1825
 msgid "You could not get subscribed to this item."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1819 src/moin/apps/frontend/views.py:1996
-#: src/moin/apps/frontend/views.py:2142
+#: src/moin/apps/frontend/views.py:1834 src/moin/apps/frontend/views.py:2013
+#: src/moin/apps/frontend/views.py:2153
 msgid "The passwords do not match."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1835
+#: src/moin/apps/frontend/views.py:1851
 msgid "The login username you want to use"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1836 src/moin/apps/frontend/views.py:2020
-#: src/moin/apps/frontend/views.py:2178
+#: src/moin/apps/frontend/views.py:1853 src/moin/apps/frontend/views.py:2037
+#: src/moin/apps/frontend/views.py:2189
 msgid "The login password you want to use"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1837 src/moin/apps/frontend/views.py:2022
-#: src/moin/apps/frontend/views.py:2180
+#: src/moin/apps/frontend/views.py:1854 src/moin/apps/frontend/views.py:2039
+#: src/moin/apps/frontend/views.py:2191
 msgid "Repeat the same password"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1890
+#: src/moin/apps/frontend/views.py:1907
 msgid ""
 "Account verification required, please see the email we sent to your "
 "address."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1892
+#: src/moin/apps/frontend/views.py:1909
 #, python-format
 msgid ""
 "An error occurred while sending the verification email: \"%(message)s\" "
 "Please contact an administrator to activate your account."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1896
+#: src/moin/apps/frontend/views.py:1913
 msgid "Account created, please log in now."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1915
+#: src/moin/apps/frontend/views.py:1932
 msgid "This email is already in use."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1919
+#: src/moin/apps/frontend/views.py:1936
 msgid "Your account has been activated, you can log in now."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1921
+#: src/moin/apps/frontend/views.py:1938
 msgid "Your new email address has been confirmed."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1927
+#: src/moin/apps/frontend/views.py:1944
 msgid "Your username and/or token is invalid!"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1939
+#: src/moin/apps/frontend/views.py:1956
 msgid "Your user name or your email address is needed."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1953 src/moin/apps/frontend/views.py:2016
-#: src/moin/converters/archive_in.py:63
+#: src/moin/apps/frontend/views.py:1970 src/moin/apps/frontend/views.py:2033
+#: src/moin/converters/archive_in.py:66
 msgid "Name"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1953 src/moin/apps/frontend/views.py:2016
+#: src/moin/apps/frontend/views.py:1970 src/moin/apps/frontend/views.py:2033
 msgid "Your login name"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1955
+#: src/moin/apps/frontend/views.py:1972
 msgid "Recover password"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1963 src/moin/templates/lostpass.html:5
+#: src/moin/apps/frontend/views.py:1980 src/moin/templates/lostpass.html:5
 msgid "Lost Password"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1985
+#: src/moin/apps/frontend/views.py:2002
 msgid "If this account exists, you will be notified."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1997 src/moin/apps/frontend/views.py:2144
+#: src/moin/apps/frontend/views.py:2014 src/moin/apps/frontend/views.py:2155
 msgid "New password is unacceptable, could not get processed."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2017
+#: src/moin/apps/frontend/views.py:2034
 msgid "Recovery token"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2018
+#: src/moin/apps/frontend/views.py:2035
 msgid "The recovery token that has been sent to you"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2019 src/moin/apps/frontend/views.py:2177
+#: src/moin/apps/frontend/views.py:2036 src/moin/apps/frontend/views.py:2188
 msgid "New password"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2021 src/moin/apps/frontend/views.py:2179
+#: src/moin/apps/frontend/views.py:2038 src/moin/apps/frontend/views.py:2190
 msgid "New password (repeat)"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2023 src/moin/apps/frontend/views.py:2181
+#: src/moin/apps/frontend/views.py:2040 src/moin/apps/frontend/views.py:2192
 msgid "Change password"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2031 src/moin/templates/recoverpass.html:5
+#: src/moin/apps/frontend/views.py:2048 src/moin/templates/recoverpass.html:5
 msgid "Recover Password"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2044
+#: src/moin/apps/frontend/views.py:2061
 msgid "Your password has been changed, you can log in now."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2046
+#: src/moin/apps/frontend/views.py:2063
 msgid "Your token is invalid!"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2058
+#: src/moin/apps/frontend/views.py:2075
 msgid "Either your username or password was invalid."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2088
+#: src/moin/apps/frontend/views.py:2105
 msgid "Log in"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2096
-msgid "You are logged in."
-msgstr ""
-
-#: src/moin/apps/frontend/views.py:2100 src/moin/templates/utils.html:476
+#: src/moin/apps/frontend/views.py:2112 src/moin/templates/utils.html:476
 #: src/moin/themes/basic/templates/layout.html:172
 msgid "Login"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2131
+#: src/moin/apps/frontend/views.py:2126
+msgid "You are logged in."
+msgstr ""
+
+#: src/moin/apps/frontend/views.py:2142
 msgid "You are logged out."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2143
+#: src/moin/apps/frontend/views.py:2154
 msgid "The current password was wrong."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2147
+#: src/moin/apps/frontend/views.py:2158
 msgid "New password not acceptable: "
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2175
+#: src/moin/apps/frontend/views.py:2186
 msgid "Current Password"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2176
+#: src/moin/apps/frontend/views.py:2187
 msgid "Your current login password"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2202
+#: src/moin/apps/frontend/views.py:2214
 msgid "Always use ISO 8601 date-time format"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2203
+#: src/moin/apps/frontend/views.py:2215
 msgid "Publish my email (not my wiki homepage) in author info"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2204
+#: src/moin/apps/frontend/views.py:2216
 msgid "Open editor on double click"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2205
+#: src/moin/apps/frontend/views.py:2217
 msgid "Scroll page after edit"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2206
+#: src/moin/apps/frontend/views.py:2218
 msgid "Show comment sections"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2207
+#: src/moin/apps/frontend/views.py:2219
 msgid "Disable this account forever"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2217
+#: src/moin/apps/frontend/views.py:2229
 msgid "Invalid subscription syntax: "
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2218
+#: src/moin/apps/frontend/views.py:2230
 msgid "Invalid keyword: "
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2219
+#: src/moin/apps/frontend/views.py:2231
 msgid "Invalid RE syntax: "
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2259 src/moin/templates/usersettings.html:19
+#: src/moin/apps/frontend/views.py:2271 src/moin/templates/usersettings.html:19
 msgid "User Settings"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2268
+#: src/moin/apps/frontend/views.py:2281
 msgid "Usernames"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2268
+#: src/moin/apps/frontend/views.py:2281
 msgid "The login usernames you want to use"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2269
+#: src/moin/apps/frontend/views.py:2282
 msgid "Display-Name"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2270
+#: src/moin/apps/frontend/views.py:2283
 msgid "Your display name (informational)"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2273
+#: src/moin/apps/frontend/views.py:2286
 msgid "Timezone"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2275
+#: src/moin/apps/frontend/views.py:2288
 msgid "Locale"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2281
+#: src/moin/apps/frontend/views.py:2294
 msgid "Theme name"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2283
+#: src/moin/apps/frontend/views.py:2296
 msgid "User CSS URL"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2284
+#: src/moin/apps/frontend/views.py:2297
 msgid "Give the URL of your custom CSS (optional)"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2285
+#: src/moin/apps/frontend/views.py:2298
 msgid "Number rows in edit textarea"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2286
+#: src/moin/apps/frontend/views.py:2299
 msgid "Editor textarea height (0=auto)"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2287
+#: src/moin/apps/frontend/views.py:2300
 msgid "History results per page"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2288
+#: src/moin/apps/frontend/views.py:2301
 msgid "Number of results per page (0=no paging)"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2332
+#: src/moin/apps/frontend/views.py:2345
 msgid "Your password has been changed."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2340
+#: src/moin/apps/frontend/views.py:2354
 #, python-format
 msgid "The username '%(name)s' is already in use."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2347
+#: src/moin/apps/frontend/views.py:2361
 msgid "This email is already in use"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2362
+#: src/moin/apps/frontend/views.py:2376
 msgid "A confirmation email has been sent to your newly configured email address."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2369
+#: src/moin/apps/frontend/views.py:2383
 msgid ""
 "Your email address was not changed because sending the verification email"
 " failed. Please try again later."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2376
+#: src/moin/apps/frontend/views.py:2390
 msgid "Nothing saved."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2379
+#: src/moin/apps/frontend/views.py:2393
 msgid "Your changes have been saved."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2431
+#: src/moin/apps/frontend/views.py:2445
 msgid "You must log in to use bookmarks."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2529
+#: src/moin/apps/frontend/views.py:2539
 msgid "There is only one revision eligible for diff."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2658
+#: src/moin/apps/frontend/views.py:2670
 #, python-format
 msgid "Items with similar names to '%(item_name)s'"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2753 src/moin/apps/frontend/views.py:2761
+#: src/moin/apps/frontend/views.py:2765 src/moin/apps/frontend/views.py:2773
 msgid "Global Tags"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2763
+#: src/moin/apps/frontend/views.py:2775
 msgid "Global Tags in All Namespaces"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2765
+#: src/moin/apps/frontend/views.py:2777
 #, python-format
 msgid "Tags in Namespace '%(namespace)s'"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2813
+#: src/moin/apps/frontend/views.py:2825
 #, python-format
 msgid "Items tagged with %(tag)s"
 msgstr ""
 
-#: src/moin/auth/__init__.py:257 src/moin/auth/ldap_login.py:133
+#: src/moin/auth/__init__.py:258 src/moin/auth/ldap_login.py:133
 msgid "Missing password. Please enter user name and password."
 msgstr ""
 
-#: src/moin/auth/__init__.py:265 src/moin/auth/ldap_login.py:204
+#: src/moin/auth/__init__.py:266 src/moin/auth/ldap_login.py:204
 #: src/moin/auth/ldap_login.py:255
 msgid "Invalid username or password."
 msgstr ""
 
-#: src/moin/auth/__init__.py:272
+#: src/moin/auth/__init__.py:273
 #, python-format
 msgid ""
 "If you do not have an account, <a href=\"%(register_url)s\">you can "
 "create one now</a>. "
 msgstr ""
 
-#: src/moin/auth/__init__.py:274
+#: src/moin/auth/__init__.py:275
 #, python-format
 msgid "<a href=\"%(recover_url)s\">Forgot your password?</a>"
 msgstr ""
@@ -1181,245 +1184,251 @@ msgstr ""
 msgid "LDAP server %(server)s failed."
 msgstr ""
 
-#: src/moin/config/default.py:266
+#: src/moin/config/default.py:267
 #, python-format
 msgid "For a password a minimum length of %(min_length)d characters is required."
 msgstr ""
 
-#: src/moin/config/default.py:269
+#: src/moin/config/default.py:270
 #, python-format
 msgid ""
 "For a password a minimum of %(min_different)d different characters is "
 "required."
 msgstr ""
 
-#: src/moin/config/default.py:276
+#: src/moin/config/default.py:277
 msgid ""
 "Password is too easy to guess (password contains name or name contains "
 "password)."
 msgstr ""
 
-#: src/moin/config/default.py:285
+#: src/moin/config/default.py:286
 msgid "Password is too easy to guess (keyboard sequence)."
 msgstr ""
 
-#: src/moin/config/default.py:348
+#: src/moin/config/default.py:349
 msgid "Home"
 msgstr ""
 
-#: src/moin/config/default.py:348
+#: src/moin/config/default.py:349
 msgid "Home Page"
 msgstr ""
 
-#: src/moin/config/default.py:350 src/moin/templates/all.html:7
+#: src/moin/config/default.py:351 src/moin/templates/all.html:7
 msgid "Index"
 msgstr ""
 
-#: src/moin/config/default.py:351
+#: src/moin/config/default.py:352
 msgid "Global Tags Index"
 msgstr ""
 
-#: src/moin/config/default.py:353
+#: src/moin/config/default.py:354
 msgid "Administration & Docs"
 msgstr ""
 
-#: src/moin/config/default.py:380 src/moin/templates/blog/utils.html:12
+#: src/moin/config/default.py:381 src/moin/templates/blog/utils.html:12
 #: src/moin/templates/show.html:14
 msgid "Modify"
 msgstr ""
 
-#: src/moin/config/default.py:380
+#: src/moin/config/default.py:381
 msgid "Edit or Upload"
 msgstr ""
 
-#: src/moin/config/default.py:381
+#: src/moin/config/default.py:382
 msgid "Revision History"
 msgstr ""
 
-#: src/moin/config/default.py:382 src/moin/templates/index.html:116
+#: src/moin/config/default.py:383 src/moin/templates/index.html:116
 #: src/moin/themes/basic/templates/modify.html:30
 msgid "Download"
 msgstr ""
 
-#: src/moin/config/default.py:383 src/moin/templates/index.html:121
+#: src/moin/config/default.py:384 src/moin/templates/index.html:121
 msgid "Delete"
 msgstr ""
 
-#: src/moin/config/default.py:383
+#: src/moin/config/default.py:384
 msgid "Delete this item"
 msgstr ""
 
-#: src/moin/config/default.py:384
+#: src/moin/config/default.py:385
 msgid "Create or remove a navigation link to this item"
 msgstr ""
 
-#: src/moin/config/default.py:385
+#: src/moin/config/default.py:386
 msgid "Switch notifications about item changes on or off"
 msgstr ""
 
-#: src/moin/config/default.py:386
+#: src/moin/config/default.py:387
 msgid "Subitems"
 msgstr ""
 
-#: src/moin/config/default.py:386
+#: src/moin/config/default.py:387
 msgid "Subitems Index"
 msgstr ""
 
-#: src/moin/config/default.py:388
+#: src/moin/config/default.py:389
 msgid "Rename"
 msgstr ""
 
-#: src/moin/config/default.py:388
+#: src/moin/config/default.py:389
 msgid "Rename this item"
 msgstr ""
 
-#: src/moin/config/default.py:389
+#: src/moin/config/default.py:390
 msgid "Show with Syntax-Highlighting"
 msgstr ""
 
-#: src/moin/config/default.py:390
+#: src/moin/config/default.py:391
 msgid "Display Metadata"
 msgstr ""
 
-#: src/moin/config/default.py:391
+#: src/moin/config/default.py:392
 msgid "Site Map"
 msgstr ""
 
-#: src/moin/config/default.py:391
+#: src/moin/config/default.py:392
 msgid "Local Site Map of this item"
 msgstr ""
 
-#: src/moin/config/default.py:392
+#: src/moin/config/default.py:393
 msgid "Similar"
 msgstr ""
 
-#: src/moin/config/default.py:392
+#: src/moin/config/default.py:393
 msgid "Items with similar names"
 msgstr ""
 
-#: src/moin/config/default.py:393
+#: src/moin/config/default.py:394
 msgid "Convert"
 msgstr ""
 
-#: src/moin/config/default.py:393
+#: src/moin/config/default.py:394
 msgid "Convert this item"
 msgstr ""
 
-#: src/moin/config/default.py:394
+#: src/moin/config/default.py:395
 msgid "Completely destroy this item"
 msgstr ""
 
-#: src/moin/config/default.py:395 src/moin/templates/ticket/modify.html:23
+#: src/moin/config/default.py:396 src/moin/templates/ticket/modify.html:23
 msgid "Comments"
 msgstr ""
 
-#: src/moin/config/default.py:395
+#: src/moin/config/default.py:396
 msgid "Hide comments"
 msgstr ""
 
-#: src/moin/config/default.py:396
+#: src/moin/config/default.py:397
 msgid "Transclusions"
 msgstr ""
 
-#: src/moin/config/default.py:396
+#: src/moin/config/default.py:397
 msgid "Show transclusions"
 msgstr ""
 
-#: src/moin/config/default.py:580
+#: src/moin/config/default.py:576
 msgid "To request an account, see bottom of Home page."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:162
+#: src/moin/constants/contenttypes.py:164
 msgid "This is a plain text item, there is no markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:163
+#: src/moin/constants/contenttypes.py:165
 msgid "This item can not be edited, upload a revised file."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:165
+#: src/moin/constants/contenttypes.py:167
 msgid "Use a semicolon or comma to separate cells."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:166
+#: src/moin/constants/contenttypes.py:168
 msgid "If the first row is recognized as a header, the table will be sortable."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:172
+#: src/moin/constants/contenttypes.py:175
 msgid "Click for help on Moin Wiki markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:173
+#: src/moin/constants/contenttypes.py:176
 msgid "Moinmoin 1.9 format is deprecated, convert to moin 2."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:174
+#: src/moin/constants/contenttypes.py:177
 msgid "Click for help on Media Wiki markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:175
+#: src/moin/constants/contenttypes.py:178
 msgid "Click for help on Creole Wiki markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:176
+#: src/moin/constants/contenttypes.py:179
 msgid "Click for help on Markdown Wiki markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:177
+#: src/moin/constants/contenttypes.py:180
 msgid "Click for help on reST Wiki markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:178
+#: src/moin/constants/contenttypes.py:181
 msgid "Click for help on Docbook Wiki markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:206
+#: src/moin/constants/contenttypes.py:209
 msgid "No help for unknown content type."
 msgstr ""
 
-#: src/moin/converters/_wiki_macro.py:68
+#: src/moin/converters/_wiki_macro.py:66
 msgid "Include Macro above has invalid format, missing item name"
 msgstr ""
 
-#: src/moin/converters/_wiki_macro.py:79
+#: src/moin/converters/_wiki_macro.py:77
 msgid ""
 "Include Macro above has invalid format, expected sort=ascending or "
 "descending"
 msgstr ""
 
-#: src/moin/converters/html_in.py:126
+#: src/moin/converters/everything.py:32
+msgid ""
+"This deleted item must be restored before it can be viewed or downloaded,"
+" ItemID = {itemid}"
+msgstr ""
+
+#: src/moin/converters/html_in.py:128
 msgid "Error: malformed HTML: {reason}."
 msgstr ""
 
-#: src/moin/converters/html_in.py:132
+#: src/moin/converters/html_in.py:134
 msgid "Error: malformed HTML. Try viewing source with Highlight or Modify links."
 msgstr ""
 
-#: src/moin/converters/html_in.py:266
+#: src/moin/converters/html_in.py:268
 #, python-format
 msgid "Tag '%(invalid_tag)s' is not supported; all tag contents are discarded."
 msgstr ""
 
-#: src/moin/converters/html_in.py:272
+#: src/moin/converters/html_in.py:275
 #, python-format
 msgid ""
 "Tag '%(invalid_tag)s' is not known; tag ignored but children are "
 "processed."
 msgstr ""
 
-#: src/moin/converters/html_out.py:695
+#: src/moin/converters/html_out.py:690
 msgid "Link to this heading"
 msgstr ""
 
-#: src/moin/converters/html_out.py:761
+#: src/moin/converters/html_out.py:756
 msgid "Contents"
 msgstr ""
 
-#: src/moin/converters/include.py:306
+#: src/moin/converters/include.py:302
 msgid "Access Denied, transcluded content suppressed."
 msgstr ""
 
-#: src/moin/converters/include.py:324
+#: src/moin/converters/include.py:320
 msgid "Error: no items found matching \"<<Include({0})>>\""
 msgstr ""
 
@@ -1432,17 +1441,17 @@ msgstr ""
 msgid "<<%(macro_name)s: execution failed [%(error_msg)s] (see also the log)>>"
 msgstr ""
 
-#: src/moin/converters/moinwiki_in.py:958
+#: src/moin/converters/moinwiki_in.py:976
 msgid "Error:"
 msgstr ""
 
-#: src/moin/converters/moinwiki_in.py:959
+#: src/moin/converters/moinwiki_in.py:977
 msgid "is invalid within"
 msgstr ""
 
-#: src/moin/converters/nonexistent_in.py:35
+#: src/moin/converters/nonexistent_in.py:33
 #, python-format
-msgid "%(item_name)s does not exist. Create it?"
+msgid "%(item_name)s does not exist. Create it? "
 msgstr ""
 
 #: src/moin/converters/nowiki.py:39
@@ -1460,281 +1469,285 @@ msgid ""
 "'%(parent_name)s' is missing."
 msgstr ""
 
-#: src/moin/items/__init__.py:339
+#: src/moin/items/__init__.py:344
 msgid "Preview"
 msgstr ""
 
-#: src/moin/items/__init__.py:340 src/moin/templates/index.html:306
+#: src/moin/items/__init__.py:345 src/moin/templates/index.html:306
 #: src/moin/themes/basic/templates/modify.html:91
 msgid "Cancel"
 msgstr ""
 
-#: src/moin/items/__init__.py:377 src/moin/items/__init__.py:382
+#: src/moin/items/__init__.py:382 src/moin/items/__init__.py:387
 msgid "The ACL string is invalid."
 msgstr ""
 
-#: src/moin/items/__init__.py:388
+#: src/moin/items/__init__.py:396
 msgid "Access Control List - Use 'None' for default"
 msgstr ""
 
-#: src/moin/items/__init__.py:389 src/moin/items/ticket.py:97
-#: src/moin/items/ticket.py:108 src/moin/templates/ticket/advanced.html:20
+#: src/moin/items/__init__.py:399 src/moin/items/ticket.py:97
+#: src/moin/items/ticket.py:109 src/moin/templates/ticket/advanced.html:20
 #: src/moin/templates/ticket/modify.html:52
 #: src/moin/templates/ticket/submit.html:13 src/moin/templates/tickets.html:54
 msgid "Summary"
 msgstr ""
 
-#: src/moin/items/__init__.py:389
+#: src/moin/items/__init__.py:399
 msgid "One-line summary of the item"
 msgstr ""
 
-#: src/moin/items/__init__.py:635 src/moin/items/__init__.py:637
-#: src/moin/items/__init__.py:659
+#: src/moin/items/__init__.py:645 src/moin/items/__init__.py:647
+#: src/moin/items/__init__.py:672
 #, python-format
 msgid "The item \"%(name)s\" was deleted."
 msgstr ""
 
-#: src/moin/items/__init__.py:641 src/moin/items/__init__.py:643
-#: src/moin/items/__init__.py:674
+#: src/moin/items/__init__.py:651 src/moin/items/__init__.py:654
+#: src/moin/items/__init__.py:688
 #, python-format
 msgid "The item \"%(name)s\" was renamed to \"%(new_name)s\"."
 msgstr ""
 
-#: src/moin/items/__init__.py:657
+#: src/moin/items/__init__.py:670
 #, python-format
 msgid "The subitem \"%(name)s\" was deleted."
 msgstr ""
 
-#: src/moin/items/__init__.py:689
+#: src/moin/items/__init__.py:705
 #, python-format
 msgid "An item named %s already exists in the namespace %s."
 msgstr ""
 
-#: src/moin/items/__init__.py:729 src/moin/items/__init__.py:731
-#: src/moin/items/__init__.py:743
+#: src/moin/items/__init__.py:746 src/moin/items/__init__.py:748
+#: src/moin/items/__init__.py:760
 #, python-format
 msgid "The item \"%(name)s\" was destroyed."
 msgstr ""
 
-#: src/moin/items/__init__.py:741
+#: src/moin/items/__init__.py:758
 #, python-format
 msgid "The subitem \"%(name)s\" was destroyed."
 msgstr ""
 
-#: src/moin/items/__init__.py:747 src/moin/items/__init__.py:749
+#: src/moin/items/__init__.py:764 src/moin/items/__init__.py:767
 #, python-format
 msgid "Error: The subitem \"%(name)s\" was not destroyed, permission denied."
 msgstr ""
 
-#: src/moin/items/__init__.py:753
+#: src/moin/items/__init__.py:772
 #, python-format
 msgid "Rev Number %(rev_number)s of the item \"%(name)s\" was destroyed."
 msgstr ""
 
-#: src/moin/items/__init__.py:1147
+#: src/moin/items/__init__.py:1167
 msgid "Wiki item"
 msgstr ""
 
-#: src/moin/items/__init__.py:1227
+#: src/moin/items/__init__.py:1228
+msgid "Alert wiki admin that help items are not loaded"
+msgstr ""
+
+#: src/moin/items/__init__.py:1251
 msgid "You do not have permission to create the item named \"{name}\"."
 msgstr ""
 
-#: src/moin/items/__init__.py:1332
+#: src/moin/items/__init__.py:1357
 msgid "Nothing changed, nothing saved."
 msgstr ""
 
-#: src/moin/items/__init__.py:1346
+#: src/moin/items/__init__.py:1372
 msgid "CONFLICT "
 msgstr ""
 
-#: src/moin/items/__init__.py:1347
+#: src/moin/items/__init__.py:1373
 msgid "An edit conflict has occurred, edit this item again to resolve conflicts."
 msgstr ""
 
-#: src/moin/items/__init__.py:1387
+#: src/moin/items/__init__.py:1416
 #, python-format
 msgid ""
 "You may recover your draft saved %(number)s %(interval)s ago by clicking "
 "the 'Load Draft' button."
 msgstr ""
 
-#: src/moin/items/__init__.py:1389
+#: src/moin/items/__init__.py:1420
 #, python-format
 msgid ""
 "Your draft saved %(number)s %(interval)s ago is outdated, click 'Cancel' "
 "to discard or 'Load Draft', then 'Save' to merge conflicting updates."
 msgstr ""
 
-#: src/moin/items/__init__.py:1426
+#: src/moin/items/__init__.py:1460
 msgid "User profile"
 msgstr ""
 
-#: src/moin/items/__init__.py:1427
+#: src/moin/items/__init__.py:1461
 msgid "User profile item (not implemented yet!)"
 msgstr ""
 
-#: src/moin/items/blog.py:33
+#: src/moin/items/blog.py:32
 msgid "Supertags (Categories)"
 msgstr ""
 
-#: src/moin/items/blog.py:34
+#: src/moin/items/blog.py:33
 msgid "Ordered comma separated list of tags"
 msgstr ""
 
-#: src/moin/items/blog.py:38
+#: src/moin/items/blog.py:37
 msgid "Title (required)"
 msgstr ""
 
-#: src/moin/items/blog.py:39
+#: src/moin/items/blog.py:38
 msgid "One-line title of the blog entry"
 msgstr ""
 
-#: src/moin/items/blog.py:40
+#: src/moin/items/blog.py:39
 msgid "Publication time (UTC)"
 msgstr ""
 
-#: src/moin/items/blog.py:46
+#: src/moin/items/blog.py:45
 msgid "Blog"
 msgstr ""
 
-#: src/moin/items/blog.py:47
+#: src/moin/items/blog.py:46
 msgid "Blog item"
 msgstr ""
 
-#: src/moin/items/blog.py:101
+#: src/moin/items/blog.py:99
 msgid "Blog entry"
 msgstr ""
 
-#: src/moin/items/blog.py:102
+#: src/moin/items/blog.py:100
 msgid "Blog entry item"
 msgstr ""
 
-#: src/moin/items/content.py:337 src/moin/items/ticket.py:135
+#: src/moin/items/content.py:338 src/moin/items/ticket.py:137
 msgid "Upload file:"
 msgstr ""
 
-#: src/moin/items/content.py:355
+#: src/moin/items/content.py:356
 msgid ""
 "The items have the same data hash code (that means they very likely have "
 "the same data)."
 msgstr ""
 
-#: src/moin/items/content.py:357
+#: src/moin/items/content.py:358
 msgid "The items have different data."
 msgstr ""
 
-#: src/moin/items/content.py:369
+#: src/moin/items/content.py:370
 #, python-format
 msgid "Impossible to convert the data to the contenttype: %(contenttype)s"
 msgstr ""
 
-#: src/moin/items/content.py:822
+#: src/moin/items/content.py:821
 msgid "Type your text here"
 msgstr ""
 
-#: src/moin/items/content.py:1111
+#: src/moin/items/content.py:1109
 #, python-format
 msgid "Edit drawing %(filename)s (opens in new window)"
 msgstr ""
 
-#: src/moin/items/content.py:1115
+#: src/moin/items/content.py:1113
 #, python-format
 msgid "Clickable drawing: %(filename)s"
 msgstr ""
 
-#: src/moin/items/ticket.py:97
+#: src/moin/items/ticket.py:98
 msgid "Find Tickets"
 msgstr ""
 
-#: src/moin/items/ticket.py:98 src/moin/items/ticket.py:109
+#: src/moin/items/ticket.py:99 src/moin/items/ticket.py:111
 #: src/moin/templates/ticket/advanced.html:24
 #: src/moin/templates/tickets.html:58
 msgid "Effort"
 msgstr ""
 
-#: src/moin/items/ticket.py:99 src/moin/items/ticket.py:110
+#: src/moin/items/ticket.py:100 src/moin/items/ticket.py:112
 #: src/moin/templates/ticket/advanced.html:25
 #: src/moin/templates/tickets.html:59
 msgid "Difficulty"
 msgstr ""
 
-#: src/moin/items/ticket.py:100 src/moin/items/ticket.py:111
+#: src/moin/items/ticket.py:101 src/moin/items/ticket.py:113
 #: src/moin/templates/ticket/advanced.html:26
 #: src/moin/templates/tickets.html:60
 msgid "Severity"
 msgstr ""
 
-#: src/moin/items/ticket.py:101 src/moin/items/ticket.py:112
+#: src/moin/items/ticket.py:102 src/moin/items/ticket.py:114
 #: src/moin/templates/ticket/advanced.html:27
 #: src/moin/templates/tickets.html:61
 msgid "Priority"
 msgstr ""
 
-#: src/moin/items/ticket.py:103 src/moin/items/ticket.py:114
+#: src/moin/items/ticket.py:104 src/moin/items/ticket.py:116
 msgid "Assigned To"
 msgstr ""
 
-#: src/moin/items/ticket.py:104
+#: src/moin/items/ticket.py:105
 msgid "Author"
 msgstr ""
 
-#: src/moin/items/ticket.py:108
+#: src/moin/items/ticket.py:110
 msgid "One-line summary"
 msgstr ""
 
-#: src/moin/items/ticket.py:115
+#: src/moin/items/ticket.py:117
 msgid "Superseded By"
 msgstr ""
 
-#: src/moin/items/ticket.py:116
+#: src/moin/items/ticket.py:118
 msgid "Depends On"
 msgstr ""
 
-#: src/moin/items/ticket.py:120
+#: src/moin/items/ticket.py:122
 msgid "Supersedes"
 msgstr ""
 
-#: src/moin/items/ticket.py:121
+#: src/moin/items/ticket.py:123
 msgid "Required By"
 msgstr ""
 
-#: src/moin/items/ticket.py:122
+#: src/moin/items/ticket.py:124
 msgid "Subscribers"
 msgstr ""
 
-#: src/moin/items/ticket.py:134
+#: src/moin/items/ticket.py:136
 msgid "Message"
 msgstr ""
 
-#: src/moin/items/ticket.py:146
+#: src/moin/items/ticket.py:148
 msgid "Submit ticket"
 msgstr ""
 
-#: src/moin/items/ticket.py:166
+#: src/moin/items/ticket.py:168
 msgid "Update ticket"
 msgstr ""
 
-#: src/moin/items/ticket.py:167 src/moin/templates/ticket/modify.html:39
+#: src/moin/items/ticket.py:169 src/moin/templates/ticket/modify.html:39
 msgid "Update & reopen ticket"
 msgstr ""
 
-#: src/moin/items/ticket.py:168 src/moin/templates/ticket/modify.html:41
+#: src/moin/items/ticket.py:170 src/moin/templates/ticket/modify.html:41
 msgid "Update & close ticket"
 msgstr ""
 
-#: src/moin/items/ticket.py:189
+#: src/moin/items/ticket.py:191
 msgid "{key} changed from {original} to {new}"
 msgstr ""
 
-#: src/moin/items/ticket.py:214
+#: src/moin/items/ticket.py:216
 msgid "{author} wrote on {timestamp}:"
 msgstr ""
 
-#: src/moin/items/ticket.py:344
+#: src/moin/items/ticket.py:346
 msgid "Ticket"
 msgstr ""
 
-#: src/moin/items/ticket.py:345
+#: src/moin/items/ticket.py:347
 msgid "Ticket item"
 msgstr ""
 
@@ -1762,7 +1775,7 @@ msgstr ""
 msgid "File Patterns"
 msgstr ""
 
-#: src/moin/macros/Icon.py:27 src/moin/macros/ShowIcons.py:35
+#: src/moin/macros/Icon.py:27
 msgid "Icon not rendered, verify name is valid"
 msgstr ""
 
@@ -1773,110 +1786,109 @@ msgid ""
 "(arguments, if more than one, must be comma-separated)."
 msgstr ""
 
-#: src/moin/macros/ItemList.py:95
+#: src/moin/macros/ItemList.py:96
 msgid "ItemList macro: The key's value must be bracketed by matching quotes."
 msgstr ""
 
-#: src/moin/macros/ItemList.py:110
+#: src/moin/macros/ItemList.py:111
 #, python-format
 msgid "ItemList macro: The value must be \"True\" or \"False\". (got \"%s\")"
 msgstr ""
 
-#: src/moin/macros/ItemList.py:116
+#: src/moin/macros/ItemList.py:117
 #, python-format
 msgid "ItemList macro: Unrecognized key \"%s\"."
 msgstr ""
 
 #: src/moin/macros/ItemList.py:128
-#, python-format
-msgid "ItemList macro: The specified item \"%s\" does not exist."
+msgid "Item does not exist or read access blocked by ACLs: {0}"
 msgstr ""
 
-#: src/moin/macros/ItemList.py:136
+#: src/moin/macros/ItemList.py:139
 msgid "ItemList macro: Error in regex {0!r}: {1}"
 msgstr ""
 
-#: src/moin/macros/ItemList.py:144
+#: src/moin/macros/ItemList.py:147
 msgid "<ItemList macro: No matching items were found.>"
 msgstr ""
 
-#: src/moin/macros/MailTo.py:32
+#: src/moin/macros/MailTo.py:31
 msgid "MailTo: invalid format, try: <<MailTo(user AT example DOT org, write me)>>"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:208
+#: src/moin/macros/MonthCalendar.py:209
 msgid "January"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:208
+#: src/moin/macros/MonthCalendar.py:209
 msgid "February"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:208
+#: src/moin/macros/MonthCalendar.py:209
 msgid "March"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:208
+#: src/moin/macros/MonthCalendar.py:209
 msgid "April"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:209
+#: src/moin/macros/MonthCalendar.py:210
 msgid "May"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:209
+#: src/moin/macros/MonthCalendar.py:210
 msgid "June"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:209
+#: src/moin/macros/MonthCalendar.py:210
 msgid "July"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:209
+#: src/moin/macros/MonthCalendar.py:210
 msgid "August"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:210
+#: src/moin/macros/MonthCalendar.py:211
 msgid "September"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:210
+#: src/moin/macros/MonthCalendar.py:211
 msgid "October"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:210
+#: src/moin/macros/MonthCalendar.py:211
 msgid "November"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:210
+#: src/moin/macros/MonthCalendar.py:211
 msgid "December"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Mon"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Tue"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Wed"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Thu"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Fri"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Sat"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Sun"
 msgstr ""
 
@@ -1888,31 +1900,31 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: src/moin/macros/_base.py:119
+#: src/moin/macros/_base.py:123
 msgid "\"ItemTitle\" is not implemented yet."
 msgstr ""
 
-#: src/moin/macros/_base.py:121
+#: src/moin/macros/_base.py:125
 #, python-format
 msgid "Unrecognized display value \"%s\"."
 msgstr ""
 
-#: src/moin/mail/sendmail.py:55
+#: src/moin/mail/sendmail.py:53
 msgid ""
 "Contact administrator: cannot send password recovery e-mail because mail "
 "configuration is incomplete."
 msgstr ""
 
-#: src/moin/mail/sendmail.py:63
+#: src/moin/mail/sendmail.py:61
 msgid "No recipients, nothing to do"
 msgstr ""
 
-#: src/moin/mail/sendmail.py:121
+#: src/moin/mail/sendmail.py:119
 #, python-format
 msgid "Connection to mailserver '%(server)s' failed: %(reason)s"
 msgstr ""
 
-#: src/moin/mail/sendmail.py:127
+#: src/moin/mail/sendmail.py:125
 msgid "Mail sent successfully"
 msgstr ""
 
@@ -1923,6 +1935,14 @@ msgstr ""
 #: src/moin/search/__init__.py:31 src/moin/templates/search.html:16
 #: src/moin/templates/search.html:21
 msgid "Search"
+msgstr ""
+
+#: src/moin/storage/middleware/indexing.py:1215
+msgid "Error: metadata validation failed, invalid field value(s) = {0}"
+msgstr ""
+
+#: src/moin/storage/middleware/indexing.py:1232
+msgid "Error: nothing changed. Data unicode validation failed."
 msgstr ""
 
 #: src/moin/templates/404.html:12
@@ -1959,62 +1979,45 @@ msgstr ""
 msgid "Common words omitted from query:"
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:48
-msgid "Input suggestions : "
-msgstr ""
-
-#: src/moin/templates/ajaxsearch.html:53
-msgid "Name term suggestions : "
-msgstr ""
-
-#: src/moin/templates/ajaxsearch.html:56
-msgid "Content term suggestions : "
-msgstr ""
-
-#: src/moin/templates/ajaxsearch.html:63
+#: src/moin/templates/ajaxsearch.html:50
 #, python-format
 msgid ""
 "%(found)d items found, %(items_filtered)d more items filtered by content "
 "types."
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:65
+#: src/moin/templates/ajaxsearch.html:52
 #, python-format
 msgid "%(result_len)d items found."
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:95
+#: src/moin/templates/ajaxsearch.html:82
 msgid "MATCHED TERMS:"
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:102
+#: src/moin/templates/ajaxsearch.html:89
 #, python-format
 msgid ""
 "REVISION: %(revid)s, SIZE: %(size)s, MODIFIED: %(mtime)s, CONTENT TYPE: "
 "%(type)s, SCORE: %(score)s"
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:107
+#: src/moin/templates/ajaxsearch.html:94
 #, python-format
 msgid "COMMENT: %(content)s"
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:110
-#, python-format
-msgid "SUMMARY: %(content)s"
-msgstr ""
-
-#: src/moin/templates/ajaxsearch.html:113
+#: src/moin/templates/ajaxsearch.html:97
 #, python-format
 msgid "TAGS: %(content)s"
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:116
+#: src/moin/templates/ajaxsearch.html:100
 #, python-format
 msgid "CONTENT: %(content)s"
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:125
+#: src/moin/templates/ajaxsearch.html:109
 #, python-format
 msgid "%(count)d items are not shown because read permission was denied."
 msgstr ""
@@ -2408,13 +2411,13 @@ msgstr ""
 
 #: src/moin/templates/itemviews.html:86 src/moin/templates/ticket/base.html:26
 #: src/moin/templates/ticket/ticket_macros.html:101
-#: src/moin/themes/__init__.py:232
+#: src/moin/themes/__init__.py:233
 msgid "Remove Link"
 msgstr ""
 
 #: src/moin/templates/itemviews.html:88 src/moin/templates/ticket/base.html:28
 #: src/moin/templates/ticket/ticket_macros.html:103
-#: src/moin/themes/__init__.py:230
+#: src/moin/themes/__init__.py:231
 msgid "Add Link"
 msgstr ""
 
@@ -3019,7 +3022,7 @@ msgstr ""
 msgid "You are not allowed to access this resource."
 msgstr ""
 
-#: src/moin/themes/__init__.py:592
+#: src/moin/themes/__init__.py:593
 msgid "anonymous"
 msgstr ""
 
@@ -3039,106 +3042,104 @@ msgstr ""
 msgid "Item Actions"
 msgstr ""
 
-#: src/moin/utils/edit_locking.py:252
+#: src/moin/utils/edit_locking.py:267
 #, python-format
 msgid ""
 "Edit lock for %(user_name)s timed out %(number)s %(interval)s ago, click "
-"Cancel to yield more time,\n"
-"                             clicking Save may require %(user_name)s to "
-"resolve conflicting edits."
+"'Cancel' to yield more time, clicking 'Save' may require %(user_name)s to"
+" resolve conflicting edits."
 msgstr ""
 
-#: src/moin/utils/edit_locking.py:260
+#: src/moin/utils/edit_locking.py:276
 #, python-format
 msgid ""
 "Item '%(item_name)s' is locked by %(user_name)s. Try again in %(number)s "
 "%(interval)s."
 msgstr ""
 
-#: src/moin/utils/edit_locking.py:272
+#: src/moin/utils/edit_locking.py:288
 #, python-format
 msgid ""
 "Someone else updated '%(item_name)s' after your edit lock timed out. If "
-"you click 'Save',\n"
-"                                 conflicting changes must be manually "
-"merged. Click 'Cancel' to discard changes."
+"you click 'Save', conflicting changes must be manually merged. Click "
+"'Cancel' to discard changes."
 msgstr ""
 
-#: src/moin/utils/edit_locking.py:303
+#: src/moin/utils/edit_locking.py:322
 #, python-format
 msgid ""
 "Item '%(item_name)s' is locked by %(user_name)s. Edit lock error, check "
 "Item History to verify no changes were lost."
 msgstr ""
 
-#: src/moin/utils/notifications.py:49
+#: src/moin/utils/notifications.py:47
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been created by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:50
+#: src/moin/utils/notifications.py:48
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been modified by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:51
+#: src/moin/utils/notifications.py:49
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been renamed by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:52
+#: src/moin/utils/notifications.py:50
 #, python-format
 msgid "The '%(fqname)s' item on '%(wiki_name)s' has been copied by %(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:53
+#: src/moin/utils/notifications.py:51
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been converted by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:54
+#: src/moin/utils/notifications.py:52
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been reverted by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:55
+#: src/moin/utils/notifications.py:53
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been deleted by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:56
+#: src/moin/utils/notifications.py:54
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has one revision destroyed by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:57
+#: src/moin/utils/notifications.py:55
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been destroyed by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:205
+#: src/moin/utils/notifications.py:210
 msgid ""
 "An error has occurred, the current or prior revision of this item may be "
 "corrupt."
 msgstr ""
 
-#: src/moin/utils/notifications.py:212
+#: src/moin/utils/notifications.py:217
 #, python-format
 msgid "[%(moin_name)s] Update of \"%(fqname)s\" by %(user_name)s"
 msgstr ""
@@ -3211,31 +3212,31 @@ msgstr ""
 msgid "No argument named \"%(name)s\""
 msgstr ""
 
-#: src/moin/utils/show_time.py:25
+#: src/moin/utils/show_time.py:23
 msgid "seconds"
 msgstr ""
 
-#: src/moin/utils/show_time.py:27
+#: src/moin/utils/show_time.py:25
 msgid "minutes"
 msgstr ""
 
-#: src/moin/utils/show_time.py:29
+#: src/moin/utils/show_time.py:27
 msgid "hours"
 msgstr ""
 
-#: src/moin/utils/show_time.py:31
+#: src/moin/utils/show_time.py:29
 msgid "days"
 msgstr ""
 
-#: src/moin/utils/show_time.py:33
+#: src/moin/utils/show_time.py:31
 msgid "weeks"
 msgstr ""
 
-#: src/moin/utils/show_time.py:35
+#: src/moin/utils/show_time.py:33
 msgid "months"
 msgstr ""
 
-#: src/moin/utils/show_time.py:36
+#: src/moin/utils/show_time.py:34
 msgid "years"
 msgstr ""
 

--- a/src/moin/translations/de/LC_MESSAGES/messages.po
+++ b/src/moin/translations/de/LC_MESSAGES/messages.po
@@ -204,7 +204,7 @@ msgstr "Neuen Benutzer anlegen"
 
 #: src/moin/apps/admin/views.py:114
 msgid "User already exists"
-msgstr "Benutzer existiert bereits.
+msgstr "Benutzer existiert bereits"
 
 #: src/moin/apps/admin/views.py:122
 #, python-format
@@ -240,7 +240,7 @@ msgstr "{0} \"{1}\" Status geändert zu \"{2}\""
 
 #: src/moin/apps/admin/views.py:203
 msgid "modifying {0}.{1} failed"
-msgstr "Ändern von {0}.{1} schlug fehl.""
+msgstr "Ändern von {0}.{1} schlug fehl."
 
 #: src/moin/apps/admin/views.py:221
 msgid "{0} has been sent a password recovery email."
@@ -3104,7 +3104,7 @@ msgid ""
 "'Cancel' to yield more time, clicking 'Save' may require %(user_name)s to"
 " resolve conflicting edits."
 msgstr ""
-"Die Sperre für %(user_name)s ist vor %(number)s %(interval) abgelaufen, klicken "
+"Die Sperre für %(user_name)s ist vor %(number)s %(interval)s abgelaufen, klicken "
 "Sie auf 'Abbrechen', um mehr Zeit zu erhalten. Wenn Sie auf 'Speichern' klicken, "
 "muss %(user_name)s Konflikte zwischen den Bearbeitungen beheben."
 

--- a/src/moin/translations/de/LC_MESSAGES/messages.po
+++ b/src/moin/translations/de/LC_MESSAGES/messages.po
@@ -8,129 +8,129 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MoinMoin 2.0\n"
 "Report-Msgid-Bugs-To: German <moin-user@python.org>\n"
-"POT-Creation-Date: 2022-02-26 21:10+0000\n"
+"POT-Creation-Date: 2023-04-25 16:06+0100\n"
 "PO-Revision-Date: 2018-09-15 23:37+0100\n"
 "Last-Translator: \n"
 "Language: de\n"
 "Language-Team: German <moin-user@python.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.12.1\n"
 
-#: src/moin/forms.py:94 src/moin/forms.py:168
+#: src/moin/forms.py:100 src/moin/forms.py:179
 msgid "No namespace field in the meta."
 msgstr "Kein Namespace-Feld in den Metadaten."
 
-#: src/moin/forms.py:98
+#: src/moin/forms.py:104
 msgid "The names in the name list must be unique."
 msgstr "Kein Name darf mehrfach in der Namensliste enthalten sein."
 
-#: src/moin/forms.py:105
+#: src/moin/forms.py:112
 #, python-format
-msgid "Item names (%(invalid_names)s) must not start with '@' or '+'."
+msgid "Item names (%(invalid_names)s) must not start with '@' or '+'"
 msgstr "Item-Namen (%(invalid_names)s) dürfen nicht mit '@' oder '+' anfangen."
 
-#: src/moin/forms.py:112
+#: src/moin/forms.py:121
 #, python-format
 msgid ""
 "Item name (%(invalid_names)s) must not contain ',' characters. Create "
 "item with 1 name, use rename to create multiple names."
 msgstr ""
 
-#: src/moin/forms.py:120
+#: src/moin/forms.py:130
 #, python-format
 msgid "Item names (%(invalid_names)s) must not match with existing namespaces."
 msgstr "Item-Namen (%(invalid_names)s) dürfen nicht mit Namespaces übereinstimmen"
 
-#: src/moin/forms.py:131
+#: src/moin/forms.py:141
 #, python-format
 msgid "Item(s) named %(duplicate_names)s already exist."
 msgstr "Items mit Namen %(duplicate_names)s existieren bereits."
 
-#: src/moin/forms.py:156
+#: src/moin/forms.py:167
 msgid "Invalid JSON."
 msgstr "Ungültiges JSON"
 
-#: src/moin/forms.py:157
+#: src/moin/forms.py:168
 msgid "Itemid not a proper UUID"
 msgstr "Itemid ist keine richtige UUID"
 
-#: src/moin/forms.py:162
+#: src/moin/forms.py:173
 msgid "No ITEMID field"
 msgstr "Kein ITEMID-Feld"
 
-#: src/moin/forms.py:172
+#: src/moin/forms.py:183
 #, python-format
 msgid "%(_namespace)s is not a valid namespace."
 msgstr "%(_namespace)s ist kein gültiger Namespace."
 
-#: src/moin/forms.py:193
+#: src/moin/forms.py:204
 msgid "E-Mail"
 msgstr "E-Mail"
 
-#: src/moin/forms.py:194
+#: src/moin/forms.py:205
 msgid "E-Mail address"
 msgstr "E-Mail-Adresse"
 
-#: src/moin/forms.py:196
+#: src/moin/forms.py:207
 msgid "Your E-Mail address"
 msgstr "Ihre E-Mail-Adresse"
 
-#: src/moin/forms.py:198
+#: src/moin/forms.py:209
 msgid "Password"
 msgstr "Passwort"
 
-#: src/moin/forms.py:259
+#: src/moin/forms.py:270
 msgid "This item doesn't exist."
 msgstr "Dieses Item existiert nicht."
 
-#: src/moin/forms.py:261
+#: src/moin/forms.py:272
 msgid "This item name is corrupt, delete and recreate."
 msgstr "Der Name dieses Items ist beschädigt. Lösch und erstell ihn neu."
 
-#: src/moin/config/default.py:351 src/moin/forms.py:271
+#: src/moin/config/default.py:352 src/moin/forms.py:282
 #: src/moin/templates/all.html:6 src/moin/templates/ticket/advanced.html:28
 #: src/moin/templates/tickets.html:20 src/moin/templates/tickets.html:62
 msgid "Tags"
 msgstr "Schlagworte"
 
-#: src/moin/forms.py:274
+#: src/moin/forms.py:285
 msgid "Names"
 msgstr "Namen"
 
 #: src/moin/apps/admin/templates/admin/userbrowser.html:18
-#: src/moin/forms.py:278 src/moin/templates/usersettings_forms.html:149
+#: src/moin/forms.py:289 src/moin/templates/usersettings_forms.html:149
 msgid "Subscriptions"
 msgstr "Abonnements"
 
-#: src/moin/forms.py:282 src/moin/templates/usersettings_forms.html:133
+#: src/moin/forms.py:293 src/moin/templates/usersettings_forms.html:133
 #: src/moin/themes/basic/templates/layout.html:105
 msgid "Quick Links"
 msgstr "Quick Links"
 
-#: src/moin/forms.py:284
+#: src/moin/forms.py:295
 msgid "Search Query"
 msgstr "Such-Anfrage"
 
-#: src/moin/forms.py:334
+#: src/moin/forms.py:345
 msgid "YYYY-MM-DD HH:MM:SS (example: 2013-12-31 23:59:59)"
 msgstr "JJJJ-MM-TT HH:MM:SS (z.B.: 2013-12-31 23:59:59)"
 
-#: src/moin/forms.py:335
+#: src/moin/forms.py:346
 msgid "Please use the following format: YYYY-MM-DD HH:MM:SS"
 msgstr "Bitte benutzen Sie folgendes Format: JJJJ-MM-TT HH:MM:SS"
 
-#: src/moin/forms.py:353
+#: src/moin/forms.py:364
 msgid "Invalid Reference."
 msgstr "Ungültige Referenz."
 
-#: src/moin/forms.py:361
+#: src/moin/forms.py:372
 msgid "(None)"
 msgstr "(Nichts)"
 
-#: src/moin/user.py:68
+#: src/moin/user.py:72
 #, python-format
 msgid ""
 "Invalid user name '%(name)s'.\n"
@@ -143,16 +143,16 @@ msgstr ""
 "vorkommen dürfen. Der Benutzername darf auch kein existierender "
 "Gruppenname sein."
 
-#: src/moin/user.py:74
+#: src/moin/user.py:78
 msgid "This user name already belongs to somebody else."
 msgstr "Dieser Benutzername ist bereits vergeben."
 
-#: src/moin/user.py:83
+#: src/moin/user.py:87
 #, python-format
 msgid "Password not acceptable: %(msg)s"
 msgstr "Dieses Passwort ist nicht ausreichend: %(msg)s"
 
-#: src/moin/user.py:89
+#: src/moin/user.py:93
 msgid ""
 "Please provide your email address. If you lose your login information, "
 "you can get it by email."
@@ -160,30 +160,30 @@ msgstr ""
 "Bitte geben Sie Ihre E-Mail-Adresse an. Wenn Sie Ihre Logindaten "
 "vergessen, können Sie Ihnen per E-Mail zugesendet werden."
 
-#: src/moin/apps/admin/views.py:119 src/moin/user.py:95
+#: src/moin/apps/admin/views.py:119 src/moin/user.py:99
 msgid "This email already belongs to somebody else."
 msgstr "Diese E-Mail-Adresse wird bereits verwendet."
 
-#: src/moin/user.py:808
+#: src/moin/user.py:819
 #, python-format
 msgid "[%(sitename)s] Your wiki password recovery link"
 msgstr "[%(sitename)s] Passwort vergessen"
 
-#: src/moin/user.py:824
+#: src/moin/user.py:835
 #, python-format
 msgid "[%(sitename)s] Please verify your email address"
 msgstr "[%(sitename)s] Bitte überprüfen Sie Ihre E-Mail-Addresse"
 
-#: src/moin/apps/admin/views.py:52 src/moin/config/default.py:353
+#: src/moin/apps/admin/views.py:52 src/moin/config/default.py:354
 msgid "Admin"
 msgstr "Admin"
 
-#: src/moin/apps/admin/views.py:58 src/moin/config/default.py:352
+#: src/moin/apps/admin/views.py:58 src/moin/config/default.py:353
 msgid "User"
 msgstr "Benutzer"
 
-#: src/moin/apps/admin/views.py:80 src/moin/apps/frontend/views.py:1835
-#: src/moin/apps/frontend/views.py:2082
+#: src/moin/apps/admin/views.py:80 src/moin/apps/frontend/views.py:1850
+#: src/moin/apps/frontend/views.py:2099
 msgid "Username"
 msgstr "Benutzername"
 
@@ -191,8 +191,8 @@ msgstr "Benutzername"
 msgid "User Name"
 msgstr "Benutzername"
 
-#: src/moin/apps/admin/views.py:82 src/moin/apps/frontend/views.py:1839
-#: src/moin/apps/frontend/views.py:1865
+#: src/moin/apps/admin/views.py:82 src/moin/apps/frontend/views.py:1856
+#: src/moin/apps/frontend/views.py:1882
 msgid "Register"
 msgstr "Registrieren"
 
@@ -203,8 +203,8 @@ msgid "Register New User"
 msgstr "Neuen Benutzer anlegen"
 
 #: src/moin/apps/admin/views.py:114
-msgid "User already exists."
-msgstr "Benutzer existiert bereits."
+msgid "User already exists"
+msgstr "Benutzer existiert bereits.
 
 #: src/moin/apps/admin/views.py:122
 #, python-format
@@ -214,8 +214,9 @@ msgstr "Der Account für %(username)s wurde erstellt."
 #: src/moin/apps/admin/views.py:131
 #, python-format
 msgid "%(username)s has been sent a password recovery email."
-msgstr "Eine E-Mail zur Wiederherstellung des Passwortes wurde an " 
-"%(username)s gesendet."
+msgstr ""
+"Eine E-Mail zur Wiederherstellung des Passwortes wurde an%(username)s "
+"gesendet."
 
 #: src/moin/apps/admin/views.py:133
 #, python-format
@@ -238,14 +239,12 @@ msgid "{0} \"{1}\" status changed to \"{2}\""
 msgstr "{0} \"{1}\" Status geändert zu \"{2}\""
 
 #: src/moin/apps/admin/views.py:203
-msgid "modifying {0}.{1} failed."
-msgstr "Modifizieren von {0}.{1} schlug fehl."
+msgid "modifying {0}.{1} failed"
+msgstr "Ändern von {0}.{1} schlug fehl.""
 
 #: src/moin/apps/admin/views.py:221
 msgid "{0} has been sent a password recovery email."
-msgstr ""
-"Eine E-Mail zur Wiederherstellung des Passwortes wurde an" 
-"{0} gesendet."
+msgstr "Eine E-Mail zur Wiederherstellung des Passwortes wurde an{0} gesendet."
 
 #: src/moin/apps/admin/views.py:223
 msgid "{0} is an invalid user, no email has been sent."
@@ -253,9 +252,7 @@ msgstr "{0} existiert nicht. Es wurde keine E-Mail versendet."
 
 #: src/moin/apps/admin/views.py:225
 msgid "No user name provided, no email sent."
-msgstr ""
-"Es wurde kein Benutzername eingegeben."
-"Daher wurde keine E-Mail versendet."
+msgstr "Es wurde kein Benutzername eingegeben. Daher wurde keine E-Mail versendet."
 
 #: src/moin/apps/admin/templates/admin/index.html:10
 #: src/moin/apps/admin/templates/admin/wikiconfig.html:50
@@ -303,7 +300,7 @@ msgstr "URL"
 msgid "Interwiki Names"
 msgstr "InterWiki-Namen"
 
-#: src/moin/apps/admin/views.py:362 src/moin/converters/archive_in.py:63
+#: src/moin/apps/admin/views.py:362 src/moin/converters/archive_in.py:66
 #: src/moin/templates/history.html:51 src/moin/templates/mychanges.html:22
 #: src/moin/templates/utils.html:380
 msgid "Size"
@@ -313,48 +310,48 @@ msgstr "Größe"
 msgid "Item name"
 msgstr "Item-Name"
 
-#: src/moin/apps/admin/views.py:371
+#: src/moin/apps/admin/views.py:372
 msgid "Item Sizes"
 msgstr "Item-Größen"
 
-#: src/moin/apps/admin/views.py:385 src/moin/apps/admin/views.py:386
+#: src/moin/apps/admin/views.py:386 src/moin/apps/admin/views.py:387
 msgid "Trashed Items"
 msgstr "Gelöschte Items"
 
 #: src/moin/apps/admin/templates/admin/user_acl_report.html:16
 #: src/moin/apps/admin/templates/admin/userbrowser.html:50
-#: src/moin/apps/admin/views.py:425
+#: src/moin/apps/admin/views.py:427
 msgid "User ACL Report"
 msgstr "Benutzer-ACL-Report"
 
 #: src/moin/apps/admin/templates/admin/groupbrowser.html:4
 #: src/moin/apps/admin/templates/admin/index.html:7
 #: src/moin/apps/admin/templates/admin/userbrowser.html:17
-#: src/moin/apps/admin/views.py:449
+#: src/moin/apps/admin/views.py:451
 msgid "Groups"
 msgstr "Gruppen"
 
-#: src/moin/apps/admin/views.py:491
+#: src/moin/apps/admin/views.py:492
 msgid "Item ACL Report"
 msgstr "Item-ACL-Report"
 
 #: src/moin/apps/admin/templates/admin/group_acl_report.html:16
 #: src/moin/apps/admin/templates/admin/groupbrowser.html:11
-#: src/moin/apps/admin/views.py:525
+#: src/moin/apps/admin/views.py:526
 msgid "Group ACL Report"
 msgstr "Gruppen-ACL-Report"
 
-#: src/moin/apps/admin/views.py:550
+#: src/moin/apps/admin/views.py:551
 #, python-format
 msgid "Failed! Not authorized.<br>Item: %(item_name)s<br>ACL: %(acl_rule)s"
 msgstr "Gescheitert! Nicht berechtigt.<br>Item: %(item_name)s<br>ACL: %(acl_rule)s"
 
-#: src/moin/apps/admin/views.py:552
+#: src/moin/apps/admin/views.py:554
 #, python-format
 msgid "Success! ACL saved.<br>Item: %(item_name)s<br>ACL: %(acl_rule)s"
 msgstr "Erfolg! ACL gespeichert.<br>Item: %(item_name)s<br>ACL: %(acl_rule)s"
 
-#: src/moin/apps/admin/views.py:554
+#: src/moin/apps/admin/views.py:557
 #, python-format
 msgid "Nothing changed, invalid ACL.<br>Item: %(item_name)s<br>ACL: %(acl_rule)s"
 msgstr "Keine Änderung, ungültige ACL.<br>Item: %(item_name)s<br>ACL: %(acl_rule)s"
@@ -448,14 +445,14 @@ msgid "Number items:"
 msgstr "Anzahl Items"
 
 #: src/moin/apps/admin/templates/admin/item_acl_report.html:19
-#: src/moin/items/__init__.py:388
+#: src/moin/items/__init__.py:395
 msgid "ACL"
 msgstr "ACL"
 
 #: src/moin/apps/admin/templates/admin/item_acl_report.html:31
-#: src/moin/apps/frontend/views.py:2187 src/moin/apps/frontend/views.py:2197
-#: src/moin/apps/frontend/views.py:2208 src/moin/apps/frontend/views.py:2251
-#: src/moin/apps/frontend/views.py:2277 src/moin/apps/frontend/views.py:2289
+#: src/moin/apps/frontend/views.py:2198 src/moin/apps/frontend/views.py:2209
+#: src/moin/apps/frontend/views.py:2220 src/moin/apps/frontend/views.py:2263
+#: src/moin/apps/frontend/views.py:2290 src/moin/apps/frontend/views.py:2302
 msgid "Save"
 msgstr "Speichern"
 
@@ -469,7 +466,7 @@ msgid "Rev."
 msgstr "Rev."
 
 #: src/moin/apps/admin/templates/admin/trash.html:14
-#: src/moin/converters/archive_in.py:63 src/moin/templates/history.html:50
+#: src/moin/converters/archive_in.py:66 src/moin/templates/history.html:50
 #: src/moin/templates/mychanges.html:21
 msgid "Timestamp"
 msgstr "Zeit"
@@ -480,7 +477,7 @@ msgid "Editor"
 msgstr "Autor"
 
 #: src/moin/apps/admin/templates/admin/trash.html:16
-#: src/moin/apps/frontend/views.py:690 src/moin/items/__init__.py:337
+#: src/moin/apps/frontend/views.py:682 src/moin/items/__init__.py:340
 #: src/moin/templates/mail/notification_main.html:24
 #: src/moin/templates/utils.html:396
 msgid "Comment"
@@ -493,22 +490,22 @@ msgid "Actions"
 msgstr "Aktionen"
 
 #: src/moin/apps/admin/templates/admin/trash.html:29
-#: src/moin/config/default.py:379
+#: src/moin/config/default.py:380
 msgid "Show"
 msgstr "Anzeigen"
 
 #: src/moin/apps/admin/templates/admin/trash.html:34
-#: src/moin/config/default.py:389
+#: src/moin/config/default.py:390
 msgid "Highlight"
 msgstr "Hervorheben"
 
 #: src/moin/apps/admin/templates/admin/trash.html:39
-#: src/moin/config/default.py:390
+#: src/moin/config/default.py:391
 msgid "Meta"
 msgstr "Metadaten"
 
 #: src/moin/apps/admin/templates/admin/trash.html:44
-#: src/moin/config/default.py:349 src/moin/config/default.py:381
+#: src/moin/config/default.py:350 src/moin/config/default.py:382
 #: src/moin/templates/all.html:5 src/moin/templates/global_history.html:59
 msgid "History"
 msgstr "Historie"
@@ -519,7 +516,7 @@ msgid "Revert deleted item"
 msgstr "Gelöschtes Item wiederherstellen"
 
 #: src/moin/apps/admin/templates/admin/trash.html:55
-#: src/moin/config/default.py:394 src/moin/templates/index.html:126
+#: src/moin/config/default.py:395 src/moin/templates/index.html:126
 msgid "Destroy"
 msgstr "Vernichten"
 
@@ -585,15 +582,15 @@ msgid ""
 "This table shows all settings in this wiki that retain their default "
 "values. "
 msgstr ""
-"Diese Tabelle zeigt alle Einstellungen des Wikis, die dem"
-"Standardwert entsprechen."
+"Diese Tabelle zeigt alle Einstellungen des Wikis, die dem Standardwert "
+"entsprechen."
 
 #: src/moin/apps/admin/templates/admin/wikiconfig.html:66
 msgid "Default Setting"
 msgstr "Standardeinstellung"
 
 #: src/moin/apps/admin/templates/admin/wikiconfighelp.html:14
-#: src/moin/items/__init__.py:1146
+#: src/moin/items/__init__.py:1166
 msgid "Default"
 msgstr "Standardeinstellung"
 
@@ -624,18 +621,18 @@ msgstr "Berichte"
 
 #: src/moin/apps/admin/templates/user/index_user.html:15
 #: src/moin/apps/admin/templates/user/index_user.html:17
-#: src/moin/apps/frontend/views.py:1440 src/moin/apps/frontend/views.py:1441
+#: src/moin/apps/frontend/views.py:1453 src/moin/apps/frontend/views.py:1454
 #: src/moin/templates/mychanges.html:11
 msgid "My Changes"
 msgstr "Meine Änderungen"
 
 #: src/moin/apps/admin/templates/user/index_user.html:19
-#: src/moin/apps/frontend/views.py:1743 src/moin/apps/frontend/views.py:1745
+#: src/moin/apps/frontend/views.py:1759 src/moin/apps/frontend/views.py:1761
 msgid "Wanted Items"
 msgstr "Fehlende Items"
 
 #: src/moin/apps/admin/templates/user/index_user.html:20
-#: src/moin/apps/frontend/views.py:1760 src/moin/apps/frontend/views.py:1763
+#: src/moin/apps/frontend/views.py:1776 src/moin/apps/frontend/views.py:1779
 msgid "Orphaned Items"
 msgstr "Verwaiste Items"
 
@@ -658,241 +655,244 @@ msgstr "Namespaces"
 msgid "all"
 msgstr "alle"
 
-#: src/moin/apps/feed/views.py:89
+#: src/moin/apps/feed/views.py:90
 msgid "MoinMoin feels unhappy."
 msgstr "MoinMoin ist unglücklich."
 
-#: src/moin/apps/frontend/views.py:157
+#: src/moin/apps/frontend/views.py:159
 msgid "Global Views"
 msgstr "Globale Ansichten"
 
-#: src/moin/apps/frontend/views.py:173
+#: src/moin/apps/frontend/views.py:175
 msgid "search also in non-current revisions"
 msgstr "auch in nicht-aktuellen Revisionen suchen"
 
-#: src/moin/apps/frontend/views.py:174 src/moin/apps/frontend/views.py:202
+#: src/moin/apps/frontend/views.py:176 src/moin/apps/frontend/views.py:204
 #: src/moin/templates/lookup.html:6
 msgid "Lookup"
 msgstr "Nachschlagen"
 
-#: src/moin/apps/frontend/views.py:433
+#: src/moin/apps/frontend/views.py:437
 #, python-format
 msgid "QueryError: invalid search term: %(search_term)s"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:441
+#: src/moin/apps/frontend/views.py:445
 #, python-format
 msgid "TermNotFound: field is not indexed: %(search_term)s"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:540 src/moin/apps/frontend/views.py:547
+#: src/moin/apps/frontend/views.py:532 src/moin/apps/frontend/views.py:539
 msgid "This item is deleted."
 msgstr "Dieses Item wurde gelöscht."
 
-#: src/moin/apps/frontend/views.py:543
+#: src/moin/apps/frontend/views.py:535
 msgid "This item revision is deleted."
 msgstr "Diese Item-Revision wurde gelöscht."
 
-#: src/moin/apps/frontend/views.py:576
+#: src/moin/apps/frontend/views.py:568
 #, python-format
 msgid "Items with %(field)s %(value)s"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:685
+#: src/moin/apps/frontend/views.py:677
 msgid "New Content Type"
 msgstr "Neuer Content-Type"
 
-#: src/moin/apps/frontend/views.py:690 src/moin/items/__init__.py:337
+#: src/moin/apps/frontend/views.py:682 src/moin/items/__init__.py:341
 msgid "Comment about your change"
 msgstr "Kommentar zu Ihrer Änderung"
 
-#: src/moin/apps/frontend/views.py:691 src/moin/items/__init__.py:338
+#: src/moin/apps/frontend/views.py:683 src/moin/items/__init__.py:343
 msgid "OK"
 msgstr "OK"
 
-#: src/moin/apps/frontend/views.py:737
+#: src/moin/apps/frontend/views.py:728
 msgid "Item conversion failed"
 msgstr "Item-Konversion schlug fehl"
 
-#: src/moin/apps/frontend/views.py:772
+#: src/moin/apps/frontend/views.py:763
 msgid "Item converted successfully"
 msgstr "Item erfolgreich konvertiert"
 
-#: src/moin/apps/frontend/views.py:799
-msgid "Error: nothing changed. Meta data validation failed."
-msgstr "Fehler: Keine Änderungen. Metadateien konnten nicht validiert werden"
-
-#: src/moin/apps/frontend/views.py:806 src/moin/items/__init__.py:344
+#: src/moin/apps/frontend/views.py:796 src/moin/items/__init__.py:349
 msgid "Target"
 msgstr "Ziel"
 
-#: src/moin/apps/frontend/views.py:806
+#: src/moin/apps/frontend/views.py:797
 msgid "The name of the target item"
 msgstr "Name des Ziel-Items"
 
-#: src/moin/apps/frontend/views.py:834
+#: src/moin/apps/frontend/views.py:826
 msgid "Delete all subitems listed below if checked:"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:839
+#: src/moin/apps/frontend/views.py:831
 msgid "Destroy all subitems listed below if checked:"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1024
+#: src/moin/apps/frontend/views.py:1018
 #, python-format
 msgid "Item '%(bad_name)s' does not exist."
 msgstr "Das Item '%(bad_name)s' existiert nicht."
 
-#: src/moin/apps/frontend/views.py:1039
+#: src/moin/apps/frontend/views.py:1035
 #, python-format
 msgid "Access denied for a subitem of %(bad_name)s, check History for status."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:1044
+#: src/moin/apps/frontend/views.py:1041
 #, python-format
 msgid "Access denied processing '%(bad_name)s'."
 msgstr "Zugriff verweigert beim Verarbeiten von '%(bad_name)s'."
 
-#: src/moin/apps/frontend/views.py:1233
+#: src/moin/apps/frontend/views.py:1230
 #, python-format
 msgid ""
 "File Successfully uploaded and renamed from %(bad_name)s to "
 "%(good_name)s. "
 msgstr ""
-"Datei erfolgreich hochgeladen und von %(bad_name)s zu "
-"%(good_name)s umbenannt."
+"Datei erfolgreich hochgeladen und von %(bad_name)s zu %(good_name)s "
+"umbenannt."
 
-#: src/moin/apps/frontend/views.py:1247
+#: src/moin/apps/frontend/views.py:1239
+#, python-format
+msgid ""
+"UnicodeDecodeError, upload failed, not a text file, nothing saved: "
+"'%(file_name)s'. Try changing the name."
+msgstr ""
+
+#: src/moin/apps/frontend/views.py:1258
 #, python-format
 msgid "File Successfully uploaded, existing file overwritten: '%(file_name)s'."
 msgstr ""
-"Datei erfolgreich hochgeladen."
-"Bereits existierende Datei wurde überschrieben: '%(file_name)s'."
+"Datei erfolgreich hochgeladen. Bereits existierende Datei wurde "
+"überschrieben: '%(file_name)s'."
 
-#: src/moin/apps/frontend/views.py:1253
+#: src/moin/apps/frontend/views.py:1264
 #, python-format
 msgid "Permission denied, upload failed: '%(file_name)s'."
 msgstr "Zugriff verweigert, Hochladen fehlgeschlagen: '%(file_name)s'."
 
-#: src/moin/apps/frontend/views.py:1265
+#: src/moin/apps/frontend/views.py:1276
 #, python-format
 msgid "File Successfully uploaded: '%(item_name)s'."
 msgstr "Datei erfolgreich hochgeladen: '%(item_name)s'."
 
-#: src/moin/apps/frontend/views.py:1288
+#: src/moin/apps/frontend/views.py:1299
 msgid "Apply Filter"
 msgstr "Filter anwenden"
 
-#: src/moin/apps/frontend/views.py:1362
+#: src/moin/apps/frontend/views.py:1373
 msgid "Global Index of All Namespaces"
 msgstr "Globaler Index aller Namespaces"
 
-#: src/moin/apps/frontend/views.py:1364
+#: src/moin/apps/frontend/views.py:1375
 #, python-format
 msgid "Namespace '%(name)s' "
 msgstr "Namespace '%(name)s' "
 
-#: src/moin/apps/frontend/views.py:1367
+#: src/moin/apps/frontend/views.py:1378
 #, python-format
 msgid "subitems '%(item_name)s'"
 msgstr "Subitems '%(item_name)s'"
 
-#: src/moin/apps/frontend/views.py:1368
+#: src/moin/apps/frontend/views.py:1379
 #, python-format
 msgid "Index of %(what)s"
 msgstr "Index von %(what)s"
 
-#: src/moin/apps/frontend/views.py:1370
+#: src/moin/apps/frontend/views.py:1381
 #, python-format
 msgid "Index of subitems '%(item_name)s'"
 msgstr "Index der Subitems '%(item_name)s'"
 
-#: src/moin/apps/frontend/views.py:1372 src/moin/config/default.py:350
+#: src/moin/apps/frontend/views.py:1383 src/moin/config/default.py:351
 #: src/moin/templates/index.html:220
 msgid "Global Index"
 msgstr "Globaler Index"
 
-#: src/moin/apps/frontend/views.py:1409
+#: src/moin/apps/frontend/views.py:1420
 msgid "You must be logged in to see your changes."
 msgstr "Sie müssen sich anmelden, um Ihre Änderungen zu sehen."
 
-#: src/moin/apps/frontend/views.py:1471
+#: src/moin/apps/frontend/views.py:1485
 #, python-format
 msgid "Items that are referred by '%(item_name)s'"
 msgstr "Items, auf die von '%(item_name)s' verweisen wird"
 
-#: src/moin/apps/frontend/views.py:1513
+#: src/moin/apps/frontend/views.py:1527
 #, python-format
 msgid "Items which refer to '%(item_name)s'"
 msgstr "Items, die auf '%(item_name)s' verweisen"
 
-#: src/moin/apps/frontend/views.py:1671 src/moin/apps/frontend/views.py:1677
-#: src/moin/config/default.py:349
+#: src/moin/apps/frontend/views.py:1687 src/moin/apps/frontend/views.py:1693
+#: src/moin/config/default.py:350
 msgid "Global History"
 msgstr "Globale Historie"
 
-#: src/moin/apps/frontend/views.py:1673
+#: src/moin/apps/frontend/views.py:1689
 msgid "Global History of All Namespaces"
 msgstr "Globale Historie aller Namespaces"
 
-#: src/moin/apps/frontend/views.py:1675
+#: src/moin/apps/frontend/views.py:1691
 #, python-format
 msgid "History of Namespace '%(namespace)s'"
 msgstr "Historie des Namespaces '%(namespace)s'"
 
-#: src/moin/apps/frontend/views.py:1773 src/moin/apps/frontend/views.py:1798
+#: src/moin/apps/frontend/views.py:1789 src/moin/apps/frontend/views.py:1813
 #, python-format
 msgid "You must login to use this action: %(action)s."
 msgstr "Sie müssen sich hierzu anmelden: %(action)s."
 
-#: src/moin/apps/frontend/views.py:1776
+#: src/moin/apps/frontend/views.py:1792
 msgid "A quicklink to this page could not be added for you."
 msgstr "Es konnte kein Quicklink zu dieser Item für Sie erstellt werden."
 
-#: src/moin/apps/frontend/views.py:1779
+#: src/moin/apps/frontend/views.py:1795
 msgid "Your quicklink to this page could not be removed."
 msgstr "Ihr Quicklink zu dieser Item konnte nicht entfernt werden."
 
-#: src/moin/apps/frontend/views.py:1800
+#: src/moin/apps/frontend/views.py:1815
 msgid "You are not allowed to subscribe to an item you may not read."
 msgstr "Sie dürfen kein Item abonnieren, für das Sie keine Leserechte haben."
 
-#: src/moin/apps/frontend/views.py:1804
+#: src/moin/apps/frontend/views.py:1819
 msgid ""
 "Can't remove the subscription! You are subscribed to this page, but not "
 "by itemid."
 msgstr ""
-"Das Abonnement kann nicht aufgehoben werden! Sie haben diese Seite"
-"abonniert, aber nicht über die Itemid."
+"Das Abonnement kann nicht aufgehoben werden! Sie haben diese "
+"Seite abonniert, aber nicht über die Itemid."
 
-#: src/moin/apps/frontend/views.py:1805
+#: src/moin/apps/frontend/views.py:1820
 msgid "Please edit the subscription in your settings."
 msgstr "Bitte bearbeiten Sie die Abonnements in Ihren Einstellungen."
 
-#: src/moin/apps/frontend/views.py:1810
+#: src/moin/apps/frontend/views.py:1825
 msgid "You could not get subscribed to this item."
 msgstr "Sie konnten nicht zu den Abonnenten dieses Items hinzugefügt werden."
 
-#: src/moin/apps/frontend/views.py:1819 src/moin/apps/frontend/views.py:1996
-#: src/moin/apps/frontend/views.py:2142
+#: src/moin/apps/frontend/views.py:1834 src/moin/apps/frontend/views.py:2013
+#: src/moin/apps/frontend/views.py:2153
 msgid "The passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
-#: src/moin/apps/frontend/views.py:1835
+#: src/moin/apps/frontend/views.py:1851
 msgid "The login username you want to use"
 msgstr "Der Anmelde-Name, den Sie benutzen wollen"
 
-#: src/moin/apps/frontend/views.py:1836 src/moin/apps/frontend/views.py:2020
-#: src/moin/apps/frontend/views.py:2178
+#: src/moin/apps/frontend/views.py:1853 src/moin/apps/frontend/views.py:2037
+#: src/moin/apps/frontend/views.py:2189
 msgid "The login password you want to use"
 msgstr "Das Anmelde-Passwort, das Sie benutzen wollen"
 
-#: src/moin/apps/frontend/views.py:1837 src/moin/apps/frontend/views.py:2022
-#: src/moin/apps/frontend/views.py:2180
+#: src/moin/apps/frontend/views.py:1854 src/moin/apps/frontend/views.py:2039
+#: src/moin/apps/frontend/views.py:2191
 msgid "Repeat the same password"
 msgstr "Wiederholen Sie das gleiche Passwort"
 
-#: src/moin/apps/frontend/views.py:1890
+#: src/moin/apps/frontend/views.py:1907
 msgid ""
 "Account verification required, please see the email we sent to your "
 "address."
@@ -900,7 +900,7 @@ msgstr ""
 "Eine Überprüfung des Kontos ist notwendig, bitte prüfen Sie \"\n"
 "\"die E-Mail, die wir an Ihre Adresse gesandt haben."
 
-#: src/moin/apps/frontend/views.py:1892
+#: src/moin/apps/frontend/views.py:1909
 #, python-format
 msgid ""
 "An error occurred while sending the verification email: \"%(message)s\" "
@@ -911,238 +911,238 @@ msgstr ""
 "\"\"%(message)s\" Bitte kontaktieren Sie einen Administrator, um Ihr "
 "Konto zu aktivieren."
 
-#: src/moin/apps/frontend/views.py:1896
+#: src/moin/apps/frontend/views.py:1913
 msgid "Account created, please log in now."
 msgstr "Das Benutzerkonto wurde erstellt. Bitte melden Sie sich an."
 
-#: src/moin/apps/frontend/views.py:1915
+#: src/moin/apps/frontend/views.py:1932
 msgid "This email is already in use."
 msgstr "Diese E-Mail-Adresse wird bereits verwendet."
 
-#: src/moin/apps/frontend/views.py:1919
+#: src/moin/apps/frontend/views.py:1936
 msgid "Your account has been activated, you can log in now."
 msgstr "Ihr Account wurde aktiviert, Sie können sich jetzt anmelden."
 
-#: src/moin/apps/frontend/views.py:1921
+#: src/moin/apps/frontend/views.py:1938
 msgid "Your new email address has been confirmed."
 msgstr "Ihre neue E-Mail-Adresse wurde bestätigt."
 
-#: src/moin/apps/frontend/views.py:1927
+#: src/moin/apps/frontend/views.py:1944
 msgid "Your username and/or token is invalid!"
 msgstr "Ihr Benutzername und/oder Token ist ungültig!"
 
-#: src/moin/apps/frontend/views.py:1939
+#: src/moin/apps/frontend/views.py:1956
 msgid "Your user name or your email address is needed."
 msgstr "Bitte geben Sie Ihren Benutzernamen oder Ihre E-Mail-Adresse an."
 
-#: src/moin/apps/frontend/views.py:1953 src/moin/apps/frontend/views.py:2016
-#: src/moin/converters/archive_in.py:63
+#: src/moin/apps/frontend/views.py:1970 src/moin/apps/frontend/views.py:2033
+#: src/moin/converters/archive_in.py:66
 msgid "Name"
 msgstr "Name"
 
-#: src/moin/apps/frontend/views.py:1953 src/moin/apps/frontend/views.py:2016
+#: src/moin/apps/frontend/views.py:1970 src/moin/apps/frontend/views.py:2033
 msgid "Your login name"
 msgstr "Ihr Anmelde-Name"
 
-#: src/moin/apps/frontend/views.py:1955
+#: src/moin/apps/frontend/views.py:1972
 msgid "Recover password"
 msgstr "Passwort zurücksetzen"
 
-#: src/moin/apps/frontend/views.py:1963 src/moin/templates/lostpass.html:5
+#: src/moin/apps/frontend/views.py:1980 src/moin/templates/lostpass.html:5
 msgid "Lost Password"
 msgstr "Passwort vergessen"
 
-#: src/moin/apps/frontend/views.py:1985
+#: src/moin/apps/frontend/views.py:2002
 msgid "If this account exists, you will be notified."
 msgstr "Wenn dieses Benutzerkonto existiert, werden Sie benachrichtigt."
 
-#: src/moin/apps/frontend/views.py:1997 src/moin/apps/frontend/views.py:2144
+#: src/moin/apps/frontend/views.py:2014 src/moin/apps/frontend/views.py:2155
 msgid "New password is unacceptable, could not get processed."
 msgstr ""
 "Das neue Passwort kann nicht verwendet werden, da es nicht verarbeitet "
 "werden konnte."
 
-#: src/moin/apps/frontend/views.py:2017
+#: src/moin/apps/frontend/views.py:2034
 msgid "Recovery token"
 msgstr "Wiederherstellungscode"
 
-#: src/moin/apps/frontend/views.py:2018
+#: src/moin/apps/frontend/views.py:2035
 msgid "The recovery token that has been sent to you"
 msgstr "Das Recovery-Token, das an Sie gesendet wurde"
 
-#: src/moin/apps/frontend/views.py:2019 src/moin/apps/frontend/views.py:2177
+#: src/moin/apps/frontend/views.py:2036 src/moin/apps/frontend/views.py:2188
 msgid "New password"
 msgstr "Neues Passwort"
 
-#: src/moin/apps/frontend/views.py:2021 src/moin/apps/frontend/views.py:2179
+#: src/moin/apps/frontend/views.py:2038 src/moin/apps/frontend/views.py:2190
 msgid "New password (repeat)"
 msgstr "Neues Passwort (wiederholen)"
 
-#: src/moin/apps/frontend/views.py:2023 src/moin/apps/frontend/views.py:2181
+#: src/moin/apps/frontend/views.py:2040 src/moin/apps/frontend/views.py:2192
 msgid "Change password"
 msgstr "Passwort ändern"
 
-#: src/moin/apps/frontend/views.py:2031 src/moin/templates/recoverpass.html:5
+#: src/moin/apps/frontend/views.py:2048 src/moin/templates/recoverpass.html:5
 msgid "Recover Password"
 msgstr "Passwort zurücksetzen"
 
-#: src/moin/apps/frontend/views.py:2044
+#: src/moin/apps/frontend/views.py:2061
 msgid "Your password has been changed, you can log in now."
 msgstr "Ihr Passwort wurde geändert. Sie können sich jetzt anmelden."
 
-#: src/moin/apps/frontend/views.py:2046
+#: src/moin/apps/frontend/views.py:2063
 msgid "Your token is invalid!"
 msgstr "Ihr Code ist ungültig!"
 
-#: src/moin/apps/frontend/views.py:2058
+#: src/moin/apps/frontend/views.py:2075
 msgid "Either your username or password was invalid."
 msgstr "Ihr Benutzername oder Passwort war ungültig."
 
-#: src/moin/apps/frontend/views.py:2088
+#: src/moin/apps/frontend/views.py:2105
 msgid "Log in"
 msgstr "Anmelden"
 
-#: src/moin/apps/frontend/views.py:2096
-msgid "You are logged in."
-msgstr "Sie sind jetzt angemeldet."
-
-#: src/moin/apps/frontend/views.py:2100 src/moin/templates/utils.html:476
+#: src/moin/apps/frontend/views.py:2112 src/moin/templates/utils.html:476
 #: src/moin/themes/basic/templates/layout.html:172
 msgid "Login"
 msgstr "Anmelden"
 
-#: src/moin/apps/frontend/views.py:2131
+#: src/moin/apps/frontend/views.py:2126
+msgid "You are logged in."
+msgstr "Sie sind jetzt angemeldet."
+
+#: src/moin/apps/frontend/views.py:2142
 msgid "You are logged out."
 msgstr "Sie sind jetzt abgemeldet."
 
-#: src/moin/apps/frontend/views.py:2143
+#: src/moin/apps/frontend/views.py:2154
 msgid "The current password was wrong."
 msgstr "Das aktuelle Passwort war nicht korrekt."
 
-#: src/moin/apps/frontend/views.py:2147
+#: src/moin/apps/frontend/views.py:2158
 msgid "New password not acceptable: "
 msgstr "Neues Passwort ist nicht akzeptabel: "
 
-#: src/moin/apps/frontend/views.py:2175
+#: src/moin/apps/frontend/views.py:2186
 msgid "Current Password"
 msgstr "Aktuelles Passwort"
 
-#: src/moin/apps/frontend/views.py:2176
+#: src/moin/apps/frontend/views.py:2187
 msgid "Your current login password"
 msgstr "Ihr aktuelles Anmelde-Passwort"
 
-#: src/moin/apps/frontend/views.py:2202
+#: src/moin/apps/frontend/views.py:2214
 msgid "Always use ISO 8601 date-time format"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2203
+#: src/moin/apps/frontend/views.py:2215
 msgid "Publish my email (not my wiki homepage) in author info"
 msgstr ""
 "Veröffentliche meine E-Mail-Adresse (statt meiner Wiki-Homepage) in den "
 "Autoreninformationen"
 
-#: src/moin/apps/frontend/views.py:2204
+#: src/moin/apps/frontend/views.py:2216
 msgid "Open editor on double click"
 msgstr "Editor durch Doppelklick öffnen"
 
-#: src/moin/apps/frontend/views.py:2205
+#: src/moin/apps/frontend/views.py:2217
 msgid "Scroll page after edit"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2206
+#: src/moin/apps/frontend/views.py:2218
 msgid "Show comment sections"
 msgstr "Kommentarbereiche anzeigen"
 
-#: src/moin/apps/frontend/views.py:2207
+#: src/moin/apps/frontend/views.py:2219
 msgid "Disable this account forever"
 msgstr "Benutzerkonto dauerhaft deaktivieren"
 
-#: src/moin/apps/frontend/views.py:2217
+#: src/moin/apps/frontend/views.py:2229
 msgid "Invalid subscription syntax: "
 msgstr "Invalider Abonnement-Syntax"
 
-#: src/moin/apps/frontend/views.py:2218
+#: src/moin/apps/frontend/views.py:2230
 msgid "Invalid keyword: "
 msgstr "Invalides Schlüsselwort"
 
-#: src/moin/apps/frontend/views.py:2219
+#: src/moin/apps/frontend/views.py:2231
 msgid "Invalid RE syntax: "
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2259 src/moin/templates/usersettings.html:19
+#: src/moin/apps/frontend/views.py:2271 src/moin/templates/usersettings.html:19
 msgid "User Settings"
 msgstr "Benutzer-Einstellungen"
 
-#: src/moin/apps/frontend/views.py:2268
+#: src/moin/apps/frontend/views.py:2281
 msgid "Usernames"
 msgstr "Benutzernamen"
 
-#: src/moin/apps/frontend/views.py:2268
+#: src/moin/apps/frontend/views.py:2281
 msgid "The login usernames you want to use"
 msgstr "Die Anmelde-Namen, die Sie benutzen wollen"
 
-#: src/moin/apps/frontend/views.py:2269
+#: src/moin/apps/frontend/views.py:2282
 msgid "Display-Name"
 msgstr "Anzeigename"
 
-#: src/moin/apps/frontend/views.py:2270
+#: src/moin/apps/frontend/views.py:2283
 msgid "Your display name (informational)"
 msgstr "Ihr Anzeige-Name (informativ)"
 
-#: src/moin/apps/frontend/views.py:2273
+#: src/moin/apps/frontend/views.py:2286
 msgid "Timezone"
 msgstr "Zeitzone"
 
-#: src/moin/apps/frontend/views.py:2275
+#: src/moin/apps/frontend/views.py:2288
 msgid "Locale"
 msgstr "Lokalisierung"
 
-#: src/moin/apps/frontend/views.py:2281
+#: src/moin/apps/frontend/views.py:2294
 msgid "Theme name"
 msgstr "Theme-Name"
 
-#: src/moin/apps/frontend/views.py:2283
+#: src/moin/apps/frontend/views.py:2296
 msgid "User CSS URL"
 msgstr "URL für benutzerdefiniertes CSS"
 
-#: src/moin/apps/frontend/views.py:2284
+#: src/moin/apps/frontend/views.py:2297
 msgid "Give the URL of your custom CSS (optional)"
 msgstr "Geben Sie die URL Ihres benutzerspezifischen CSS an (optional)"
 
-#: src/moin/apps/frontend/views.py:2285
+#: src/moin/apps/frontend/views.py:2298
 msgid "Number rows in edit textarea"
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2286
+#: src/moin/apps/frontend/views.py:2299
 msgid "Editor textarea height (0=auto)"
 msgstr "Höhe des Editors (0=automatisch)"
 
-#: src/moin/apps/frontend/views.py:2287
+#: src/moin/apps/frontend/views.py:2300
 msgid "History results per page"
 msgstr "Anzahl Historien-Ergebnisse pro Seite"
 
-#: src/moin/apps/frontend/views.py:2288
+#: src/moin/apps/frontend/views.py:2301
 msgid "Number of results per page (0=no paging)"
 msgstr "Anzahl der Ergebnisse pro Seite (0=nicht seitenweise)"
 
-#: src/moin/apps/frontend/views.py:2332
+#: src/moin/apps/frontend/views.py:2345
 msgid "Your password has been changed."
 msgstr "Ihr Passwort wurde geändert."
 
-#: src/moin/apps/frontend/views.py:2340
+#: src/moin/apps/frontend/views.py:2354
 #, python-format
 msgid "The username '%(name)s' is already in use."
 msgstr "Der Benutzername %(name)s wird bereits verwendet."
 
-#: src/moin/apps/frontend/views.py:2347
+#: src/moin/apps/frontend/views.py:2361
 msgid "This email is already in use"
 msgstr "Diese E-Mail-Adresse wird bereits verwendet."
 
-#: src/moin/apps/frontend/views.py:2362
+#: src/moin/apps/frontend/views.py:2376
 msgid "A confirmation email has been sent to your newly configured email address."
 msgstr "Eine Bestätigungs-E-Mail wurde an ihre neue E-Mail-Adresse gesendet."
 
-#: src/moin/apps/frontend/views.py:2369
+#: src/moin/apps/frontend/views.py:2383
 msgid ""
 "Your email address was not changed because sending the verification email"
 " failed. Please try again later."
@@ -1151,55 +1151,55 @@ msgstr ""
 "Überprüfungs-E-Mail fehlgeschlagen ist. Bitte versuchen Sie es später "
 "erneut."
 
-#: src/moin/apps/frontend/views.py:2376
+#: src/moin/apps/frontend/views.py:2390
 msgid "Nothing saved."
 msgstr "Nichts gespeichert."
 
-#: src/moin/apps/frontend/views.py:2379
+#: src/moin/apps/frontend/views.py:2393
 msgid "Your changes have been saved."
 msgstr "Ihre Änderungen wurden gespeichert."
 
-#: src/moin/apps/frontend/views.py:2431
+#: src/moin/apps/frontend/views.py:2445
 msgid "You must log in to use bookmarks."
 msgstr "Sie müssen sich anmelden, um Lesezeichen verwenden zu können."
 
-#: src/moin/apps/frontend/views.py:2529
+#: src/moin/apps/frontend/views.py:2539
 msgid "There is only one revision eligible for diff."
 msgstr ""
 
-#: src/moin/apps/frontend/views.py:2658
+#: src/moin/apps/frontend/views.py:2670
 #, python-format
 msgid "Items with similar names to '%(item_name)s'"
 msgstr "Items mit ähnlichen Namen wie '%(item_name)s'"
 
-#: src/moin/apps/frontend/views.py:2753 src/moin/apps/frontend/views.py:2761
+#: src/moin/apps/frontend/views.py:2765 src/moin/apps/frontend/views.py:2773
 msgid "Global Tags"
 msgstr "Globale Schlagworte"
 
-#: src/moin/apps/frontend/views.py:2763
+#: src/moin/apps/frontend/views.py:2775
 msgid "Global Tags in All Namespaces"
 msgstr "Globale Schlagworte in allen Namespaces"
 
-#: src/moin/apps/frontend/views.py:2765
+#: src/moin/apps/frontend/views.py:2777
 #, python-format
 msgid "Tags in Namespace '%(namespace)s'"
 msgstr "Schlagworte im Namespace '%(namespace)s'"
 
-#: src/moin/apps/frontend/views.py:2813
+#: src/moin/apps/frontend/views.py:2825
 #, python-format
 msgid "Items tagged with %(tag)s"
 msgstr "Items, die mit dem Schlagwort %(tag)s markiert wurden"
 
-#: src/moin/auth/__init__.py:257 src/moin/auth/ldap_login.py:133
+#: src/moin/auth/__init__.py:258 src/moin/auth/ldap_login.py:133
 msgid "Missing password. Please enter user name and password."
 msgstr "Fehlendes Passwort. Bitte geben Sie Benutzername und Passwort ein."
 
-#: src/moin/auth/__init__.py:265 src/moin/auth/ldap_login.py:204
+#: src/moin/auth/__init__.py:266 src/moin/auth/ldap_login.py:204
 #: src/moin/auth/ldap_login.py:255
 msgid "Invalid username or password."
 msgstr "Benutzername oder Passwort ungültig."
 
-#: src/moin/auth/__init__.py:272
+#: src/moin/auth/__init__.py:273
 #, python-format
 msgid ""
 "If you do not have an account, <a href=\"%(register_url)s\">you can "
@@ -1208,7 +1208,7 @@ msgstr ""
 "Wenn Sie kein Benutzerkonto haben, <a href=\"%(register_url)s\">können "
 "Sie jetzt eines anlegen</a>. "
 
-#: src/moin/auth/__init__.py:274
+#: src/moin/auth/__init__.py:275
 #, python-format
 msgid "<a href=\"%(recover_url)s\">Forgot your password?</a>"
 msgstr "<a href=\"%(recover_url)s\">Passwort vergessen?</a>"
@@ -1222,12 +1222,12 @@ msgstr "Bitte melden Sie sich erst an."
 msgid "LDAP server %(server)s failed."
 msgstr "Verbindung zum LDAP-Server %(server)s fehlgeschlagen."
 
-#: src/moin/config/default.py:266
+#: src/moin/config/default.py:267
 #, python-format
 msgid "For a password a minimum length of %(min_length)d characters is required."
 msgstr "Ein Passwort muss mindestens %(min_length)d Zeichen haben."
 
-#: src/moin/config/default.py:269
+#: src/moin/config/default.py:270
 #, python-format
 msgid ""
 "For a password a minimum of %(min_different)d different characters is "
@@ -1235,7 +1235,8 @@ msgid ""
 msgstr ""
 "Ein Passwort muss mindestens %(min_different)d verschiedene Zeichen "
 "beinhalten."
-#: src/moin/config/default.py:276
+
+#: src/moin/config/default.py:277
 msgid ""
 "Password is too easy to guess (password contains name or name contains "
 "password)."
@@ -1243,227 +1244,233 @@ msgstr ""
 "Das Passwort ist zu leicht zu erraten (Passwort ist Teil des "
 "Benutzernamens oder umgekehrt)."
 
-#: src/moin/config/default.py:285
+#: src/moin/config/default.py:286
 msgid "Password is too easy to guess (keyboard sequence)."
 msgstr "Das Passwort ist zu leicht zu erraten (Zeichenfolge auf der Tastatur)."
 
-#: src/moin/config/default.py:348
+#: src/moin/config/default.py:349
 msgid "Home"
 msgstr "Start"
 
-#: src/moin/config/default.py:348
+#: src/moin/config/default.py:349
 msgid "Home Page"
 msgstr "HomePage"
 
-#: src/moin/config/default.py:350 src/moin/templates/all.html:7
+#: src/moin/config/default.py:351 src/moin/templates/all.html:7
 msgid "Index"
 msgstr "Index"
 
-#: src/moin/config/default.py:351
+#: src/moin/config/default.py:352
 msgid "Global Tags Index"
 msgstr "Globaler Schlagwort-Index"
 
-#: src/moin/config/default.py:353
+#: src/moin/config/default.py:354
 msgid "Administration & Docs"
 msgstr "Administration & Doku"
 
-#: src/moin/config/default.py:380 src/moin/templates/blog/utils.html:12
+#: src/moin/config/default.py:381 src/moin/templates/blog/utils.html:12
 #: src/moin/templates/show.html:14
 msgid "Modify"
 msgstr "Bearbeiten"
 
-#: src/moin/config/default.py:380
+#: src/moin/config/default.py:381
 msgid "Edit or Upload"
 msgstr "Bearbeiten oder Hochladen"
 
-#: src/moin/config/default.py:381
+#: src/moin/config/default.py:382
 msgid "Revision History"
 msgstr "Revisions-Historie"
 
-#: src/moin/config/default.py:382 src/moin/templates/index.html:116
+#: src/moin/config/default.py:383 src/moin/templates/index.html:116
 #: src/moin/themes/basic/templates/modify.html:30
 msgid "Download"
 msgstr "Herunterladen"
 
-#: src/moin/config/default.py:383 src/moin/templates/index.html:121
+#: src/moin/config/default.py:384 src/moin/templates/index.html:121
 msgid "Delete"
 msgstr "Löschen"
 
-#: src/moin/config/default.py:383
+#: src/moin/config/default.py:384
 msgid "Delete this item"
 msgstr "Dieses Item löschen"
 
-#: src/moin/config/default.py:384
+#: src/moin/config/default.py:385
 msgid "Create or remove a navigation link to this item"
 msgstr "Einen Navigations-Link zu diesem Item anlegen oder entfernen"
 
-#: src/moin/config/default.py:385
+#: src/moin/config/default.py:386
 msgid "Switch notifications about item changes on or off"
 msgstr "Benachrichtigungen über Item-Änderungen an- oder abschalten"
 
-#: src/moin/config/default.py:386
+#: src/moin/config/default.py:387
 msgid "Subitems"
 msgstr "Untergeordnete Items"
 
-#: src/moin/config/default.py:386
+#: src/moin/config/default.py:387
 msgid "Subitems Index"
 msgstr "Index der untergeordneten Items"
 
-#: src/moin/config/default.py:388
+#: src/moin/config/default.py:389
 msgid "Rename"
 msgstr "Umbenennen"
 
-#: src/moin/config/default.py:388
+#: src/moin/config/default.py:389
 msgid "Rename this item"
 msgstr "Dieses Item umbenennen"
 
-#: src/moin/config/default.py:389
+#: src/moin/config/default.py:390
 msgid "Show with Syntax-Highlighting"
 msgstr "Mit Syntax-Highlighting anzeigen"
 
-#: src/moin/config/default.py:390
+#: src/moin/config/default.py:391
 msgid "Display Metadata"
 msgstr "Metadaten anzeigen"
 
-#: src/moin/config/default.py:391
+#: src/moin/config/default.py:392
 msgid "Site Map"
 msgstr "Sitemap"
 
-#: src/moin/config/default.py:391
+#: src/moin/config/default.py:392
 msgid "Local Site Map of this item"
 msgstr "Lokale Sitemap dieses Items"
 
-#: src/moin/config/default.py:392
+#: src/moin/config/default.py:393
 msgid "Similar"
 msgstr "Ähnliches"
 
-#: src/moin/config/default.py:392
+#: src/moin/config/default.py:393
 msgid "Items with similar names"
 msgstr "Items mit ähnlichen Namen"
 
-#: src/moin/config/default.py:393
+#: src/moin/config/default.py:394
 msgid "Convert"
 msgstr "Konvertieren"
 
-#: src/moin/config/default.py:393
+#: src/moin/config/default.py:394
 msgid "Convert this item"
 msgstr "Dieses Item konvertieren"
 
-#: src/moin/config/default.py:394
+#: src/moin/config/default.py:395
 msgid "Completely destroy this item"
 msgstr "Dieses Item vollständig zerstören"
 
-#: src/moin/config/default.py:395 src/moin/templates/ticket/modify.html:23
+#: src/moin/config/default.py:396 src/moin/templates/ticket/modify.html:23
 msgid "Comments"
 msgstr "Kommentare"
 
-#: src/moin/config/default.py:395
+#: src/moin/config/default.py:396
 msgid "Hide comments"
 msgstr "Kommentare verstecken"
 
-#: src/moin/config/default.py:396
+#: src/moin/config/default.py:397
 msgid "Transclusions"
 msgstr "Transklusionen"
 
-#: src/moin/config/default.py:396
+#: src/moin/config/default.py:397
 msgid "Show transclusions"
 msgstr "Transklusionen anzeigen"
 
-#: src/moin/config/default.py:580
+#: src/moin/config/default.py:576
 msgid "To request an account, see bottom of Home page."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:162
+#: src/moin/constants/contenttypes.py:164
 msgid "This is a plain text item, there is no markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:163
+#: src/moin/constants/contenttypes.py:165
 msgid "This item can not be edited, upload a revised file."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:165
+#: src/moin/constants/contenttypes.py:167
 msgid "Use a semicolon or comma to separate cells."
 msgstr "Nutze ein Semikolon oder Komma um Zellen zu trennen."
 
-#: src/moin/constants/contenttypes.py:166
+#: src/moin/constants/contenttypes.py:168
 msgid "If the first row is recognized as a header, the table will be sortable."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:172
+#: src/moin/constants/contenttypes.py:175
 msgid "Click for help on Moin Wiki markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:173
+#: src/moin/constants/contenttypes.py:176
 msgid "Moinmoin 1.9 format is deprecated, convert to moin 2."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:174
+#: src/moin/constants/contenttypes.py:177
 msgid "Click for help on Media Wiki markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:175
+#: src/moin/constants/contenttypes.py:178
 msgid "Click for help on Creole Wiki markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:176
+#: src/moin/constants/contenttypes.py:179
 msgid "Click for help on Markdown Wiki markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:177
+#: src/moin/constants/contenttypes.py:180
 msgid "Click for help on reST Wiki markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:178
+#: src/moin/constants/contenttypes.py:181
 msgid "Click for help on Docbook Wiki markup."
 msgstr ""
 
-#: src/moin/constants/contenttypes.py:206
+#: src/moin/constants/contenttypes.py:209
 msgid "No help for unknown content type."
 msgstr ""
 
-#: src/moin/converters/_wiki_macro.py:68
+#: src/moin/converters/_wiki_macro.py:66
 msgid "Include Macro above has invalid format, missing item name"
 msgstr ""
 
-#: src/moin/converters/_wiki_macro.py:79
+#: src/moin/converters/_wiki_macro.py:77
 msgid ""
 "Include Macro above has invalid format, expected sort=ascending or "
 "descending"
 msgstr ""
 
-#: src/moin/converters/html_in.py:126
+#: src/moin/converters/everything.py:32
+msgid ""
+"This deleted item must be restored before it can be viewed or downloaded,"
+" ItemID = {itemid}"
+msgstr ""
+
+#: src/moin/converters/html_in.py:128
 msgid "Error: malformed HTML: {reason}."
 msgstr "Error: fehlerhafte HTML: {reason}."
 
-#: src/moin/converters/html_in.py:132
+#: src/moin/converters/html_in.py:134
 msgid "Error: malformed HTML. Try viewing source with Highlight or Modify links."
 msgstr ""
 
-#: src/moin/converters/html_in.py:266
+#: src/moin/converters/html_in.py:268
 #, python-format
 msgid "Tag '%(invalid_tag)s' is not supported; all tag contents are discarded."
 msgstr ""
 
-#: src/moin/converters/html_in.py:272
+#: src/moin/converters/html_in.py:275
 #, python-format
 msgid ""
 "Tag '%(invalid_tag)s' is not known; tag ignored but children are "
 "processed."
 msgstr ""
 
-#: src/moin/converters/html_out.py:695
+#: src/moin/converters/html_out.py:690
 msgid "Link to this heading"
 msgstr "Link zu dieser Überschrift"
 
-#: src/moin/converters/html_out.py:761
+#: src/moin/converters/html_out.py:756
 msgid "Contents"
 msgstr "Inhaltsverzeichnis"
 
-#: src/moin/converters/include.py:306
+#: src/moin/converters/include.py:302
 msgid "Access Denied, transcluded content suppressed."
 msgstr ""
 
-#: src/moin/converters/include.py:324
+#: src/moin/converters/include.py:320
 msgid "Error: no items found matching \"<<Include({0})>>\""
 msgstr ""
 
@@ -1478,17 +1485,17 @@ msgstr ""
 "<<%(macro_name)s: Ausführung fehlgeschlagen [%(error_msg)s] (Sie finden "
 "weitere Informationen im Log)>>"
 
-#: src/moin/converters/moinwiki_in.py:958
+#: src/moin/converters/moinwiki_in.py:976
 msgid "Error:"
 msgstr "Fehler:"
 
-#: src/moin/converters/moinwiki_in.py:959
+#: src/moin/converters/moinwiki_in.py:977
 msgid "is invalid within"
 msgstr "ist ungültig innerhalb von"
 
-#: src/moin/converters/nonexistent_in.py:35
+#: src/moin/converters/nonexistent_in.py:33
 #, python-format
-msgid "%(item_name)s does not exist. Create it?"
+msgid "%(item_name)s does not exist. Create it? "
 msgstr "%(item_name)s existiert nicht, möchten Sie es jetzt erstellen?"
 
 #: src/moin/converters/nowiki.py:39
@@ -1506,160 +1513,164 @@ msgid ""
 "'%(parent_name)s' is missing."
 msgstr ""
 
-#: src/moin/items/__init__.py:339
+#: src/moin/items/__init__.py:344
 msgid "Preview"
 msgstr "Vorschau"
 
-#: src/moin/items/__init__.py:340 src/moin/templates/index.html:306
+#: src/moin/items/__init__.py:345 src/moin/templates/index.html:306
 #: src/moin/themes/basic/templates/modify.html:91
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/moin/items/__init__.py:377 src/moin/items/__init__.py:382
+#: src/moin/items/__init__.py:382 src/moin/items/__init__.py:387
 msgid "The ACL string is invalid."
 msgstr ""
 
-#: src/moin/items/__init__.py:388
+#: src/moin/items/__init__.py:396
 msgid "Access Control List - Use 'None' for default"
 msgstr ""
 
-#: src/moin/items/__init__.py:389 src/moin/items/ticket.py:97
-#: src/moin/items/ticket.py:108 src/moin/templates/ticket/advanced.html:20
+#: src/moin/items/__init__.py:399 src/moin/items/ticket.py:97
+#: src/moin/items/ticket.py:109 src/moin/templates/ticket/advanced.html:20
 #: src/moin/templates/ticket/modify.html:52
 #: src/moin/templates/ticket/submit.html:13 src/moin/templates/tickets.html:54
 msgid "Summary"
 msgstr "Zusammenfassung"
 
-#: src/moin/items/__init__.py:389
+#: src/moin/items/__init__.py:399
 msgid "One-line summary of the item"
 msgstr "Einzeilige Zusammenfassung dieses Items"
 
-#: src/moin/items/__init__.py:635 src/moin/items/__init__.py:637
-#: src/moin/items/__init__.py:659
+#: src/moin/items/__init__.py:645 src/moin/items/__init__.py:647
+#: src/moin/items/__init__.py:672
 #, python-format
 msgid "The item \"%(name)s\" was deleted."
 msgstr "Das Item \"%(name)s\" wurde gelöscht."
 
-#: src/moin/items/__init__.py:641 src/moin/items/__init__.py:643
-#: src/moin/items/__init__.py:674
+#: src/moin/items/__init__.py:651 src/moin/items/__init__.py:654
+#: src/moin/items/__init__.py:688
 #, python-format
 msgid "The item \"%(name)s\" was renamed to \"%(new_name)s\"."
 msgstr "Das Item \"%(name)s\" wurde umbenannt in \"%(new_name)s\"."
 
-#: src/moin/items/__init__.py:657
+#: src/moin/items/__init__.py:670
 #, python-format
 msgid "The subitem \"%(name)s\" was deleted."
 msgstr ""
 
-#: src/moin/items/__init__.py:689
+#: src/moin/items/__init__.py:705
 #, python-format
 msgid "An item named %s already exists in the namespace %s."
 msgstr "Ein Item mit Namen %s existiert bereits im Namespace %s."
 
-#: src/moin/items/__init__.py:729 src/moin/items/__init__.py:731
-#: src/moin/items/__init__.py:743
+#: src/moin/items/__init__.py:746 src/moin/items/__init__.py:748
+#: src/moin/items/__init__.py:760
 #, python-format
 msgid "The item \"%(name)s\" was destroyed."
 msgstr "Das Item \"%(name)s\" wurde gelöscht."
 
-#: src/moin/items/__init__.py:741
+#: src/moin/items/__init__.py:758
 #, python-format
 msgid "The subitem \"%(name)s\" was destroyed."
 msgstr ""
 
-#: src/moin/items/__init__.py:747 src/moin/items/__init__.py:749
+#: src/moin/items/__init__.py:764 src/moin/items/__init__.py:767
 #, python-format
 msgid "Error: The subitem \"%(name)s\" was not destroyed, permission denied."
 msgstr ""
 
-#: src/moin/items/__init__.py:753
+#: src/moin/items/__init__.py:772
 #, python-format
 msgid "Rev Number %(rev_number)s of the item \"%(name)s\" was destroyed."
 msgstr ""
 
-#: src/moin/items/__init__.py:1147
+#: src/moin/items/__init__.py:1167
 msgid "Wiki item"
 msgstr "Wiki-Item"
 
-#: src/moin/items/__init__.py:1227
+#: src/moin/items/__init__.py:1228
+msgid "Alert wiki admin that help items are not loaded"
+msgstr ""
+
+#: src/moin/items/__init__.py:1251
 msgid "You do not have permission to create the item named \"{name}\"."
 msgstr "Sie haben nicht die Berechtigung, das Item \"{name}\" zu erzeugen."
 
-#: src/moin/items/__init__.py:1332
+#: src/moin/items/__init__.py:1357
 msgid "Nothing changed, nothing saved."
 msgstr "Keine Änderungen durchgeführt."
 
-#: src/moin/items/__init__.py:1346
+#: src/moin/items/__init__.py:1372
 msgid "CONFLICT "
 msgstr ""
 
-#: src/moin/items/__init__.py:1347
+#: src/moin/items/__init__.py:1373
 msgid "An edit conflict has occurred, edit this item again to resolve conflicts."
 msgstr ""
 
-#: src/moin/items/__init__.py:1387
+#: src/moin/items/__init__.py:1416
 #, python-format
 msgid ""
 "You may recover your draft saved %(number)s %(interval)s ago by clicking "
 "the 'Load Draft' button."
 msgstr ""
 
-#: src/moin/items/__init__.py:1389
+#: src/moin/items/__init__.py:1420
 #, python-format
 msgid ""
 "Your draft saved %(number)s %(interval)s ago is outdated, click 'Cancel' "
 "to discard or 'Load Draft', then 'Save' to merge conflicting updates."
 msgstr ""
 
-#: src/moin/items/__init__.py:1426
+#: src/moin/items/__init__.py:1460
 msgid "User profile"
 msgstr "Benutzer-Profil"
 
-#: src/moin/items/__init__.py:1427
+#: src/moin/items/__init__.py:1461
 msgid "User profile item (not implemented yet!)"
 msgstr ""
 
-#: src/moin/items/blog.py:33
+#: src/moin/items/blog.py:32
 msgid "Supertags (Categories)"
 msgstr "Super-Tags (Kategorien)"
 
-#: src/moin/items/blog.py:34
+#: src/moin/items/blog.py:33
 msgid "Ordered comma separated list of tags"
 msgstr "Sortierte komma-separierte Liste von Schlagworten"
 
-#: src/moin/items/blog.py:38
+#: src/moin/items/blog.py:37
 msgid "Title (required)"
 msgstr ""
 
-#: src/moin/items/blog.py:39
+#: src/moin/items/blog.py:38
 msgid "One-line title of the blog entry"
 msgstr "Einzeiliger Titel des Blog-Eintrags"
 
-#: src/moin/items/blog.py:40
+#: src/moin/items/blog.py:39
 msgid "Publication time (UTC)"
 msgstr "Zeitpunkt der Veröffentlichung (UTC)"
 
-#: src/moin/items/blog.py:46
+#: src/moin/items/blog.py:45
 msgid "Blog"
 msgstr "Blog"
 
-#: src/moin/items/blog.py:47
+#: src/moin/items/blog.py:46
 msgid "Blog item"
 msgstr "Blog-Item"
 
-#: src/moin/items/blog.py:101
+#: src/moin/items/blog.py:99
 msgid "Blog entry"
 msgstr "Blog-Eintrag"
 
-#: src/moin/items/blog.py:102
+#: src/moin/items/blog.py:100
 msgid "Blog entry item"
 msgstr "Blog-Eintrags-Item"
 
-#: src/moin/items/content.py:337 src/moin/items/ticket.py:135
+#: src/moin/items/content.py:338 src/moin/items/ticket.py:137
 msgid "Upload file:"
 msgstr "Datei hochladen:"
 
-#: src/moin/items/content.py:355
+#: src/moin/items/content.py:356
 msgid ""
 "The items have the same data hash code (that means they very likely have "
 "the same data)."
@@ -1667,124 +1678,124 @@ msgstr ""
 "Die Items haben die gleiche Hash-Code (das bedeutet, dass sie "
 "wahrscheinlich den selben Inhalt haben)."
 
-#: src/moin/items/content.py:357
+#: src/moin/items/content.py:358
 msgid "The items have different data."
 msgstr "Der Inhalt der Items ist verschieden."
 
-#: src/moin/items/content.py:369
+#: src/moin/items/content.py:370
 #, python-format
 msgid "Impossible to convert the data to the contenttype: %(contenttype)s"
 msgstr ""
 "Es ist nicht möglich, die Daten zu diesem Contenttype umzuwandeln: "
 "%(contenttype)s"
 
-#: src/moin/items/content.py:822
+#: src/moin/items/content.py:821
 msgid "Type your text here"
 msgstr "Tippen Sie hier"
 
-#: src/moin/items/content.py:1111
+#: src/moin/items/content.py:1109
 #, python-format
 msgid "Edit drawing %(filename)s (opens in new window)"
 msgstr "Zeichnung %(filename)s bearbeiten (öffnet in neuem Fenster)"
 
-#: src/moin/items/content.py:1115
+#: src/moin/items/content.py:1113
 #, python-format
 msgid "Clickable drawing: %(filename)s"
 msgstr "Anklickbare Zeichnung: %(filename)s"
 
-#: src/moin/items/ticket.py:97
+#: src/moin/items/ticket.py:98
 msgid "Find Tickets"
 msgstr "Tickets finden"
 
-#: src/moin/items/ticket.py:98 src/moin/items/ticket.py:109
+#: src/moin/items/ticket.py:99 src/moin/items/ticket.py:111
 #: src/moin/templates/ticket/advanced.html:24
 #: src/moin/templates/tickets.html:58
 msgid "Effort"
 msgstr "Aufwand"
 
-#: src/moin/items/ticket.py:99 src/moin/items/ticket.py:110
+#: src/moin/items/ticket.py:100 src/moin/items/ticket.py:112
 #: src/moin/templates/ticket/advanced.html:25
 #: src/moin/templates/tickets.html:59
 msgid "Difficulty"
 msgstr "Schwierigkeit"
 
-#: src/moin/items/ticket.py:100 src/moin/items/ticket.py:111
+#: src/moin/items/ticket.py:101 src/moin/items/ticket.py:113
 #: src/moin/templates/ticket/advanced.html:26
 #: src/moin/templates/tickets.html:60
 msgid "Severity"
 msgstr "Schweregrad"
 
-#: src/moin/items/ticket.py:101 src/moin/items/ticket.py:112
+#: src/moin/items/ticket.py:102 src/moin/items/ticket.py:114
 #: src/moin/templates/ticket/advanced.html:27
 #: src/moin/templates/tickets.html:61
 msgid "Priority"
 msgstr "Priorität"
 
-#: src/moin/items/ticket.py:103 src/moin/items/ticket.py:114
+#: src/moin/items/ticket.py:104 src/moin/items/ticket.py:116
 msgid "Assigned To"
 msgstr "Zugewiesen an"
 
-#: src/moin/items/ticket.py:104
+#: src/moin/items/ticket.py:105
 msgid "Author"
 msgstr "Autor"
 
-#: src/moin/items/ticket.py:108
+#: src/moin/items/ticket.py:110
 msgid "One-line summary"
 msgstr "Einzeilige Zusammenfassung"
 
-#: src/moin/items/ticket.py:115
+#: src/moin/items/ticket.py:117
 msgid "Superseded By"
 msgstr "Ersetzt von"
 
-#: src/moin/items/ticket.py:116
+#: src/moin/items/ticket.py:118
 msgid "Depends On"
 msgstr "Hängt ab von"
 
-#: src/moin/items/ticket.py:120
+#: src/moin/items/ticket.py:122
 msgid "Supersedes"
 msgstr "Ersetzt"
 
-#: src/moin/items/ticket.py:121
+#: src/moin/items/ticket.py:123
 msgid "Required By"
 msgstr "Benötigt von"
 
-#: src/moin/items/ticket.py:122
+#: src/moin/items/ticket.py:124
 msgid "Subscribers"
 msgstr "Abonnenten"
 
-#: src/moin/items/ticket.py:134
+#: src/moin/items/ticket.py:136
 msgid "Message"
 msgstr "Nachricht"
 
-#: src/moin/items/ticket.py:146
+#: src/moin/items/ticket.py:148
 msgid "Submit ticket"
 msgstr "Ticket absenden"
 
-#: src/moin/items/ticket.py:166
+#: src/moin/items/ticket.py:168
 msgid "Update ticket"
 msgstr "Ticket aktualisieren"
 
-#: src/moin/items/ticket.py:167 src/moin/templates/ticket/modify.html:39
+#: src/moin/items/ticket.py:169 src/moin/templates/ticket/modify.html:39
 msgid "Update & reopen ticket"
 msgstr "Ticket aktualisieren & wieder eröffnen"
 
-#: src/moin/items/ticket.py:168 src/moin/templates/ticket/modify.html:41
+#: src/moin/items/ticket.py:170 src/moin/templates/ticket/modify.html:41
 msgid "Update & close ticket"
 msgstr "Ticket aktualisieren & schließen"
 
-#: src/moin/items/ticket.py:189
+#: src/moin/items/ticket.py:191
 msgid "{key} changed from {original} to {new}"
 msgstr ""
 
-#: src/moin/items/ticket.py:214
+#: src/moin/items/ticket.py:216
 msgid "{author} wrote on {timestamp}:"
 msgstr ""
 
-#: src/moin/items/ticket.py:344
+#: src/moin/items/ticket.py:346
 msgid "Ticket"
 msgstr "Ticket"
 
-#: src/moin/items/ticket.py:345
+#: src/moin/items/ticket.py:347
 msgid "Ticket item"
 msgstr "Ticket-Item"
 
@@ -1812,7 +1823,7 @@ msgstr "Lexer-Alias-Namen"
 msgid "File Patterns"
 msgstr "Datei-Muster"
 
-#: src/moin/macros/Icon.py:27 src/moin/macros/ShowIcons.py:35
+#: src/moin/macros/Icon.py:27
 msgid "Icon not rendered, verify name is valid"
 msgstr ""
 
@@ -1823,110 +1834,109 @@ msgid ""
 "(arguments, if more than one, must be comma-separated)."
 msgstr ""
 
-#: src/moin/macros/ItemList.py:95
+#: src/moin/macros/ItemList.py:96
 msgid "ItemList macro: The key's value must be bracketed by matching quotes."
 msgstr ""
 
-#: src/moin/macros/ItemList.py:110
+#: src/moin/macros/ItemList.py:111
 #, python-format
 msgid "ItemList macro: The value must be \"True\" or \"False\". (got \"%s\")"
 msgstr ""
 
-#: src/moin/macros/ItemList.py:116
+#: src/moin/macros/ItemList.py:117
 #, python-format
 msgid "ItemList macro: Unrecognized key \"%s\"."
 msgstr ""
 
 #: src/moin/macros/ItemList.py:128
-#, python-format
-msgid "ItemList macro: The specified item \"%s\" does not exist."
+msgid "Item does not exist or read access blocked by ACLs: {0}"
 msgstr ""
 
-#: src/moin/macros/ItemList.py:136
+#: src/moin/macros/ItemList.py:139
 msgid "ItemList macro: Error in regex {0!r}: {1}"
 msgstr ""
 
-#: src/moin/macros/ItemList.py:144
+#: src/moin/macros/ItemList.py:147
 msgid "<ItemList macro: No matching items were found.>"
 msgstr ""
 
-#: src/moin/macros/MailTo.py:32
+#: src/moin/macros/MailTo.py:31
 msgid "MailTo: invalid format, try: <<MailTo(user AT example DOT org, write me)>>"
 msgstr ""
 
-#: src/moin/macros/MonthCalendar.py:208
+#: src/moin/macros/MonthCalendar.py:209
 msgid "January"
 msgstr "Januar"
 
-#: src/moin/macros/MonthCalendar.py:208
+#: src/moin/macros/MonthCalendar.py:209
 msgid "February"
 msgstr "Februar"
 
-#: src/moin/macros/MonthCalendar.py:208
+#: src/moin/macros/MonthCalendar.py:209
 msgid "March"
 msgstr "März"
 
-#: src/moin/macros/MonthCalendar.py:208
+#: src/moin/macros/MonthCalendar.py:209
 msgid "April"
 msgstr "April"
 
-#: src/moin/macros/MonthCalendar.py:209
+#: src/moin/macros/MonthCalendar.py:210
 msgid "May"
 msgstr "Mai"
 
-#: src/moin/macros/MonthCalendar.py:209
+#: src/moin/macros/MonthCalendar.py:210
 msgid "June"
 msgstr "Juni"
 
-#: src/moin/macros/MonthCalendar.py:209
+#: src/moin/macros/MonthCalendar.py:210
 msgid "July"
 msgstr "Juli"
 
-#: src/moin/macros/MonthCalendar.py:209
+#: src/moin/macros/MonthCalendar.py:210
 msgid "August"
 msgstr "August"
 
-#: src/moin/macros/MonthCalendar.py:210
+#: src/moin/macros/MonthCalendar.py:211
 msgid "September"
 msgstr "September"
 
-#: src/moin/macros/MonthCalendar.py:210
+#: src/moin/macros/MonthCalendar.py:211
 msgid "October"
 msgstr "Oktober"
 
-#: src/moin/macros/MonthCalendar.py:210
+#: src/moin/macros/MonthCalendar.py:211
 msgid "November"
 msgstr "November"
 
-#: src/moin/macros/MonthCalendar.py:210
+#: src/moin/macros/MonthCalendar.py:211
 msgid "December"
 msgstr "Dezember"
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Mon"
 msgstr "Mo"
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Tue"
 msgstr "Di"
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Wed"
 msgstr "Mi"
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Thu"
 msgstr "Do"
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Fri"
 msgstr "Fr"
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Sat"
 msgstr "Sa"
 
-#: src/moin/macros/MonthCalendar.py:214 src/moin/macros/MonthCalendar.py:217
+#: src/moin/macros/MonthCalendar.py:215 src/moin/macros/MonthCalendar.py:218
 msgid "Sun"
 msgstr "So"
 
@@ -1938,31 +1948,31 @@ msgstr ""
 msgid "Result"
 msgstr "Ergebnis"
 
-#: src/moin/macros/_base.py:119
+#: src/moin/macros/_base.py:123
 msgid "\"ItemTitle\" is not implemented yet."
 msgstr ""
 
-#: src/moin/macros/_base.py:121
+#: src/moin/macros/_base.py:125
 #, python-format
 msgid "Unrecognized display value \"%s\"."
 msgstr ""
 
-#: src/moin/mail/sendmail.py:55
+#: src/moin/mail/sendmail.py:53
 msgid ""
 "Contact administrator: cannot send password recovery e-mail because mail "
 "configuration is incomplete."
 msgstr ""
 
-#: src/moin/mail/sendmail.py:63
+#: src/moin/mail/sendmail.py:61
 msgid "No recipients, nothing to do"
 msgstr "Keine Empfänger, nichts zu tun"
 
-#: src/moin/mail/sendmail.py:121
+#: src/moin/mail/sendmail.py:119
 #, python-format
 msgid "Connection to mailserver '%(server)s' failed: %(reason)s"
 msgstr "Verbindung zum Mailserver '%(server)s' fehlgeschlagen: %(reason)s"
 
-#: src/moin/mail/sendmail.py:127
+#: src/moin/mail/sendmail.py:125
 msgid "Mail sent successfully"
 msgstr "E-Mail wurde erfolgreich versandt"
 
@@ -1974,6 +1984,14 @@ msgstr "Such-Anfrage ist zu kurz."
 #: src/moin/templates/search.html:21
 msgid "Search"
 msgstr "Suche"
+
+#: src/moin/storage/middleware/indexing.py:1215
+msgid "Error: metadata validation failed, invalid field value(s) = {0}"
+msgstr ""
+
+#: src/moin/storage/middleware/indexing.py:1232
+msgid "Error: nothing changed. Data unicode validation failed."
+msgstr ""
 
 #: src/moin/templates/404.html:12
 msgid "Not Found"
@@ -2009,62 +2027,45 @@ msgstr ""
 msgid "Common words omitted from query:"
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:48
-msgid "Input suggestions : "
-msgstr ""
-
-#: src/moin/templates/ajaxsearch.html:53
-msgid "Name term suggestions : "
-msgstr "Vorschläge für Namens-Terme : "
-
-#: src/moin/templates/ajaxsearch.html:56
-msgid "Content term suggestions : "
-msgstr "Vorschläge für Inhalts-Terme : "
-
-#: src/moin/templates/ajaxsearch.html:63
+#: src/moin/templates/ajaxsearch.html:50
 #, python-format
 msgid ""
 "%(found)d items found, %(items_filtered)d more items filtered by content "
 "types."
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:65
+#: src/moin/templates/ajaxsearch.html:52
 #, python-format
 msgid "%(result_len)d items found."
 msgstr "%(result_len)d Items gefunden."
 
-#: src/moin/templates/ajaxsearch.html:95
+#: src/moin/templates/ajaxsearch.html:82
 msgid "MATCHED TERMS:"
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:102
+#: src/moin/templates/ajaxsearch.html:89
 #, python-format
 msgid ""
 "REVISION: %(revid)s, SIZE: %(size)s, MODIFIED: %(mtime)s, CONTENT TYPE: "
 "%(type)s, SCORE: %(score)s"
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:107
+#: src/moin/templates/ajaxsearch.html:94
 #, python-format
 msgid "COMMENT: %(content)s"
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:110
-#, python-format
-msgid "SUMMARY: %(content)s"
-msgstr "Zusammenfassung: %(content)s"
-
-#: src/moin/templates/ajaxsearch.html:113
+#: src/moin/templates/ajaxsearch.html:97
 #, python-format
 msgid "TAGS: %(content)s"
 msgstr ""
 
-#: src/moin/templates/ajaxsearch.html:116
+#: src/moin/templates/ajaxsearch.html:100
 #, python-format
 msgid "CONTENT: %(content)s"
 msgstr "INHALT: %(content)s"
 
-#: src/moin/templates/ajaxsearch.html:125
+#: src/moin/templates/ajaxsearch.html:109
 #, python-format
 msgid "%(count)d items are not shown because read permission was denied."
 msgstr "%(count)d Items werden wegen fehlender Leseberechtigungen nicht angezeigt."
@@ -2458,13 +2459,13 @@ msgstr "Item-Ansichten"
 
 #: src/moin/templates/itemviews.html:86 src/moin/templates/ticket/base.html:26
 #: src/moin/templates/ticket/ticket_macros.html:101
-#: src/moin/themes/__init__.py:232
+#: src/moin/themes/__init__.py:233
 msgid "Remove Link"
 msgstr "Link entfernen"
 
 #: src/moin/templates/itemviews.html:88 src/moin/templates/ticket/base.html:28
 #: src/moin/templates/ticket/ticket_macros.html:103
-#: src/moin/themes/__init__.py:230
+#: src/moin/themes/__init__.py:231
 msgid "Add Link"
 msgstr "Link hinzufügen"
 
@@ -3076,7 +3077,7 @@ msgstr "Zugriff verweigert"
 msgid "You are not allowed to access this resource."
 msgstr "Sie haben nicht die notwendigen Rechte, um auf diese Ressource zuzugreifen"
 
-#: src/moin/themes/__init__.py:592
+#: src/moin/themes/__init__.py:593
 msgid "anonymous"
 msgstr "anonym"
 
@@ -3096,106 +3097,115 @@ msgstr "Anzeige-Optionenen"
 msgid "Item Actions"
 msgstr "Item-Aktionen"
 
-#: src/moin/utils/edit_locking.py:252
+#: src/moin/utils/edit_locking.py:267
 #, python-format
 msgid ""
 "Edit lock for %(user_name)s timed out %(number)s %(interval)s ago, click "
-"Cancel to yield more time,\n"
-"                             clicking Save may require %(user_name)s to "
-"resolve conflicting edits."
+"'Cancel' to yield more time, clicking 'Save' may require %(user_name)s to"
+" resolve conflicting edits."
 msgstr ""
+"Die Sperre für %(user_name)s ist vor %(number)s %(interval) abgelaufen, klicken "
+"Sie auf 'Abbrechen', um mehr Zeit zu erhalten. Wenn Sie auf 'Speichern' klicken, "
+"muss %(user_name)s Konflikte zwischen den Bearbeitungen beheben."
 
-#: src/moin/utils/edit_locking.py:260
+#: src/moin/utils/edit_locking.py:276
 #, python-format
 msgid ""
 "Item '%(item_name)s' is locked by %(user_name)s. Try again in %(number)s "
 "%(interval)s."
 msgstr ""
+"Item '%(item_name)s' ist durch %(user_name)s gesperrt. Versuchen Sie es in "
+"%(number)s %(interval)s erneut."
 
-#: src/moin/utils/edit_locking.py:272
+#: src/moin/utils/edit_locking.py:288
 #, python-format
 msgid ""
 "Someone else updated '%(item_name)s' after your edit lock timed out. If "
-"you click 'Save',\n"
-"                                 conflicting changes must be manually "
-"merged. Click 'Cancel' to discard changes."
+"you click 'Save', conflicting changes must be manually merged. Click "
+"'Cancel' to discard changes."
 msgstr ""
+"Jemand anderes hat '%(item_name)s' geändert nachdem Ihre Schreibsperre abgelaufen "
+"ist. Wenn Sie 'Speichern' klicken, müssen Bearbeitungskonflikte manuell behoben "
+"werden. Klicken Sie auf 'Abbrechen' um die Änderungen zu verwerfen."
 
-#: src/moin/utils/edit_locking.py:303
+#: src/moin/utils/edit_locking.py:322
 #, python-format
 msgid ""
 "Item '%(item_name)s' is locked by %(user_name)s. Edit lock error, check "
 "Item History to verify no changes were lost."
 msgstr ""
+"Item '%(item_name)s' ist durch %(user_name)s gesperrt. Fehler der Schreibsperre, "
+"prüfen Sie die Historie um sicherzustellen, dass keine Änderungen verloren "
+"gegangen sind."
 
-#: src/moin/utils/notifications.py:49
+#: src/moin/utils/notifications.py:47
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been created by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:50
+#: src/moin/utils/notifications.py:48
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been modified by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:51
+#: src/moin/utils/notifications.py:49
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been renamed by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:52
+#: src/moin/utils/notifications.py:50
 #, python-format
 msgid "The '%(fqname)s' item on '%(wiki_name)s' has been copied by %(user_name)s:"
 msgstr "Das '%(fqname)s' Item von '%(wiki_name)s' wurde von %(user_name)s kopiert:"
 
-#: src/moin/utils/notifications.py:53
+#: src/moin/utils/notifications.py:51
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been converted by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:54
+#: src/moin/utils/notifications.py:52
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been reverted by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:55
+#: src/moin/utils/notifications.py:53
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been deleted by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:56
+#: src/moin/utils/notifications.py:54
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has one revision destroyed by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:57
+#: src/moin/utils/notifications.py:55
 #, python-format
 msgid ""
 "The '%(fqname)s' item on '%(wiki_name)s' has been destroyed by "
 "%(user_name)s:"
 msgstr ""
 
-#: src/moin/utils/notifications.py:205
+#: src/moin/utils/notifications.py:210
 msgid ""
 "An error has occurred, the current or prior revision of this item may be "
 "corrupt."
 msgstr ""
 
-#: src/moin/utils/notifications.py:212
+#: src/moin/utils/notifications.py:217
 #, python-format
 msgid "[%(moin_name)s] Update of \"%(fqname)s\" by %(user_name)s"
 msgstr ""
@@ -3270,31 +3280,30 @@ msgstr "Argument \"%(name)s\" wird benötigt"
 msgid "No argument named \"%(name)s\""
 msgstr "Kein Argument mit dem Namen \"%(name)s\""
 
-#: src/moin/utils/show_time.py:25
+#: src/moin/utils/show_time.py:23
 msgid "seconds"
 msgstr "Sekunden"
 
-#: src/moin/utils/show_time.py:27
+#: src/moin/utils/show_time.py:25
 msgid "minutes"
 msgstr "Minuten"
 
-#: src/moin/utils/show_time.py:29
+#: src/moin/utils/show_time.py:27
 msgid "hours"
 msgstr "Stunden"
 
-#: src/moin/utils/show_time.py:31
+#: src/moin/utils/show_time.py:29
 msgid "days"
 msgstr "Tage"
 
-#: src/moin/utils/show_time.py:33
+#: src/moin/utils/show_time.py:31
 msgid "weeks"
 msgstr "Wochen"
 
-#: src/moin/utils/show_time.py:35
+#: src/moin/utils/show_time.py:33
 msgid "months"
 msgstr "Monate"
 
-#: src/moin/utils/show_time.py:36
+#: src/moin/utils/show_time.py:34
 msgid "years"
 msgstr "Jahre"
-

--- a/src/moin/utils/edit_locking.py
+++ b/src/moin/utils/edit_locking.py
@@ -265,8 +265,8 @@ class Edit_Utils:
                 if wait_time < 0.0:
                     # some other user's lock has timed out, give one-time alert user about potential future conflict,
                     msg = L_(
-                        """Edit lock for %(user_name)s timed out %(number)s %(interval)s ago, click Cancel
-                        to yield more time, clicking Save may require %(user_name)s to resolve conflicting edits.""",
+                        "Edit lock for %(user_name)s timed out %(number)s %(interval)s ago, click 'Cancel' "
+                        "to yield more time, clicking 'Save' may require %(user_name)s to resolve conflicting edits.",
                         user_name=u_name, number=number, interval=interval)
                     self.update_editlock()
                     self.put_draft(None)
@@ -285,9 +285,9 @@ class Edit_Utils:
                     u_name, i_id, i_name, rev_number, save_time, rev_id = draft
                     if self.rev_number > rev_number:
                         # current user timed out, then other user updated and saved
-                        msg = L_("""Someone else updated '%(item_name)s' after your edit lock timed out.
-                                 If you click 'Save', conflicting changes must be manually merged.
-                                 Click 'Cancel' to discard changes.""",
+                        msg = L_("Someone else updated '%(item_name)s' after your edit lock timed out. "
+                                 "If you click 'Save', conflicting changes must be manually merged. "
+                                 "Click 'Cancel' to discard changes.",
                                  item_name=self.item_name)
                     self.cursor.execute('''INSERT INTO editlock(item_id, item_name, user_name, timeout)
                                       VALUES(?,?,?,?)''', (self.item_id, self.item_name, self.user_name, timeout))


### PR DESCRIPTION
Removed blanks and linefeed in utils/edit_locking.py.
Updated catalog using
```
python setup.py extract_messages
python setup.py update_catalog -l de
```
and added some German translations related to edit locking.
Other languages should be supported by native speakers. 

Related to #651.