### PR TITLE
WIP: add feature to enable selected content types

### DIFF
--- a/src/moin/items/_tests/test_Content.py
+++ b/src/moin/items/_tests/test_Content.py
@@ -26,6 +26,8 @@ from functools import reduce
 class TestContent:
     """ Test for arbitrary content """
 
+    @pytest.mark.skipif(len(Content.enabled_content_types) > 0 and 'PNG' not in Content.enabled_content_types,
+                        reason="'PNG' content_type disabled")
     def testClassFinder(self):
         for contenttype, ExpectedClass in [
                 ('application/x-foobar', Binary),
@@ -71,6 +73,8 @@ class TestTarItems:
     tests for the container items
     """
 
+    @pytest.mark.skipif(len(Content.enabled_content_types) > 0 and 'TAR' not in Content.enabled_content_types,
+                        reason="'TAR' content_type disabled")
     def testCreateContainerRevision(self):
         """
         creates a container and tests the content saved to the container
@@ -88,6 +92,8 @@ class TestTarItems:
         assert tf_names == members
         assert item.content.get_member('example1.txt').read() == filecontent
 
+    @pytest.mark.skipif(len(Content.enabled_content_types) > 0 and 'TAR' not in Content.enabled_content_types,
+                        reason="'TAR' content_type disabled")
     def testRevisionUpdate(self):
         """
         creates two revisions of a container item
@@ -109,6 +115,8 @@ class TestTarItems:
 class TestZipMixin:
     """ Test for zip-like items """
 
+    @pytest.mark.skipif(len(Content.enabled_content_types) > 0 and 'ZIP' not in Content.enabled_content_types,
+                        reason="'ZIP' content_type disabled")
     def test_put_member(self):
         item_name = 'Zip_file'
         item = Item.create(item_name, itemtype=ITEMTYPE_DEFAULT, contenttype='application/zip')
@@ -156,6 +164,8 @@ class TestTransformableBitmapImage:
             # no PIL
             pass
 
+    @pytest.mark.skipif(len(Content.enabled_content_types) > 0 and 'JPEG' not in Content.enabled_content_types,
+                        reason="'JPEG' content_type disabled")
     def test__render_data_diff_text(self):
         item_name = 'image_Item'
         item = Item.create(item_name)

--- a/src/moin/items/_tests/test_Item.py
+++ b/src/moin/items/_tests/test_Item.py
@@ -10,6 +10,7 @@ import pytest
 
 from moin._tests import become_trusted, update_item
 from moin.items import Item, NonExistent, IndexEntry, MixedIndexEntry
+from moin.items.content import Content
 from moin.utils.interwiki import CompositeName
 from moin.constants.keys import (ITEMTYPE, CONTENTTYPE, NAME, NAME_OLD, COMMENT,
                                  ADDRESS, TRASH, ITEMID, NAME_EXACT, SIZE, MTIME,
@@ -126,6 +127,9 @@ class TestItem:
         assert saved_meta[COMMENT] == comment
         assert saved_data == b''
 
+    @pytest.mark.skipif(len(Content.enabled_content_types) > 0 and
+                        not all(i in Content.enabled_content_types for i in ['JPEG', 'Plain Text']),
+                        reason="'JPEG' or 'Plain Text' content_type disabled")
     def testIndex(self):
         # create a toplevel and some sub-items
         basename = 'Foo'

--- a/src/moin/items/content.py
+++ b/src/moin/items/content.py
@@ -1,10 +1,11 @@
-# Copyright: 2012 MoinMoin:CheerXiao
 # Copyright: 2009 MoinMoin:ThomasWaldmann
 # Copyright: 2009-2011 MoinMoin:ReimarBauer
 # Copyright: 2009 MoinMoin:ChristopherDenter
 # Copyright: 2008,2009 MoinMoin:BastianBlank
 # Copyright: 2010 MoinMoin:ValentinJaniaut
 # Copyright: 2010 MoinMoin:DiogenesAugusto
+# Copyright: 2012 MoinMoin:CheerXiao
+# Copyright: 2023 MoinMoin:UlrichB
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -78,6 +79,8 @@ logging = log.getLogger(__name__)
 
 COLS = 80
 ROWS_DATA = 20
+# ENABLED_CONTENT_TYPES = []  # Allow all content types
+ENABLED_CONTENT_TYPES = ['MoinMoin', 'PDF', 'PNG', 'JPEG',]  # restrict content types
 
 
 class RegistryContent(RegistryBase):
@@ -125,9 +128,11 @@ content_registry = RegistryContent([
 
 
 def register(cls):
-    content_registry.register(RegistryContent.Entry(cls._factory, Type(cls.contenttype),
-                                                    cls.default_contenttype_params, cls.display_name,
-                                                    cls.ingroup_order, RegistryContent.PRIORITY_MIDDLE), cls.group)
+    if not cls.display_name or len(ENABLED_CONTENT_TYPES) == 0 or cls.display_name in ENABLED_CONTENT_TYPES:
+        logging.debug("register contenttype {0} in group {1}".format(cls.display_name, cls.group))
+        content_registry.register(RegistryContent.Entry(cls._factory, Type(cls.contenttype),
+                                                        cls.default_contenttype_params, cls.display_name,
+                                                        cls.ingroup_order, RegistryContent.PRIORITY_MIDDLE), cls.group)
     return cls
 
 

--- a/src/moin/items/content.py
+++ b/src/moin/items/content.py
@@ -79,8 +79,8 @@ logging = log.getLogger(__name__)
 
 COLS = 80
 ROWS_DATA = 20
-# ENABLED_CONTENT_TYPES = []  # Allow all content types
-ENABLED_CONTENT_TYPES = ['MoinMoin', 'PDF', 'PNG', 'JPEG',]  # restrict content types
+ENABLED_CONTENT_TYPES = []  # Allow all content types
+# ENABLED_CONTENT_TYPES = ['MoinMoin', 'PDF', 'PNG', 'JPEG',]  # example: restrict content types
 
 
 class RegistryContent(RegistryBase):
@@ -154,6 +154,7 @@ class Content:
     display_name = None
     group = GROUP_OTHER
     ingroup_order = 0
+    enabled_content_types = ENABLED_CONTENT_TYPES
 
     @classmethod
     def _factory(cls, *args, **kw):

--- a/src/moin/templates/modify_select_contenttype.html
+++ b/src/moin/templates/modify_select_contenttype.html
@@ -16,6 +16,7 @@
     </p>
     <table id="moin-create-table" class="zebra">
         {% for group in group_names %}
+        {% if groups[group]|length > 0 %}
             <tr>
                 <th>{{ group }}</th>
             </tr>
@@ -26,6 +27,7 @@
                     {% endfor %}
                 </td>
             </tr>
+        {% endif %}
         {% endfor %}
     </table>
 


### PR DESCRIPTION
This is a first draft for #1500.

I am still looking for a solution to move the `ENABLED_CONTENT_TYPES` variable into the configuration. It seems to be a problem because content_type registration is done before configuration is available.

I look forward to your comments and advice.
