### PR TITLE
Disable Double click on rename and delete pages

### DIFF
--- a/src/moin/templates/show.html
+++ b/src/moin/templates/show.html
@@ -51,7 +51,7 @@
 {% endblock %}
 
 {% block options_for_javascript %}
-    {%- if item_name and user.edit_on_doubleclick and user.may.write(item_name) and data_rendered -%}
+    {%- if item_name and user.edit_on_doubleclick and user.may.write(item_name) and data_rendered and not form -%}
         <br id="moin-edit-on-doubleclick" />
     {%- endif %}
     {%- if user.show_comments -%}


### PR DESCRIPTION
Double click: Disable when forms are displayed
effectively disables the double click feature on rename and delete action pages

fixes #1598