### PR TITLE
Fix search-options font and apply some W3C recommendations

### DIFF
--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -274,6 +274,8 @@ a.moin-item-overlay-lr:hover { opacity: .8; background-color: var(--bg-trans-hov
 #moin-long-searchform div { margin: 0; }
 #moin-long-searchform .moin-search-query { width: 90%; margin-left: 0; }
 .moin-search-option-bar { font-size: 1.25em; font-weight: bold; cursor: pointer;  color: var(--link); }
+.moin-searchopt-tab > th:nth-child(1), th:nth-child(2) { width: 20%; }
+.moin-searchopt-tab th:nth-child(3) { width: 60%; }
 .moin-search-hit-info { display: inline; }
 .moin-search-hits { font-weight: bold; }
 .moin-search-results { font-size: .92em; }

--- a/src/moin/templates/layout.html
+++ b/src/moin/templates/layout.html
@@ -71,7 +71,7 @@
         {{ before_footer }}
         <footer id="moin-footer">
             {% block footer %}
-                {% block footer_hr %}<hr/>{% endblock %}
+                {% block footer_hr %}<hr>{% endblock %}
                 {% block footer_itemviews %}{% endblock %}
                 {% block footer_meta %}{% endblock %}
                 {{ creditlogos }}

--- a/src/moin/templates/search.html
+++ b/src/moin/templates/search.html
@@ -32,13 +32,13 @@
             <a href="/+serve/docs/user/search.html">Local docs</a> or
             <a href="https://moin-20.readthedocs.io/en/latest/user/search.html">Internet docs.</a>
         </div>
-        <div class="moin-search-option-bar"><p class="fa fa-chevron-down"> {{ _("Search Options") }}</p></div>
+        <p class="moin-search-option-bar"><i class="fa fa-chevron-down"></i> {{ _("Search Options") }}</p>
         <div class="moin-searchoptions hidden">
             <table>
-                <tr>
-                    <th width="20%">Revisions</td>
-                    <th width="20%">Sort By</td>
-                    <th width="60%" colspan="3">Content Types</td>
+                <tr class="moin-searchopt-tab">
+                    <th>Revisions</th>
+                    <th>Sort By</th>
+                    <th colspan="3">Content Types</th>
                 </tr>
                 <tr>
                     <td>
@@ -70,9 +70,7 @@
             </table>
             <div class="hint">{{ _("An Ajax transaction is submitted each time a radio or checkbox is clicked.") }}</div>
         </div>
-        <p>
             {{ forms.render_errors(medium_search_form) }}
-        </p>
     {{ gen.form.close() }}
     <div id="finalresults">
         {%- include "ajaxsearch.html" %}


### PR DESCRIPTION
The button "search-options" was using fontawesome before.

Also related to #1704. 