### PR TITLE
Remove parawiki[.]org (Thai gambling) from intermap.txt

### DIFF
--- a/src/moin/contrib/intermap.txt
+++ b/src/moin/contrib/intermap.txt
@@ -82,7 +82,6 @@ MoinMaster https://master.moinmo.in/
 MoinMoin https://moinmo.in/
 OddMuse http://www.oddmuse.org/
 OpenWiki http://openwiki.com/ow.asp?
-Parawiki http://www.parawiki.org/index.php/
 PersonalTelco http://www.personaltelco.net/index.cgi/
 PythonInfo https://wiki.python.org/moin/
 PythonWiki http://wiki.python.de/


### PR DESCRIPTION
The Website httpX://parawiki[.]org/ promotes a Thai gambling service

It's similar to https://github.com/moinwiki/moin/issues/1729