### PR TITLE
setuptools_scm: revert workaround, use relative path for _version.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,10 +66,10 @@ setup_args = dict(
     include_package_data=True,
     zip_safe=False,
     use_scm_version={
-        'write_to': os.path.join(basedir, 'src', 'moin', '_version.py'),
+        'write_to': os.path.join('src', 'moin', '_version.py'),
     },
     setup_requires=[
-        'setuptools_scm<8.0.0',  # magically cares for version and packaged files
+        'setuptools_scm',  # magically cares for version and packaged files
     ],
     install_requires=[
         'Babel>=2.10.0',  # internationalization support


### PR DESCRIPTION
fixes #1515.