### PR TITLE
Fix moin-nonexistent class in itemlinks starting with '+'

### DIFF
--- a/src/moin/app.py
+++ b/src/moin/app.py
@@ -30,7 +30,7 @@ from whoosh.index import EmptyIndexError
 from moin.utils import monkeypatch  # noqa
 from moin.utils.clock import Clock
 from moin import auth, user, config
-from moin.constants.misc import ANON
+from moin.constants.misc import ANON, VALID_ITEMLINK_VIEWS
 from moin.i18n import i18n_init
 from moin.themes import setup_jinja_env, themed_error
 from moin.storage.middleware import protecting, indexing, routing
@@ -156,6 +156,8 @@ def create_app_ext(flask_config_file=None, flask_config_dict=None, moin_config_c
     from moin.apps.serve import serve
 
     app.register_blueprint(serve, url_prefix="/+serve")
+
+    app.view_endpoints = get_endpoints(app)
     clock.stop("create_app register")
     clock.start("create_app flask-cache")
     # 'SimpleCache' caching uses a dict and is not thread safe according to the docs.
@@ -189,6 +191,16 @@ def create_app_ext(flask_config_file=None, flask_config_dict=None, moin_config_c
     clock.stop("create_app total")
     del clock
     return app
+
+
+def get_endpoints(app):
+    """Get dict with views and related endpoints allowed as itemlink"""
+    view_endpoints = {}
+    for rule in app.url_map.iter_rules():
+        view = rule.rule.split("/")[1]
+        if view in VALID_ITEMLINK_VIEWS and rule.rule == f"/{view}/<itemname:item_name>":
+            view_endpoints[view] = rule.endpoint
+    return view_endpoints
 
 
 def destroy_app(app):

--- a/src/moin/constants/misc.py
+++ b/src/moin/constants/misc.py
@@ -1,4 +1,5 @@
 # Copyright: 2011 MoinMoin:ThomasWaldmann
+# Copyright: 2024 MoinMoin:UlrichB
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -69,3 +70,6 @@ URI_SCHEMES = [
 NO_LOCK = 0  # false, someone else holds lock for current item
 LOCKED = 1  # true, current user has obtained or renewed lock
 LOCK = "lock"
+
+# Valid views allowed for itemlinks
+VALID_ITEMLINK_VIEWS = ["+meta", "+history", "+download", "+highlight"]

--- a/src/moin/converters/link.py
+++ b/src/moin/converters/link.py
@@ -9,6 +9,7 @@ Expands all links in an internal Moin document, including interwiki and
 special wiki links.
 """
 
+from flask import current_app as app
 from flask import g as flaskg
 
 from moin.constants.misc import VALID_ITEMLINK_VIEWS
@@ -202,8 +203,9 @@ class ConverterExternOutput(ConverterBase):
             item_name = str(page.path[1:]) if page else ""
         endpoint, rev, query = self._get_do_rev(input.query)
 
-        if view_name == "+meta":  # TODO: add other views
-            endpoint = "frontend.show_item_meta"
+        if view_name in app.view_endpoints.keys():
+            # Other views will be shown with class moin-nonexistent as non-existent links
+            endpoint = app.view_endpoints[view_name]
 
         url = url_for_item(item_name, rev=rev, endpoint=endpoint)
         if not page:

--- a/src/moin/templates/utils.html
+++ b/src/moin/templates/utils.html
@@ -153,7 +153,7 @@
         <li class="list-group-item">Item Links:&nbsp;
             {%- if meta['itemlinks'] -%}
                 {%- for item in meta['itemlinks']|sort -%}
-                    <a href="{{ url_for('frontend.show_item', item_name=item) }}" {% if not theme_supp.item_exists(item) %}class="moin-nonexistent"{% endif %}>{{ item }}</a>
+                    <a href="{{ url_for('frontend.show_item', item_name=item) }}" {% if not theme_supp.itemlink_exists(item) %}class="moin-nonexistent"{% endif %}>{{ item }}</a>
                     {%- if not loop.last %}, {% endif -%}
                 {%- endfor -%}
             {%- else -%}

--- a/src/moin/themes/__init__.py
+++ b/src/moin/themes/__init__.py
@@ -1,7 +1,7 @@
 # Copyright: 2003-2010 MoinMoin:ThomasWaldmann
 # Copyright: 2008 MoinMoin:RadomirDopieralski
 # Copyright: 2010 MoinMoin:DiogenesAugusto
-# Copyright: 2023 MoinMoin project
+# Copyright: 2023-2024 MoinMoin project
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -26,6 +26,7 @@ from moin.i18n import _, L_
 from moin import wikiutil, user
 from moin.constants.keys import USERID, ADDRESS, HOSTNAME, REVID, ITEMID, NAME_EXACT, ASSIGNED_TO, NAME, NAMESPACE
 from moin.constants.contenttypes import CONTENTTYPES_MAP, CONTENTTYPE_MARKUP, CONTENTTYPE_TEXT, CONTENTTYPE_MOIN_19
+from moin.constants.misc import VALID_ITEMLINK_VIEWS
 from moin.constants.namespaces import NAMESPACE_DEFAULT, NAMESPACE_USERS, NAMESPACE_ALL
 from moin.constants.rights import SUPERUSER
 from moin.search import SearchForm
@@ -590,6 +591,20 @@ class ThemeSupport:
         :returns: whether item pointed to by the link exists or not
         """
         return self.storage.has_item(itemname)
+
+    def itemlink_exists(self, itemlink):
+        """
+        Check whether the item pointed to by the given itemlink exists or not
+
+        :rtype: boolean
+        :returns: whether item pointed to by the link exists or not
+        """
+        item_name = itemlink
+        if itemlink.startswith("+"):
+            view_name = itemlink.split("/")[0]
+            if view_name in VALID_ITEMLINK_VIEWS:
+                item_name = itemlink.split(f"{view_name}/")[1]
+        return self.storage.has_item(item_name)
 
     def variables_css(self):
         """


### PR DESCRIPTION
Related to #1699.

It is hard to solve the problem with class non-existent. I added a hack in lines 205f of `converters/link.py` to show a possible solution for view '+meta', for example. IMO adding a dictionary with view_names and endpoint-function-names seems to be too complex. 

Any ideas on how to improve this? Need help.