### PR TITLE
replace usemod[.]com with usemod.org / meatballwiki.org

### DIFF
--- a/src/moin/contrib/intermap.txt
+++ b/src/moin/contrib/intermap.txt
@@ -40,7 +40,7 @@ AltLinux http://altlinux.org/
 AltLinuxEn http://en.altlinux.org/
 hg https://www.mercurial-scm.org/wiki/
 
-## Updated 2004-11-19 from http://www.usemod.com/cgi-bin/mb.pl?InterMapTxt
+## Updated 2004-11-19 from http://www.usemod.org/cgi-bin/mb.pl?InterMapTxt
 ## Please modify the upper part of this page only
 
 AbbeNormal http://ourpla.net/cgi/pikie?
@@ -75,7 +75,7 @@ JuraWiki https://jurawiki.de/
 LinuxWiki https://linuxwiki.org/
 LiveJournal http://www.livejournal.com/users/$PAGE/
 LyricWiki http://lyricwiki.org/
-MeatBall http://www.usemod.com/cgi-bin/mb.pl?
+MeatBall http://meatballwiki.org/wiki/
 MetaWiki http://sunir.org/apps/meta.pl?
 MetaWikiPedia http://meta.wikipedia.org/wiki/
 MoinMaster https://master.moinmo.in/
@@ -96,7 +96,7 @@ ThoughtStorms http://www.nooranch.com/synaesmedia/wiki/wiki.cgi?
 TWiki http://twiki.org/cgi-bin/view/
 UPC http://www.upcdatabase.com/item/
 Unreal http://wiki.beyondunreal.com/wiki/
-UseMod http://www.usemod.com/cgi-bin/wiki.pl?
+UseMod http://www.usemod.org/cgi-bin/wiki.pl?
 WebSeitzWiki http://webseitz.fluxent.com/wiki/
 Wiki http://c2.com/cgi/wiki?
 WikiPedia https://en.wikipedia.org/wiki/

--- a/src/moin/themes/__init__.py
+++ b/src/moin/themes/__init__.py
@@ -489,7 +489,7 @@ class ThemeSupport:
             url, link_text, title = self.split_navilink(text)
             items.append(("userlink", url, link_text, title))
 
-        # Add sister pages (see http://usemod.com/cgi-bin/mb.pl?SisterSitesImplementationGuide )
+        # Add sister pages (see http://meatballwiki.org/wiki/?SisterSitesImplementationGuide )
         for sistername, sisterurl in self.cfg.sistersites:
             if is_local_wiki(sistername):
                 items.append(("sisterwiki current", sisterurl, sistername, ""))


### PR DESCRIPTION
the previous page usemod.com is no longer in use by the original owners and is now used for promotion of gambling

the original authors and owners now use usemod.org and meatballwiki.org for the same purpose

this PR changes the URLs in the code to the new destinations

this does *not* change the URLs also in the installations themselves, which all need to be update manually

fixes https://github.com/moinwiki/moin/issues/1729