### PR TITLE
import19: check for unknown macros

### DIFF
--- a/src/moin/cli/migration/moin19/import19.py
+++ b/src/moin/cli/migration/moin19/import19.py
@@ -105,7 +105,7 @@ def migr_logging(msg_id, log_msg):
         logging.debug(log_msg)
 
 
-def migr_statistics():
+def migr_statistics(unknown_macros):
     logging.info("Migration statistics:")
     logging.info("Users:       {0:6d}".format(migr_stat['users']))
     logging.info("Items:       {0:6d}".format(migr_stat['items']))
@@ -115,6 +115,9 @@ def migr_statistics():
     for message in ['missing_user', 'missing_file', 'del_item']:
         if migr_stat[message] > 0:
             logging.info("Warnings:    {0:6d} - {1}".format(migr_stat[message], message))
+
+    if len(unknown_macros) > 0:
+        logging.info("Warnings:    {0:6d} - unknown macros {1}".format(len(unknown_macros), str(unknown_macros)[1:-1]))
 
 
 @cli.command('import19', help='Import content and user data from a moin 1.9 wiki')
@@ -233,7 +236,10 @@ def ImportMoin19(data_dir=None, markup_out=None):
     indexer.open()
 
     logging.info("Finished conversion!")
-    migr_statistics()
+    if hasattr(conv_out, 'unknown_macro_list'):
+        migr_statistics(unknown_macros=conv_out.unknown_macro_list)
+    else:
+        migr_statistics([])
 
 
 class KillRequested(Exception):

--- a/src/moin/converters/moinwiki_out.py
+++ b/src/moin/converters/moinwiki_out.py
@@ -1,5 +1,6 @@
 # Copyright: 2008 MoinMoin:BastianBlank
 # Copyright: 2010 MoinMoin:DmitryAndreev
+# Copyright: 2024 MoinMoin:UlrichB
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -20,8 +21,12 @@ from moin.utils.tree import moin_page, xlink, xinclude, html
 from moin.utils.iri import Iri
 from moin.utils.mime import Type, type_moin_document, type_moin_wiki
 
+from moin.macros import modules as macro_modules
 from . import ElementException
 from . import default_registry
+
+from moin import log
+logging = log.getLogger(__name__)
 
 
 class Moinwiki:
@@ -129,6 +134,7 @@ class Converter:
         self.list_item_labels = ['', ]
         self.list_item_label = ''
         self.list_level = 0
+        self.unknown_macro_list = []
 
         # 'text' - default status - <p> = '/n' and </p> = '/n'
         # 'table' - text inside table - <p> = '<<BR>>' and </p> = ''
@@ -495,6 +501,10 @@ class Converter:
         if len(type) == 2:
             if type[0] == "x-moin/macro":
                 name = type[1].split('=')[1]
+                if name not in macro_modules:
+                    logging.debug("Unknown macro {} found.".format(name))
+                    if name not in self.unknown_macro_list:
+                        self.unknown_macro_list.append(name)
                 eol = '\n\n' if elem.tag.name == 'part' else ''
                 if len(elem) and elem[0].tag.name == "arguments":
                     return "{0}<<{1}({2})>>{0}".format(


### PR DESCRIPTION
Related to #1585.

This adds a line to the migration statistics, for example:

```
INFO moin.cli.migration.moin19.import19 Migration statistics:
[...]
INFO moin.cli.migration.moin19.import19 Warnings:         3 - unknown macros 'TitleIndex', 'Action', 'SystemAdmin'
```