### PR TITLE
Deactivate exists checks for page trail and ignore non-existent items

### DIFF
--- a/src/moin/_tests/test_user.py
+++ b/src/moin/_tests/test_user.py
@@ -217,10 +217,10 @@ class TestUser:
         assert result == expected
 
         # item name added to trail
-        theUser.add_trail("item_added")
+        theUser.add_trail("item_added", [])
         theUser = user.User(name=name, password=password)
         result = theUser.get_trail()
-        expected = ["MoinTest/item_added"]
+        expected = [("MoinTest/item_added", [])]
         assert result == expected
 
     # Sessions -------------------------------------------------------

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -531,7 +531,7 @@ def add_presenter(wrapped, view, add_trail=False, abort404=True):
         if abort404 and isinstance(item, NonExistent):
             abort(404, item_name)
         if add_trail:
-            flaskg.user.add_trail(item_name)
+            flaskg.user.add_trail(item_name, aliases=item.meta.revision.fqnames)
         return wrapped(item)
 
     return wrapper
@@ -589,7 +589,7 @@ def show_item(item_name, rev):
     try:
         item = Item.create(item_name, rev_id=rev)
         if item.itemtype != ITEMTYPE_NONEXISTENT:
-            flaskg.user.add_trail(item_name)
+            flaskg.user.add_trail(item_name, aliases=item.meta.revision.fqnames)
         item_is_deleted = flash_if_item_deleted(item_name, rev, item)
         item_may = get_item_permissions(fqname, item)
         result = item.do_show(rev, item_is_deleted=item_is_deleted, item_may=item_may)

--- a/src/moin/templates/utils.html
+++ b/src/moin/templates/utils.html
@@ -233,13 +233,13 @@
     {%- endif %}
 {%- endmacro -%}
 
-{% macro page_trail_link(wiki_name, fqname, exists) %}
+{% macro page_trail_link(wiki_name, fqname) %}
     {%- if wiki_name -%}
         <a href="{{ item_href }}"{{ " " }} title="{{ wiki_name }}" class="{% if err %}moin-badinterwiki{% else %}moin-interwiki{% endif %}">
             {{ fqname|shorten_fqname }}
         </a>
     {%- else -%}
-        <a href="{{ url_for('frontend.show_item', item_name=fqname) }}"{{ " " }} {% if not exists -%}class="moin-nonexistent"{%- endif -%}>
+        <a href="{{ url_for('frontend.show_item', item_name=fqname) }}"{{ " " }}>
             {{ fqname|shorten_fqname }}
         </a>
     {%- endif %}
@@ -257,30 +257,30 @@
         <li class="moin-panel-heading">{{ _('Page Trail') }}</li>
         {%- set trail_items = breadcrumbs() %}
         {%- if trail_items %}
-            {%- for wiki_name, fqname, item_href, exists, err in trail_items %}
+            {%- for wiki_name, fqname, item_href, aliases, err in trail_items %}
                 {%- if not loop.last %}
                     <li>
-                        {{ page_trail_link(wiki_name, fqname, exists) }}
-                        {{ alias_list(theme_supp.get_fqnames(fqname)) }}
+                        {{ page_trail_link(wiki_name, fqname) }}
+                        {{ alias_list(aliases) }}
                         <i class="fa fa-angle-double-right fa-fw"></i>
                     </li>
                 {%- endif %}
                 {%- if loop.last %}
                     <li>
                         <span class="moin-big">
-                            {%- for segment_name, segment_path, exists in theme_supp.location_breadcrumbs(fqname) -%}
+                            {%- for segment_name, segment_path in theme_supp.location_breadcrumbs(fqname) -%}
                                 {%- if not loop.last %}
-                                    <a href="{{ url_for('frontend.show_item', item_name=segment_path) }}" {%- if not exists -%}class="moin-nonexistent"{%- endif -%}>
+                                    <a href="{{ url_for('frontend.show_item', item_name=segment_path) }}">
                                         {{ segment_name|shorten_fqname }}
                                     </a>
                                 {%- else %}
-                                    <a href="{{ url_for('frontend.show_item', item_name=segment_path) }}" {% if not exists %}class="moin-nonexistent"{% endif %}>
+                                    <a href="{{ url_for('frontend.show_item', item_name=segment_path) }}">
                                         {{ segment_name|shorten_fqname }}
                                     </a>
                                 {%- endif %}
                             {%- endfor %}
                         </span>
-                        {{ alias_list(theme_supp.get_fqnames(fqname)) }}
+                        {{ alias_list(aliases) }}
                     </li>
                     {%- if title_name %}
                         <li>

--- a/src/moin/themes/__init__.py
+++ b/src/moin/themes/__init__.py
@@ -349,7 +349,7 @@ class ThemeSupport:
             current_item += segment
             fq_current = CompositeName(namespace, NAME_EXACT, current_item)
             fq_segment = CompositeName(segment1_namespace, NAME_EXACT, segment)
-            breadcrumbs.append((fq_segment, fq_current, bool(self.storage.get_item(**fq_current.query))))
+            breadcrumbs.append((fq_segment, fq_current, True))
             current_item += "/"
             segment1_namespace = ""
         return breadcrumbs
