### PR TITLE
removed Extra Metadata (JSON), replaced with Wiki Dick and User Group

### DIFF
--- a/docs/admin/configure.rst
+++ b/docs/admin/configure.rst
@@ -1068,16 +1068,12 @@ The WikiGroups backend is enabled by default so there is no need to add the foll
 To create a WikiGroup that can be used in an ACL rule:
 
 * Create a wiki item with a name ending in "Group" (the content of the item is not relevant)
-* Edit the metadata and add an entry for "usergroup" under the heading "Extra Metadata (JSON)"::
+* Edit the metadata and add entries under the heading "Wiki Groups", one entry per line.
+* Leading and trailing spaces are ignored, internal spaces are accepted.::
 
-    {
-      "itemid": "36b6cd973d7e4daa9cfa265dcf751e79",
-      "namespace": "",
-      "usergroup": [
-        "JaneDoe",
-        "JohnDoe"
-      ]
-    }
+    JaneDoe
+    JohnDoe
+    SomeOtherGroup
 
 * Use the new group name in one or more ACL rules.
 
@@ -1120,17 +1116,11 @@ The WikiDicts backend is enabled by default so there is no need to add the follo
 To create a WikiDict that can be used in an GetVal macro:
 
 * Create a wiki item with a name ending in "Dict" (the content of the item is not relevant)
-* Edit the metadata and add an entry for "somedict" under the heading "Extra Metadata (JSON)"::
+* Edit the metadata and add an entry under the heading "Wiki Dict"::
 
-    {
-      "itemid": "332458ceab334991868de8970980494e",
-      "namespace": "",
-      "somedict": {
-        "apple": "red",
-        "banana": "yellow",
-        "pear": "green"
-      }
-    }
+    apple=red
+    banana=yellow
+    pear=green
 
 The ConfigDicts backend uses dicts defined in the configuration file. Adding the
 following to wikiconfig creates a OneDict and a NumbersDict and prevents

--- a/src/moin/constants/keys.py
+++ b/src/moin/constants/keys.py
@@ -21,8 +21,7 @@ ACL = "acl"
 # keys for storing group and dict information
 # group of user names, e.g. for ACLs:
 USERGROUP = "usergroup"
-# needs more precise name / use case:
-SOMEDICT = "somedict"
+WIKIDICT = "wikidict"
 
 # TODO review plural constants
 CONTENTTYPE = "contenttype"
@@ -66,6 +65,8 @@ DATAID = "dataid"
 WIKINAME = "wikiname"
 CONTENT = "content"
 REFERS_TO = "refers_to"
