### PR TITLE
ItemList: use _args_wiki parser

### DIFF
--- a/src/moin/macros/_base.py
+++ b/src/moin/macros/_base.py
@@ -239,7 +239,7 @@ class MacroPageLinkListBase(MacroBlockBase):
             elif display == "ItemTitle":
                 linkname = extract_h1(pagename.fullname)
             else:
-                err_msg = _('Unrecognized display value "{display}".').format(display=display)
+                err_msg = _('Unrecognized "display" value "{display}".').format(display=display)
                 return fail_message(err_msg, alternative)
 
             pagelink = moin_page.a(attrib={xlink.href: url}, children=[linkname])


### PR DESCRIPTION
Related to #1809.

The usage of the _args_wiki parser changes the handling of quotes. For most arguments except regex there is no difference if quotes are used or not. E.g. following parameters are valid: `ordered="False"` or `ordered='False'` or `ordered=False`.