### PR TITLE
add workaround: use setuptools_scm < 8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup_args = dict(
         'write_to': os.path.join(basedir, 'src', 'moin', '_version.py'),
     },
     setup_requires=[
-        'setuptools_scm',  # magically cares for version and packaged files
+        'setuptools_scm<8.0.0',  # magically cares for version and packaged files
     ],
     install_requires=[
         'Babel>=2.10.0',  # internationalization support


### PR DESCRIPTION
Workaround for #1515.

New version of setuptools_scm has been released today. CI workflow is failing.