+# list of metadata fields that editors cannot modify
+# excludes COMMENT, SUMMARY, TAG, USERGROUP and WIKIDICT
 IMMUTABLE_KEYS = [
     ACTION,
     ADDRESS,
@@ -82,6 +83,11 @@ IMMUTABLE_KEYS = [
     SIZE,
     USERID,
     WIKINAME,
+    CONTENTTYPE,
+    ITEMID,
+    ITEMTYPE,
+    NAMESPACE,
+    REV_NUMBER,
 ]
 
 # magic REVID for current revision:

--- a/src/moin/datastructures/backends/_tests/test_wiki_dicts.py
+++ b/src/moin/datastructures/backends/_tests/test_wiki_dicts.py
@@ -11,7 +11,7 @@
 
 from moin.datastructures.backends._tests import DictsBackendTest
 from moin.datastructures.backends import wiki_dicts
-from moin.constants.keys import SOMEDICT
+from moin.constants.keys import WIKIDICT
 from moin._tests import become_trusted, update_item
 
 import pytest
@@ -29,15 +29,15 @@ class TestWikiDictsBackend(DictsBackendTest):
     def custom_setup(self):
         become_trusted()
 
-        somedict = {"First": "first item",
+        wikidict = {"First": "first item",
                     "text with spaces": "second item",
                     'Empty string': '',
                     "Last": "last item"}
-        update_item('SomeTestDict', {SOMEDICT: somedict}, DATA)
+        update_item('SomeTestDict', {WIKIDICT: wikidict}, DATA)
 
-        somedict = {"One": "1",
+        wikidict = {"One": "1",
                     "Two": "2"}
-        update_item('SomeOtherTestDict', {SOMEDICT: somedict}, DATA)
+        update_item('SomeOtherTestDict', {WIKIDICT: wikidict}, DATA)
 
     def test__retrieve_items(self):
         wikidict_obj = wiki_dicts.WikiDicts()

--- a/src/moin/datastructures/backends/wiki_dicts.py
+++ b/src/moin/datastructures/backends/wiki_dicts.py
@@ -11,8 +11,9 @@
 
 from flask import g as flaskg
 
-from moin.constants.keys import CURRENT, SOMEDICT
+from moin.constants.keys import CURRENT, WIKIDICT
 from moin.datastructures.backends import BaseDict, BaseDictsBackend, DictDoesNotExistError
+from flask import flash
 
 
 class WikiDict(BaseDict):
@@ -26,9 +27,10 @@ class WikiDict(BaseDict):
         item = flaskg.unprotected_storage[dict_name]
         try:
             rev = item[CURRENT]
-            somedict = rev.meta.get(SOMEDICT, {})
-            return somedict
+            wikidict = rev.meta.get(WIKIDICT, {})
+            return wikidict
         except KeyError:
+            flash('WikiDict "{dict_name}" has invalid syntax within metadata.'.format(dict_name=dict_name))
             raise DictDoesNotExistError(dict_name)
 
 
@@ -43,5 +45,5 @@ class WikiDicts(BaseDictsBackend):
     def _retrieve_items(self, dict_name):
         item = flaskg.unprotected_storage[dict_name]
         rev = item.get_revision(CURRENT)
-        somedict = rev.meta.get(SOMEDICT, {})
-        return somedict
+        wikidict = rev.meta.get(WIKIDICT, {})
+        return wikidict

--- a/src/moin/help/en/WikiDict.data
+++ b/src/moin/help/en/WikiDict.data
@@ -1,24 +1,25 @@
 = WikiDict =
 
-MOINTODO: There is no longer a way to add or view arbitrary metadata. This feature must be reworked. One suggestion is to follow moin 1.9 implementation and add data to item content rather than item metadata.
+This item is a WikiDict because the item name ends with "Dict" and it has metadata defined under the "Wiki Dict" heading that visible when this item is edited. 
 
-This item is a WikiDict because it has a "somedict" defined in "extra" metadata:
+To add metadata enter key=value pairs one per line.
 
 {{{
-{
-  "itemid": "932eec2324c3494c9ac8b9dcb2e46359",
-  "namespace": "",
-  "somedict": {
-    "var1": "value1",
-    "var2": "value2",
-    "var3": "value3"
-  }
-}
+    var1=value1
+    var2=value2
+    var3=value3
 }}}
 
 The above is used by the GetVal macro:
 
 {{{
-<<GetVal(help-en/WikiDict, var1)>>
+    <<GetVal(help-en/WikiDict, var1)>>
 }}}
+
 <<GetVal(help-en/WikiDict, var1)>>
+
+Clicking the Meta link under Item Views is an alternative way to view this item's metadata.
+
+{{{
+    Wiki Dict: {'var1': 'value1', 'var2': 'value2', 'var3': 'value3'}
+}}}

--- a/src/moin/help/en/WikiDict.meta
+++ b/src/moin/help/en/WikiDict.meta
@@ -3,28 +3,28 @@
   "address": "127.0.0.1",
   "comment": "",
   "contenttype": "text/x.moin.wiki;charset=utf-8",
-  "dataid": "d69dcb7cfc524e2fadaf4322293ae9d5",
+  "dataid": "30cc072ac1e342c8970aa4cb49571b87",
   "externallinks": [],
   "itemid": "932eec2324c3494c9ac8b9dcb2e4635a",
   "itemlinks": [],
   "itemtransclusions": [],
   "itemtype": "default",
-  "mtime": 1681742420,
+  "mtime": 1704050058,
   "name": [
     "WikiDict"
   ],
   "name_old": [],
   "namespace": "help-en",
   "rev_number": 1,
-  "revid": "56f6ff214ca549f0bc8895bd1a11caf0",
-  "sha1": "b89a611ce9754260976617b0720c21e202dba9b7",
-  "size": 613,
-  "somedict": {
+  "revid": "519deb6d2d7747d8979bde44c54d5ee6",
+  "sha1": "d9428a030ba7c34296ed9b8bd4174b91f38d5f06",
+  "size": 606,
+  "summary": "",
+  "tags": [],
+  "wikidict": {
     "var1": "value1",
     "var2": "value2",
     "var3": "value3"
   },
-  "summary": "",
-  "tags": [],
   "wikiname": "MyMoinMoin"
 }

--- a/src/moin/macros/GetVal.py
+++ b/src/moin/macros/GetVal.py
@@ -29,4 +29,7 @@ class Macro(MacroInlineBase):
         except DictDoesNotExistError:
             raise ValueError(_("GetVal: dict not found: ") + item_name)
         result = d.get(key, '')
+        if not result:
+            raise ValueError(_('GetVal macro is invalid, {item_name} missing key: {key_name}').
+                             format(item_name=item_name, key_name=key))
         return result

--- a/src/moin/macros/_tests/test_GetVal.py
+++ b/src/moin/macros/_tests/test_GetVal.py
@@ -9,7 +9,7 @@ import pytest
 from flask import g as flaskg
 
 from moin.macros.GetVal import Macro
-from moin.constants.keys import SOMEDICT
+from moin.constants.keys import WIKIDICT
 from moin._tests import become_trusted, update_item
 
 
@@ -17,9 +17,9 @@ class TestMacro:
     @pytest.fixture
     def test_dict(self):
         become_trusted()
-        somedict = {"One": "1",
+        wikidict = {"One": "1",
                     "Two": "2"}
-        update_item('TestDict', {SOMEDICT: somedict}, "This is a dict item.")
+        update_item('TestDict', {WIKIDICT: wikidict}, "This is a dict item.")
 
         return "TestDict"
 

--- a/src/moin/templates/modify.html
+++ b/src/moin/templates/modify.html
@@ -17,7 +17,7 @@
 
 {% extends theme("show.html") %}
 
-{% from form.meta_template import meta_editor %}
+{% from form.meta_template import meta_editor with context %}
 {# Import macros data_editor and extra_head from content_form's template.
    extra_head is optional, so instead of a simple "import from" we need to do
    this manually #}
@@ -68,11 +68,19 @@
             {{ data_editor(form['content_form'], item_name) }}
             {% set may_admin = user.may.admin(fqname) %}
             {{ meta_editor(form['meta_form'], may_admin) }}
-            {% if fqname.fullname.endswith(('Group', 'Dict')) %}
-                <dl>
-                    {{ forms.render(form['extra_meta_text']) }}
-                </dl>
-            {% endif %}
+
+        {% if item.meta['name'][0].endswith('Group') %}
+            {{ forms.render(form['usergroup']) }}
+            <div class="hint">
+                {{ _('Enter list of user names, one name per line.') }}
+            </div>
+        {% endif %}
+        {% if item.meta['name'][0].endswith('Dict') %}
+            {{ forms.render(form['wikidict']) }}
+            <div class="hint">
+                {{ _('Enter "key=value" strings, one per line, no quotes, no blank lines.') }}
+            </div>
+        {% endif %}
         {{ gen.form.close() }}
     </div>
 

--- a/src/moin/templates/utils.html
+++ b/src/moin/templates/utils.html
@@ -206,7 +206,13 @@
             {%- endif -%}
         </li>
         <li class="list-group-item">Trash: {{ meta['trash'] or False }}</li>
+        {% if 'usergroup' in meta %}
+            <li class="list-group-item">User Group: {{ meta['usergroup'] }}</li>
+        {% endif %}
         <li class="list-group-item">User ID: {{ meta['userid'] }}</li>
+        {% if 'wikidict' in meta %}
+            <li class="list-group-item">Wiki Dict: {{ meta['wikidict'] }}</li>
+        {% endif %}
         <li class="list-group-item">Wiki Name: {{ meta['wikiname'] }}</li>
     </ul>
 {% endmacro %}


### PR DESCRIPTION
for items with names ending in Dict or Group

renamed all instances of poorly named somedict/SOMEDICT to wikidict/WIKIDICT.

`>>>>>`Any existing wiki's using Extra Metadata (JSON) must be reworked to use UserGroup.

Updated docs.

`>>>>>`Developers must reload help-en (WikiDict) to avoid display errors.

fixes #1554