### PR TITLE
markdown: stricter detection of embedded markup

### DIFF
--- a/src/moin/converters/_tests/test_markdown_in.py
+++ b/src/moin/converters/_tests/test_markdown_in.py
@@ -182,6 +182,17 @@ class TestConverter:
     def test_admonition(self, input, output):
         self.do(input, output)
 
+    data = [
+        ("one < two", "<p>one &lt; two</p>"),
+        ("[[one]] < two", '<p><a xlink:href="wiki.local:one">one</a> &lt; two</p>'),
+        ("pre <strong>bold</strong> post", "<div><p>pre <strong>bold</strong> post</p></div>"),
+    ]
+
+    @pytest.mark.parametrize("input,output", data)
+    def test_embedded_markup(self, input, output):
+        """Test embedded markup in markdown"""
+        self.do(input, output)
+
     def serialize_strip(self, elem, **options):
         result = serialize(elem, namespaces=self.namespaces, **options)
         return self.output_re.sub("", result)

--- a/src/moin/converters/markdown_in.py
+++ b/src/moin/converters/markdown_in.py
@@ -531,7 +531,8 @@ class Converter:
         """
         for idx, child in enumerate(node):
             if isinstance(child, str):
-                if "<" in child:
+                # search for HTML tags
+                if re.search("<[^ ].*?>", child):
                     node[idx] = self.embedded_markup(child)  # child is immutable string, so must do node[idx]
             else:
                 # do not convert markup within a <pre> tag


### PR DESCRIPTION
instead of only checking only for the existence of `<`, check for text directly behind the opening bracket and a closing bracket.

This prevents added paragraphs/new lines with just brackets or "arrows" (`<-`) in lines.

fixes https://github.com/moinwiki/moin/issues/1761