### PR TITLE
Fix delete/destroy from +index and ...

### DIFF
--- a/src/moin/static/js/index_action.js
+++ b/src/moin/static/js/index_action.js
@@ -27,7 +27,7 @@ $("document").ready(function () {
     function get_checked() {
         var checked_names = [];
         $("input.moin-item:checked").each(function () {
-            var itemname = $(this).attr("value").slice(1);
+            var itemname = $(this).attr("value");
             checked_names.push(itemname);
         });
         return checked_names;
@@ -106,7 +106,7 @@ $("document").ready(function () {
             url;
         // create an array of selected item names
         $("input.moin-item:checked").each(function () {
-            var itemname = $(this).attr("value").slice(1);
+            var itemname = $(this).attr("value");
             links.push(itemname);
         });
         // remove any flash messages, display "deleting..." or "destroying..." flash msg while process is in progress
@@ -125,7 +125,7 @@ $("document").ready(function () {
             comment: comment,
             do_subitems: $("#moin-do-subitems").is(":checked") ? "true" : "false"
         }, function (data) {
-            // incoming itemnames is url-encoded list of item names (including alias names) successfully deleted/destroyed
+            // incoming itemnames is list of item names (including alias names) successfully deleted/destroyed
             var itemnames = data.itemnames,
                 idx;
             // display success/fail flash messages created by server for each selected item and subitem

--- a/src/moin/templates/index.html
+++ b/src/moin/templates/index.html
@@ -27,7 +27,7 @@ a checkbox, an invisible link used by js for download, a link to the item
     <tr>
         <td class="moin-index-icons">
             <span class="moin-select-item">
-                <input class="moin-item" type="checkbox" value="{{ url_for('.show_item', item_name=e.fullname) }}"/>
+                <input class="moin-item" type="checkbox" value="{{ e.fullname }}"/>
                 {% set mimetype = "application/x.moin.download" %}
                 {# invisible link below is used by js to download item #}
                 <a href="{{ url_for('.download_item', item_name=e.fullname, mimetype=mimetype) }}" class="moin-download-link">

--- a/src/moin/translations/de/LC_MESSAGES/messages.po
+++ b/src/moin/translations/de/LC_MESSAGES/messages.po
@@ -2443,11 +2443,11 @@ msgstr "Kommentar zum Änderungslog zufügen (optional)."
 
 #: src/moin/templates/index.html:293
 msgid "Selected names: "
-msgstr "Auswahl"
+msgstr "Auswahl: "
 
 #: src/moin/templates/index.html:294
 msgid "Alias names: "
-msgstr "Alias Namen:"
+msgstr "Alias Namen: "
 
 #: src/moin/templates/index.html:297
 msgid "Check to remove subitems"
@@ -2455,11 +2455,11 @@ msgstr "Auswählen um Subitems zu löschen"
 
 #: src/moin/templates/index.html:299
 msgid "Subitem names: "
-msgstr "Subitem-Name"
+msgstr "Subitem-Namen: "
 
 #: src/moin/templates/index.html:300
 msgid "Rejected names, permission denied: "
-msgstr "Unzulässge Namen, keine Berechtigung: "
+msgstr "Unzulässige Namen, keine Berechtigung: "
 
 #: src/moin/templates/index.html:302
 msgid "Enter your comment"


### PR DESCRIPTION
- add namespace handling for subitems and aliases in ajaxsubitems()
- fix some typos in DE translations

The reason for the issue was the url_for() usage for the itemnames in the checkbox values. Removing it also fixes problems of the javascript with non-ascii characters. Do we need any kind of encoding here? 

Fixes #1753.

This PR should be merged after #1764.