### PR TITLE
Add bandit scan to github workflow

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,0 +1,45 @@
+# Bandit is a tool designed to find common security issues in Python code
+# this is a customized copy from https://github.com/PyCQA/bandit-action
+# original author: '@PyCQA'
+#
+# Target for code check is src/moin, test modules are exclude in config file
+# All alerts are logged in the GitHub UI on the Security tab, Code Scanning (choose your branch)
+
+name: Bandit
+
+on:
+  push:
+    branches:
+      - master
+      - test-github-action
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  bandit_check:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install Bandit
+        shell: bash
+        run: pip install bandit[sarif]
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Bandit
+        shell: bash
+        run: bandit -c pyproject.toml -r src/moin -f sarif -o results.sarif || true
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Used a customized copy of the action.yml from https://github.com/PyCQA/bandit-action.

The use of bandit-action was not possible because it uses Python 3.9. Reading the configuration in pyproject.toml requires an additional installation step for toml. This tool is integrated in Python since 3.11. If bandit-action raises the Python version, we can switch to bandit-action later.

Bandit results do not abort the workflow, it is terminated with success. The results are imported into the github security area using a sarif file. This area is protected and not publicly accessible. Tested with branch name 'test-github-action'.

![image](https://github.com/user-attachments/assets/2cef4313-2bb3-4410-a4bf-685a8e852498)
 

