### PR TITLE
app.py: skip before_wiki and teardown_wiki for static content

### DIFF
--- a/src/moin/app.py
+++ b/src/moin/app.py
@@ -13,6 +13,7 @@ Use create_app(config) to create the WSGI application (using Flask).
 
 import os
 from os import path
+import re
 import sys
 
 from flask import Flask, request, session
@@ -292,6 +293,10 @@ def before_wiki():
     """
     Setup environment for wiki requests, start timers.
     """
+    if request and is_static_content(request.path):
+        logging.debug(f"skipping before_wiki for {request.path}")
+        return
+
     logging.debug("running before_wiki")
     flaskg.clock = Clock()
     flaskg.clock.start("total")
@@ -323,23 +328,22 @@ def teardown_wiki(response):
     """
     Teardown environment of wiki requests, stop timers.
     """
+    if request:
+        request_path = request.path
+        if is_static_content(request_path):
+            return response
+    else:
+        request_path = ""
+
     logging.debug("running teardown_wiki")
-    try:
-        if request:
-            request_path = request.path
-        else:
-            request_path = ""
-        flaskg.clock.stop("total", comment=request_path)
-        del flaskg.clock
-    except AttributeError:
-        # can happen if teardown_wiki() is called twice, e.g. by unit tests.
-        pass
+
     if hasattr(flaskg, "edit_utils"):
         # if transaction fails with sql file locked, we try to free it here
         try:
             flaskg.edit_utils.conn.close()
         except AttributeError:
             pass
+
     try:
         # whoosh cache performance
         for cache in (
@@ -357,4 +361,22 @@ def teardown_wiki(response):
         # moin commands may not have flaskg.storage
         pass
 
+    try:
+        flaskg.clock.stop("total", comment=request_path)
+        del flaskg.clock
+    except AttributeError:
+        # can happen if teardown_wiki() is called twice, e.g. by unit tests.
+        pass
+
     return response
+
+
+def is_static_content(request_path):
+    """
+    Check if content is static and does not need usual wiki handling
+    """
+
+    if request_path.startswith(("/static/", "/+serve/", "/+template/")) or re.match(r"/_themes/\w+/css/", request_path):
+        return True
+    else:
+        return False

--- a/src/moin/app.py
+++ b/src/moin/app.py
@@ -325,7 +325,11 @@ def teardown_wiki(response):
     """
     logging.debug("running teardown_wiki")
     try:
-        flaskg.clock.stop("total")
+        if request:
+            request_path = request.path
+        else:
+            request_path = ""
+        flaskg.clock.stop("total", comment=request_path)
         del flaskg.clock
     except AttributeError:
         # can happen if teardown_wiki() is called twice, e.g. by unit tests.

--- a/src/moin/utils/clock.py
+++ b/src/moin/utils/clock.py
@@ -1,5 +1,6 @@
 # Copyright: 2001-2003 Juergen Hermann <jh@web.de>
 # Copyright: 2003-2006 MoinMoin:ThomasWaldmann
+# Copyright: 2024 MoinMoin:UlrichB
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -22,11 +23,12 @@ class Clock:
     Helper class for measuring the time needed to run code.
 
     Usage:
-        flaskg.clock.start('mytimer')
+        flaskg.clock.start("mytimer")
         # do something
-        flaskg.clock.stop('mytimer')
+        flaskg.clock.stop("mytimer", comment="add this to the log message")
+        # the optional comment field is added to the log message
         # or if you want to use its value later
-        timerval = flaskg.clock.stop('mytimer')
+        timerval = flaskg.clock.stop("mytimer")
 
     Starting a timer multiple times is supported but the
     one started last has to be stopped first.
@@ -40,10 +42,10 @@ class Clock:
             self.timers[timer] = []
         self.timers[timer].append(time.time())
 
-    def stop(self, timer):
+    def stop(self, timer, comment=""):
         if timer in self.timers:
             value = time.time() - self.timers[timer].pop()
-            logging.debug(f"timer {timer}({len(self.timers[timer])}): {value * 1000:.2f}ms")
+            logging.debug(f"timer {timer}({len(self.timers[timer])}): {value * 1000:.2f}ms {comment}")
             if not self.timers[timer]:
                 del self.timers[timer]
             return value


### PR DESCRIPTION
Skip the before_wiki and teardown wiki handling for static content such as CSS files.
The before_wiki function is needed to open the storage, set up the user - important for ACL handling, setting up the Jinja environment, etc.. The static content is public and therefore the before_wiki and teardown_wiki code is unnecessary overhead. 

The request_path / url has been added to the timer message in the debug log.

Moved clock stop to the end of teardown_wiki. Is there a reason for the existing code sequence?

Related to #1725.