### PR TITLE
import19: correct capitalization of special users

### DIFF
--- a/src/moin/cli/migration/moin19/import19.py
+++ b/src/moin/cli/migration/moin19/import19.py
@@ -33,6 +33,7 @@ from moin.constants.keys import *  # noqa
 from moin.constants.contenttypes import CONTENTTYPE_USER, CHARSET19, CONTENTTYPE_MARKUP_OUT
 from moin.constants.itemtypes import ITEMTYPE_DEFAULT
 from moin.constants.namespaces import NAMESPACE_DEFAULT, NAMESPACE_USERPROFILES
+from moin.constants.rights import SPECIAL_USERS
 from moin.storage.error import NoSuchRevisionError
 from moin.utils.mimetype import MimeType
 from moin.utils.crypto import make_uuid, hash_hexdigest
@@ -77,6 +78,8 @@ FORMAT_TO_CONTENTTYPE = {
     'docbook': 'application/docbook+xml;charset=utf-8',
 }
 MIGR_STAT_KEYS = ['revs', 'items', 'attachments', 'users', 'missing_user', 'missing_file', 'del_item']
+
+special_users_lower = [user.lower() for user in SPECIAL_USERS]
 
 last_moin19_rev = {}
 user_names = []
@@ -652,9 +655,15 @@ def regenerate_acl(acl_string, acl_rights_valid=ACL_RIGHTS_CONTENTS):
         if (entries, rights) == (['Default'], []):
             result.append("Default")
         else:
+            entries_valid = []
+            for entry in entries:
+                if entry.lower() in special_users_lower and entry != entry.capitalize():
+                    entries_valid.append(entry.capitalize())
+                else:
+                    entries_valid.append(entry)
             result.append("{0}{1}:{2}".format(
                           modifier,
-                          ','.join(entries),
+                          ','.join(entries_valid),
                           ','.join(rights)  # iterator has removed invalid rights
                           ))
     result = ' '.join(result)

--- a/src/moin/constants/rights.py
+++ b/src/moin/constants/rights.py
@@ -1,4 +1,5 @@
 # Copyright: 2011 MoinMoin:ThomasWaldmann
+# Copyright: 2024 MoinMoin:UlrichB
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -38,3 +39,6 @@ DESTROY = 'destroy'
 
 # rights that control access to operations on contents
 ACL_RIGHTS_CONTENTS = [READ, PUBREAD, WRITE, CREATE, ADMIN, DESTROY, ]
+
+# special user groups - order is important
+SPECIAL_USERS = ['All', 'Known', 'Trusted', ]


### PR DESCRIPTION
This is related to #1561 (4).

On import of moin 1.9 wiki data ACL strings with incorrect capitalization like e.g. 'ALL:' or 'all' are converted to 'All:'