### PR TITLE
remove doubleclick on modify page

### DIFF
--- a/src/moin/templates/modify.html
+++ b/src/moin/templates/modify.html
@@ -84,7 +84,6 @@
 {% block options_for_javascript %}
     {%- if user.scroll_page_after_edit -%}
         <br id="moin-scroll-page-after-edit" />
-        <br id="moin-edit-on-doubleclick" />
     {%- endif %}
     {%- if draft_data -%}
         <textarea id="moin-draft-data">{{ draft_data }}</textarea>


### PR DESCRIPTION
the doubleclick feature is only for the show-page to open the modify-view
but the function was also enabled on the modify-view itself, leading to page reload (on a mis-click: data loss) of the same modify page

fixes moinwiki/moin#1512