### PR TITLE
Auto Scroll fails, data-lineno attribute missing, fixes #1449

### DIFF
--- a/src/moin/app.py
+++ b/src/moin/app.py
@@ -295,12 +295,9 @@ def before_wiki():
             flaskg.add_lineno_attr = False
         else:
             setup_jinja_env()
-            flaskg.add_lineno_attr = request.user_agent and flaskg.user.edit_on_doubleclick
-
+            flaskg.add_lineno_attr = request.headers.get('User-Agent', None) and flaskg.user.edit_on_doubleclick
     finally:
         flaskg.clock.stop('init')
-
-    # if return value is not None, it is the final response
 
 
 def teardown_wiki(response):


### PR DESCRIPTION
As of werkzeug 2.0, the parsed data of request.user_agent has been deprecated. request.headers.get('User-Agent' returns a string if user-agent is a browser, none if a command or test.