### PR TITLE
Fix some RTD warnings and built-in server options in serve.rst

### DIFF
--- a/docs/admin/configure.rst
+++ b/docs/admin/configure.rst
@@ -1217,7 +1217,7 @@ Call it as follows::
                               hierarchiv=False, ),
     )
 
-The *_acl variables are dictionaries specifying the ACLs for
+The `*_acl` variables are dictionaries specifying the ACLs for
 each namespace. See the docs about ACLs.
 
 The `uri` depends on the kind of storage backend and stores you want to use,

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -13,16 +13,19 @@ we won't go into details:
   for updating the installed software with security fixes or to future releases.
 
   E.g. on Debian/Ubuntu Linux
+
 ::
 
  apt install moin2
 
 - Install from PyPI:
+
 ::
 
  pip install moin2
 
 - Install from Test Python Package Index as long as moin2 is not officially released:
+
 ::
 
   pip install --pre --index-url https://test.pypi.org/simple --extra-index-url https://pypi.org/simple moin

--- a/docs/admin/serve.rst
+++ b/docs/admin/serve.rst
@@ -54,12 +54,12 @@ Using the built-in server for production
 ----------------------------------------
 
 .. caution:: Using the built-in server for public wikis is not recommended. Should you
- wish to do so, turn off the werkzeug debugger and auto reloader by passing the --debugger
- and --reload flags. The wikiconfig.py settings of `DEBUG = False` and `TESTING = False` are
+ wish to do so, turn off the werkzeug debugger and auto reloader by passing the --no-debugger
+ and --no-reload flags. The wikiconfig.py settings of `DEBUG = False` and `TESTING = False` are
  ignored by the built-in server.
- See Werkzeug docs for more information.::
+ See Werkzeug docs for more information::
 
- moin run --host 0.0.0.0 --port 80 --debugger --reload
+  moin run --host 0.0.0.0 --port 80 --no-debugger --no-reload
 
 
 External Web Server (advanced)

--- a/docs/user/moinwiki.rst
+++ b/docs/user/moinwiki.rst
@@ -156,7 +156,7 @@ refer to a sibling of the current item.
 +-------------------------------------------+---------------------------------------------+---------------------------------------------+
 | ``[[/filename.txt]]``                     | `/filename.txt </filename.txt>`_            | Link to a sub-item called Filename.txt      |
 +-------------------------------------------+---------------------------------------------+---------------------------------------------+
-| ``[[users/JoeDoe]]``                      | `users/JoeDoe`_                             | Link to a user's home item in user namespace|
+| ``[[users/JoeDoe]]``                      | `users/JoeDoe <users/JoeDoe>`_              | Link to a user's home item in user namespace|
 +-------------------------------------------+---------------------------------------------+---------------------------------------------+
 | ``[[AltItem||class="redirect"]]``         | `AltItem is displayed immediately`          | Type /+modify/<item> in address bar to edit |
 +-------------------------------------------+---------------------------------------------+---------------------------------------------+


### PR DESCRIPTION
Fixes some errors and warnings from the RTD build logs.
Correction of built-in server options in serve.rst. Please check if I am right.

Related to #1440.