### PR TITLE
Improve modify layout

### DIFF
--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -579,12 +579,12 @@ li.moin-selected-groups { font-size: 1em; font-weight: bold; }
 .moin-form dt { clear: both; float: left; width: 25%; text-align: right; margin-top: .3em; padding-right: 1em; }
 .moin-form dt label.required:after { content: '*'; color: var(--primary); }
 .moin-form button,
-.moin-form input[type="submit"] { clear: both; display: block; margin: auto; }
+.moin-form input[type="submit"] { clear: both; display: block; }
 .moin-form dl  { margin-bottom: 2em; }
 .moin-float-fix { clear: both; padding-top: .75em; }
 .moin-form  input[type="submit"].moin-modify-submit,
 .moin-form .moin-load-draft,
-.moin-form .moin-cancel { clear: none; float: left; margin-right: 3em; margin-bottom: 1em; }
+.moin-form .moin-cancel { margin-bottom: 1em; }
 .moin-form .moin-load-draft { border: 1px solid var(--alert);
     background-color: var(--bg-message); }
 .moin-watermark { background-image: url("../../../static/img/draft.png");
@@ -592,6 +592,9 @@ li.moin-selected-groups { font-size: 1em; font-weight: bold; }
 
 .moin-form dd.moin-radio { line-height: 1.5em}
 .moin-form .moin-radio input { width: 1em; }
+
+.moin-form .submit-buttons{ display: flex; column-gap: 8pt; justify-content: end;
+    margin: 8pt 0; } 
 
 #options dd { width: 10%; }
 #options dt { width: 60%; max-width: 40em; }

--- a/src/moin/templates/modify.html
+++ b/src/moin/templates/modify.html
@@ -45,29 +45,14 @@
                POSTs originate from their respective applets.
             #}
             {% if not form['content_form'].is_draw %}
-                <div>
-                    {% set warning = "" %}
-                    {% if draft_data %}
-                        <button class="moin-button moin-load-draft" type="button" >{{ _("Load Draft") }}</button>
-                        {% set warning = _("Clicking this button will delete draft!") %}
-                    {% endif %}
-                    {{ gen.input(type='submit', id='moin-save-text-button', value=form.submit_label,
-                        class='moin-button moin-modify-submit', title=warning) }}
-                    {{ gen.input(type='submit', id='moin-preview-text-button', name='preview', value=form.preview_label,
-                        class='moin-button moin-modify-submit', onclick="$('#moin-modify').removeClass('moin-changed-input')",
-                        title=warning) }}
-                    {{ gen.input(type='submit', id='moin-cancel-text-button', name='cancel', value=form.cancel_label,
-                        class='moin-button moin-modify-submit', onclick="$('#moin-modify').removeClass('moin-changed-input')",
-                        title=warning) }}
-                </div>
-                <dl>
-                    {{ forms.render(form['comment']) }}
-                </dl>
+                {% if draft_data %}
+                    <button class="moin-button moin-load-draft" type="button" >{{ _("Load Draft") }}</button>
+                    {% set warning = _("Clicking this button will delete draft!") %}
+                {% endif %}
             {% endif %}
             {{ utils.help_on_editing(help) }}
             {{ data_editor(form['content_form'], item_name) }}
             {% set may_admin = user.may.admin(fqname) %}
-            {{ meta_editor(form['meta_form'], may_admin) }}
 
             {% if item.meta['name'][0].endswith('Group') %}
                 <dl>
@@ -83,6 +68,42 @@
                 </dl>
                 <div class="hint">
                     {{ _('Enter "key=value" strings, one per line, no quotes, no blank lines.') }}
+                </div>
+            {% endif %}
+
+            {#
+                Workaround:
+                For *Draw content, hide form['comment'], since *Draw
+                POSTs originate from their respective applets.
+            #}
+            {% if not form['content_form'].is_draw %}
+            <dl>
+                {{ forms.render(form['comment']) }}
+            </dl>
+            {% endif %}
+
+            {{ meta_editor(form['meta_form'], may_admin) }}
+
+            {% block moin_flash %}
+            {% endblock %}
+
+            {#
+                Workaround:
+                For *Draw content, hide submit button, since *Draw
+                POSTs originate from their respective applets.
+            #}
+            {% if not form['content_form'].is_draw %}
+                
+                <div class="submit-buttons">
+                    {% set warning = "" %}
+                    {{ gen.input(type='submit', id='moin-cancel-text-button', name='cancel', value=form.cancel_label,
+                        class='moin-button moin-modify-submit', onclick="$('#moin-modify').removeClass('moin-changed-input')",
+                        title=warning) }}
+                    {{ gen.input(type='submit', id='moin-preview-text-button', name='preview', value=form.preview_label,
+                        class='moin-button moin-modify-submit', onclick="$('#moin-modify').removeClass('moin-changed-input')",
+                        title=warning) }}
+                    {{ gen.input(type='submit', id='moin-save-text-button', value=form.submit_label,
+                        class='moin-button moin-modify-submit', title=warning) }}
                 </div>
             {% endif %}
         {{ gen.form.close() }}

--- a/src/moin/templates/modify_meta.html
+++ b/src/moin/templates/modify_meta.html
@@ -8,7 +8,6 @@
 {% import "forms.html" as forms %}
 
 {% macro meta_editor(form, may_admin) %}
-    <h2>{{ _("General meta") }}</h2>
     <dl>
         {% if may_admin %}
             {{ forms.render(form['acl']) }}

--- a/src/moin/translations/MoinMoin.pot
+++ b/src/moin/translations/MoinMoin.pot
@@ -2504,10 +2504,6 @@ msgstr ""
 msgid "Enter \"key=value\" strings, one per line, no quotes, no blank lines."
 msgstr ""
 
-#: src/moin/templates/modify_meta.html:11
-msgid "General meta"
-msgstr ""
-
 #: src/moin/templates/modify_meta.html:26
 msgid "Tags may have embedded blanks, use commas to separate."
 msgstr ""

--- a/src/moin/translations/de/LC_MESSAGES/messages.po
+++ b/src/moin/translations/de/LC_MESSAGES/messages.po
@@ -2540,10 +2540,6 @@ msgstr "Geben Sie die Liste der Benutzer-Namen einzeln pro Zeile ein."
 msgid "Enter \"key=value\" strings, one per line, no quotes, no blank lines."
 msgstr "Geben Sie \"Schlüssel=Wert\" Paare ein, einzeln pro Zeile, keine Anführungszeichen, keine leeren Zeilen."
 
-#: src/moin/templates/modify_meta.html:11
-msgid "General meta"
-msgstr "Allgemeine Metadaten"
-
 #: src/moin/templates/modify_meta.html:26
 msgid "Tags may have embedded blanks, use commas to separate."
 msgstr "Schlagworte können Leerzeichen enthalten, benutzen Sie Kommas zum trennen."

--- a/src/moin/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/src/moin/translations/pt_BR/LC_MESSAGES/messages.po
@@ -2479,10 +2479,6 @@ msgstr ""
 msgid "Enter \"key=value\" strings, one per line, no quotes, no blank lines."
 msgstr ""
 
-#: src/moin/templates/modify_meta.html:11
-msgid "General meta"
-msgstr ""
-
 #: src/moin/templates/modify_meta.html:26
 msgid "Tags may have embedded blanks, use commas to separate."
 msgstr ""

--- a/src/moin/translations/ru/LC_MESSAGES/messages.po
+++ b/src/moin/translations/ru/LC_MESSAGES/messages.po
@@ -2470,10 +2470,6 @@ msgstr ""
 msgid "Enter \"key=value\" strings, one per line, no quotes, no blank lines."
 msgstr ""
 
-#: src/moin/templates/modify_meta.html:11
-msgid "General meta"
-msgstr ""
-
 #: src/moin/templates/modify_meta.html:26
 msgid "Tags may have embedded blanks, use commas to separate."
 msgstr ""


### PR DESCRIPTION
In most forms the buttons to confirm or cancel are at the bottom because in western countries we read from top to bottom. Because of that this PR moves the buttons for confirmation, cancellation and preview to the bottom. It also changed the order of the buttons because usually a button on the right lets users do anything to go on and a button on the left lets them go back. It also has to do something with how we read (from left to right; the right site is the "future").

Only the button to recover the draft stays at the top since it should be near the message which tells you that you can recover a draft.

~~The next change is that I also moved the alerts to the bottom because the feedback has to be where the buttons for interaction are.~~ (This causes problems, see discussion below)

Furthermore, this PR removes the `General meta` header because comments are also meta data.

This PR affects at least the basic and the modernized theme.

![improve-modify-layout](https://github.com/moinwiki/moin/assets/100708552/9083f28d-92be-4b6d-9196-d33ff93328de)
