### PR TITLE
markdown: use wikilink extension

### DIFF
--- a/docs/user/markdown.rst
+++ b/docs/user/markdown.rst
@@ -165,6 +165,22 @@ Inline links use the form: ::
 **reST NOTE**: Links with title attributes and images as links are not supported in reST.
 The internal links above are broken.
 
+Wikilinks
+---------
+
+Wikilinks use the form: ::
+
+    [[PageName]]
+
+===========================================   ===============================================
+ **Markup**                                    **Result**
+===========================================   ===============================================
+ [[Page]]                                      `Page <http:Page>`_
+ [[Page/Subpage]]                              `Subpage <http:Page/Subpage>`_
+===========================================   ===============================================
+
+This features uses the `mdx_wikilink_plus <https://github.com/neurobin/mdx_wikilink_plus>`_ extension.
+
 Reference Links
 ---------------
 

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup_args = dict(
         'blinker>=1.5',  # event signalling (e.g. for change notification trigger)
         'docutils>=0.18.1',  # reST markup processing
         'Markdown>=3.4.1',  # Markdown markup processing
+        'mdx_wikilink_plus>=1.4.1',  # Markdown Wikilinks extension
         'Flask<2.3.0',  # micro framework
         'Flask-Babel>=3.0.0',  # i18n support
         'Flask-Caching>=1.2.0',  # caching support

--- a/src/moin/converters/_tests/test_markdown_in.py
+++ b/src/moin/converters/_tests/test_markdown_in.py
@@ -143,6 +143,16 @@ class TestConverter:
     def test_table(self, input, output):
         self.do(input, output)
 
+    data = [('[[Bracketed]]',
+             '<p><a xlink:href="wiki.local:Bracketed">Bracketed</a></p>'),
+            ('[[Main/sub]]',  # check if label is kept lower case, check if slash in link is detected
+             '<p><a xlink:href="wiki.local:Main/sub">sub</a></p>')]
+
+    @pytest.mark.parametrize('input,output', data)
+    def test_wikilinks(self, input, output):
+        """ Test the Wikilinks extension: https://python-markdown.github.io/extensions/wikilinks/"""
+        self.do(input, output)
+
     def serialize_strip(self, elem, **options):
         result = serialize(elem, namespaces=self.namespaces, **options)
         return self.output_re.sub('', result)

--- a/src/moin/converters/markdown_in.py
+++ b/src/moin/converters/markdown_in.py
@@ -530,9 +530,18 @@ class Converter:
 
     def __init__(self):
         self.markdown = Markdown(extensions=[
-            ExtraExtension(),
-            CodeHiliteExtension(guess_lang=False),
-        ])
+                ExtraExtension(),
+                CodeHiliteExtension(guess_lang=False),
+                'mdx_wikilink_plus',
+            ],
+            extension_configs={
+                'mdx_wikilink_plus': {
+                    'html_class': None,
+                    'image_class': None,
+                    'label_case': 'none',  # do not automatically CamelCase the label, keep it untouched
+                }
+            },
+        )
 
     @classmethod
     def _factory(cls, input, output, **kw):


### PR DESCRIPTION
For easier internal wiki links, activate the wikilink extension https://github.com/neurobin/mdx_wikilink_plus Previously, an internal link had to be: `[OtherPage](OtherPage)` now, this works too `[[OtherPage]]` and `[[Page/Subpage]]`

The wikilink extension of python-markdown itself (https://python-markdown.github.io/extensions/wikilinks/) is minimal and does not handle links with slashes in their name, so no subpages.

The complexity of creating the internal wiki links was/is one of the blockers of our upgrade to Moin 2.
The chosen wikilinks extension is listed at https://github.com/Python-Markdown/markdown/wiki/Third-Party-Extensions and did fit the purpose best. Unfortunately, upstream made clear multiple times that their wikilink extension will stay as it is and not be extended (e.g. here https://github.com/Python-Markdown/markdown/issues/217)