### PR TITLE
Limit double-click feature to item view

### DIFF
--- a/src/moin/templates/show.html
+++ b/src/moin/templates/show.html
@@ -51,7 +51,7 @@
 {% endblock %}
 
 {% block options_for_javascript %}
-    {%- if item_name and user.edit_on_doubleclick and user.may.write(item_name) -%}
+    {%- if item_name and user.edit_on_doubleclick and user.may.write(item_name) and data_rendered -%}
         <br id="moin-edit-on-doubleclick" />
     {%- endif %}
     {%- if user.show_comments -%}


### PR DESCRIPTION
Only activate double-click feature pages with rendered content, not on meta-pages such as convert, rename etc

fixes moinwiki/moin#1545