### PR TITLE
docbook, html do not show Item Links in metadata #1259

### DIFF
--- a/src/moin/converters/_tests/test_docbook_in.py
+++ b/src/moin/converters/_tests/test_docbook_in.py
@@ -282,7 +282,7 @@ class TestConverter(Base):
         # Normal link, with conversion of all the xlink attributes
         ('<article><para><link xlink:href="http:test" xlink:title="title">link</link></para></article>',
          # <page><body><div html:class="article"><p><a xlink:href="http:test" xlink:title="title">link</a></p></div></body></page>
-         '/page/body/div/p/a[@xlink:href="http:test"][@xlink:title="title"][text()="link"]'),
+         '/page/body/div/p/a[@xlink:href="http:test"][@html:title="title"][text()="link"]'),
         # Old link from DocBook v.4.X for backward compatibility
         ('<article><para><ulink url="http:test">link</ulink></para></article>',
          # <page><body><div html:class="article"><p><a xlink:href="http:test">link</a></p></div></body></page>
@@ -290,7 +290,7 @@ class TestConverter(Base):
         # Normal link, with linkend attribute
         ('<article><para><link linkend="anchor">link</link></para></article>',
          # <page><body><div html:class="article"><p><a xlink:href="#anchor">link</a></p></div></body></page>
-         '/page/body/div/p/a[@xlink:href="#anchor"][text()="link"]'),
+         '/page/body/div/p/a[@xlink:href="wiki.local:#anchor"][text()="link"]'),
         # OLINK
         ('<article><para><olink targetdoc="uri" targetptr="anchor">link</olink></para></article>',
          # <page><body><div html:class="article"><para><a xlink:href="uri#anchor">link</a></para></div></body></page>

--- a/src/moin/converters/docbook_in.py
+++ b/src/moin/converters/docbook_in.py
@@ -683,13 +683,17 @@ class Converter:
         the anchors.
         """
         attrib = {}
-        for key, value in element.attrib.items():
-            if key.uri == xlink and allowed_uri_scheme(value):
-                attrib[key] = value
+        if element.attrib.get(xlink.title_):
+            attrib[html.title_] = element.attrib.get(xlink.title_)
+        href = element.attrib.get(xlink.href)
         linkend = element.get('linkend')
         if linkend:
-            attrib[xlink.href] = ''.join(['#', linkend])
-        return self.new_copy(moin_page.a, element, depth, attrib=attrib)
+            href = ''.join(['#', linkend])
+        iri = Iri(href)
+        if iri.scheme is None:
+            iri.scheme = 'wiki.local'
+        attrib[xlink.href] = iri
+        return self.new_copy(moin_page.a, element, depth, attrib)
 
     def visit_docbook_literallayout(self, element, depth):
         """


### PR DESCRIPTION
TODO: help-en items that do not show Item Links must be modified and saved.