### PR TITLE
Markdown: Enable Admonition extension

### DIFF
--- a/docs/user/markdown.rst
+++ b/docs/user/markdown.rst
@@ -717,3 +717,39 @@ Footnotes [1]_ have a label [#label]_ and a definition [#DEF]_.
 .. [#label] A footnote on "label"
 
 .. [#DEF] The footnote for definition
+
+Admonition
+----------
+
+The `Admonition extension <https://python-markdown.github.io/extensions/admonition/>`_ adds `rST-style <http://docutils.sourceforge.net/docs/ref/rst/directives.html#specific-admonitions>`_ admonitions to Markdown.
+
+**Syntax**: ::
+
+    !!! type "optional explicit title within double quotes"
+        Any number of other indented markdown elements.
+
+        This is the second paragraph.
+
+If you don’t want a title, use a blank string "".
+
+The following types are supported:
+
+* attention
+* caution
+* danger
+* error
+* hint
+* important
+* note
+* tip
+* warning
+
+**Markup**: ::
+
+    !!! note
+    You should note that the title will be automatically capitalized.
+
+**Result**:
+
+.. note::
+   You should note that the title will be automatically capitalized.

--- a/src/moin/converters/_tests/test_markdown_in.py
+++ b/src/moin/converters/_tests/test_markdown_in.py
@@ -153,6 +153,21 @@ class TestConverter:
         """ Test the Wikilinks extension: https://python-markdown.github.io/extensions/wikilinks/"""
         self.do(input, output)
 
+    data = [
+        ('!!! note\n    You should note that the title will be automatically capitalized.',
+         '<div class="admonition note"><p class="admonition-title">Note</p><p>You should note that the title will be automatically capitalized.</p></div>'),
+        ('!!! danger "Don\'t try this at home"\n    ...',
+         '<div class="admonition danger"><p class="admonition-title">Don\'t try this at home</p><p>...</p></div>'),
+        ('!!! important ""\n    This is an admonition box without a title.',
+         '<div class="admonition important"><p>This is an admonition box without a title.</p></div>'),
+        ('!!! danger highlight blink "Don\'t try this at home"\n    ...',
+         '<div class="admonition danger highlight blink"><p class="admonition-title">Don\'t try this at home</p><p>...</p></div>'),
+    ]
+
+    @pytest.mark.parametrize('input,output', data)
+    def test_admonition(self, input, output):
+        self.do(input, output)
+
     def serialize_strip(self, elem, **options):
         result = serialize(elem, namespaces=self.namespaces, **options)
         return self.output_re.sub('', result)

--- a/src/moin/converters/markdown_in.py
+++ b/src/moin/converters/markdown_in.py
@@ -533,6 +533,7 @@ class Converter:
                 ExtraExtension(),
                 CodeHiliteExtension(guess_lang=False),
                 'mdx_wikilink_plus',
+                'admonition',
             ],
             extension_configs={
                 'mdx_wikilink_plus': {

--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -99,6 +99,11 @@ div.tip > p,
 div.warning > ol,
 div.warning > ul,
 div.warning > p { margin-top: 8px; padding-left: 4em; }
+/* Admonition extension of Markdown parser */
+.admonition-title {
+    font-weight: bold;
+    font-size: 1.1em;
+}
 /* end of admonitions */
 
 /* mime type icons */


### PR DESCRIPTION
the Admonition extension is built in the markdown-parser: https://python-markdown.github.io/extensions/admonition/ This PR enables the extension and adds documentation to it, as well as tests

The rst admonitions don't handle titles, so the documentation can't contain examples for this feature.