@@ -370,12 +370,9 @@ class ThemeSupport:
             err = not is_known_wiki(wiki_name)
             href = url_for_item(wiki_name=wiki_name, **fqname.split)
             if is_local_wiki(wiki_name):
-                exists = bool(self.storage.get_item(**fqname.query))
                 wiki_name = ""  # means "this wiki" for the theme code
-            else:
-                exists = True  # we can't detect existance of remote items
             if item_name:
-                breadcrumbs.append((wiki_name, fqname, href, exists, err))
+                breadcrumbs.append((wiki_name, fqname, href, True, err))
         return breadcrumbs
 
     def userhome(self):

--- a/src/moin/themes/__init__.py
+++ b/src/moin/themes/__init__.py
@@ -332,14 +332,13 @@ class ThemeSupport:
         namespace as a prefix.
 
         :rtype: list
-        :returns: location breadcrumbs items in tuple (segment_name, fq_name, exists)
+        :returns: location breadcrumbs items in tuple (segment_name, fq_name)
         """
         breadcrumbs = []
         current_item = ""
         if not isinstance(fqname, CompositeName):
             fqname = split_fqname(fqname)
         if fqname.field != NAME_EXACT:
-            # flaskg.unprotected_storage.get_item(**fqname.query)
             return [(fqname, fqname, bool(self.storage.get_item(**fqname.query)))]
         namespace = segment1_namespace = fqname.namespace
         item_name = fqname.value
@@ -349,7 +348,7 @@ class ThemeSupport:
             current_item += segment
             fq_current = CompositeName(namespace, NAME_EXACT, current_item)
             fq_segment = CompositeName(segment1_namespace, NAME_EXACT, segment)
-            breadcrumbs.append((fq_segment, fq_current, True))
+            breadcrumbs.append((fq_segment, fq_current))
             current_item += "/"
             segment1_namespace = ""
         return breadcrumbs
@@ -364,7 +363,7 @@ class ThemeSupport:
         user = self.user
         breadcrumbs = []
         trail = user.get_trail()
-        for interwiki_item_name in trail:
+        for interwiki_item_name, aliases in trail:
             wiki_name, namespace, field, item_name = split_interwiki(interwiki_item_name)
             fqname = CompositeName(namespace, field, item_name)
             err = not is_known_wiki(wiki_name)
@@ -372,7 +371,7 @@ class ThemeSupport:
             if is_local_wiki(wiki_name):
                 wiki_name = ""  # means "this wiki" for the theme code
             if item_name:
-                breadcrumbs.append((wiki_name, fqname, href, True, err))
+                breadcrumbs.append((wiki_name, fqname, href, aliases, err))
         return breadcrumbs
 
     def userhome(self):
@@ -557,17 +556,6 @@ class ThemeSupport:
         if self.cfg.auth_have_login:
             url = url or url_for("frontend.login")
         return url
-
-    def get_fqnames(self, fqname):
-        """
-        Return the list of other fqnames associated with the item.
-        """
-        if fqname.field != NAME_EXACT:
-            return []
-        item = self.storage.get_item(**fqname.query)
-        fqnames = item.fqnames
-        fqnames.remove(fqname)
-        return fqnames or []
 
     def get_namespaces(self, ns=None):
         """

--- a/src/moin/themes/_tests/test_navi_bar.py
+++ b/src/moin/themes/_tests/test_navi_bar.py
@@ -45,9 +45,9 @@ class TestNaviBar:
 
     def test_location_breadcrumbs(self, theme):
         test_result = ThemeSupport.location_breadcrumbs(theme, "some/place/test_item")
-        test_segment_name_1, test_item_name_1, test_item_exists_1 = test_result[0]
-        test_segment_name_2, test_item_name_2, test_item_exists_2 = test_result[1]
-        test_segment_name_3, test_item_name_3, test_item_exists_3 = test_result[2]
+        test_segment_name_1, test_item_name_1 = test_result[0]
+        test_segment_name_2, test_item_name_2 = test_result[1]
+        test_segment_name_3, test_item_name_3 = test_result[2]
 
         assert test_segment_name_1.namespace == ""
         assert test_item_name_1.namespace == ""
@@ -59,9 +59,9 @@ class TestNaviBar:
         assert test_item_name_3.value == "some/place/test_item"
 
         test_result = ThemeSupport.location_breadcrumbs(theme, "users/some/place/test_item")
-        test_segment_name_1, test_item_name_1, test_item_exists_1 = test_result[0]
-        test_segment_name_2, test_item_name_2, test_item_exists_2 = test_result[1]
-        test_segment_name_3, test_item_name_3, test_item_exists_3 = test_result[2]
+        test_segment_name_1, test_item_name_1 = test_result[0]
+        test_segment_name_2, test_item_name_2 = test_result[1]
+        test_segment_name_3, test_item_name_3 = test_result[2]
 
         assert test_segment_name_1.namespace == "users"
         assert test_item_name_1.namespace == "users"


### PR DESCRIPTION
Related to #1781.

The cleanup of the code related to the “exists” field will be done later.


