### PR TITLE
Revert "remove Extra MetaData (JSON) from modify view, fixes #700"

### DIFF
--- a/src/moin/forms.py
+++ b/src/moin/forms.py
@@ -153,6 +153,13 @@ class ValidName(Validator):
             # incoming request is from +usersettings#personal;
             # apps/frontend/views.py will validate changes to user names
             return True
+        # Make sure that the other meta is valid before validating the name.
+        # TODO: prove the try below is always redundant and remove it.
+        try:
+            if not element.parent.parent['extra_meta_text'].valid:
+                return False
+        except AttributeError:
+            pass
         try:
             validate_name(state['meta'], state[ITEMID])
         except NameNotValidError as e:

--- a/src/moin/templates/modify.html
+++ b/src/moin/templates/modify.html
@@ -68,6 +68,11 @@
             {{ data_editor(form['content_form'], item_name) }}
             {% set may_admin = user.may.admin(fqname) %}
             {{ meta_editor(form['meta_form'], may_admin) }}
+            {% if fqname.fullname.endswith(('Group', 'Dict')) %}
+                <dl>
+                    {{ forms.render(form['extra_meta_text']) }}
+                </dl>
+            {% endif %}
         {{ gen.form.close() }}
     </div>
 

--- a/src/moin/themes/basic/templates/modify.html
+++ b/src/moin/themes/basic/templates/modify.html
@@ -54,6 +54,13 @@
                         <div class="col-md-6">
                             {{ basic_meta_editor(form['meta_form']) }}
                         </div>
+                        {% set field = form['extra_meta_text'] %}
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                {{ gen.label(field) }}
+                                {{ gen.textarea(field, rows=field.properties.rows|string, cols=field.properties.cols|string, class='form-control') }}
+                            </div>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
This reverts commit dd3532629f79074a651e6d16bf405e36ec8cbfb8.

Added 2 mods to revert:
  * items/__init__.py added try/TypeError block near line 829
  * templates/modify.html added test for item names ending in Group/Dict near line 71