### PR TITLE
Add CSP header and receiver

### DIFF
--- a/docs/admin/configure.rst
+++ b/docs/admin/configure.rst
@@ -1126,6 +1126,25 @@ items with the same names::
         return CompositeDicts(ConfigDicts(dicts),
                               WikiDicts())
 
+
+Content security policy (CSP)
+=============================
+
+MoinMoin offers a basic functionality for setting CSP headers and logging CSP reports
+from client browsers. The behavior can be configured with the options
+“content_security_policy” and “content_security_policy_report_only”.
+
+If one of these options is set to "", the corresponding header is not set.
+In the default configuration, no policy is set or enforced, but a header is added
+to report CSP violations in the log. To debug the settings, we recommend using the
+developer tools in your browser.
+
+With the option “content_security_policy_limit_per_day”, admins can limit the number
+of reports in the log per day to avoid log overflow.
+
+The CSP configuration depends on the individual wiki landscape and the capabilities
+of web browsers vary. For details see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP.
+
 Storage
 =======
 MoinMoin supports storage backends as different ways of storing wiki items.

--- a/src/moin/app.py
+++ b/src/moin/app.py
@@ -2,7 +2,7 @@
 # Copyright: 2002-2011 MoinMoin:ThomasWaldmann
 # Copyright: 2008 MoinMoin:FlorianKrupicka
 # Copyright: 2010 MoinMoin:DiogenesAugusto
-# Copyright: 2023-2024 MoinMoin:UlrichB
+# Copyright: 2023-2025 MoinMoin:UlrichB
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -190,6 +190,9 @@ def create_app_ext(flask_config_file=None, flask_config_dict=None, moin_config_c
         app.jinja_env.loader = ChoiceLoader([FileSystemLoader(app.cfg.template_dirs), app.jinja_env.loader])
     app.register_error_handler(403, themed_error)
     clock.stop("create_app flask-theme")
+    # create global counter to limit content security policy reports, prevent spam
+    app.csp_count = 0
+    app.csp_last_date = ""
     clock.stop("create_app total")
     del clock
     return app
@@ -294,7 +297,7 @@ def before_wiki():
     """
     Setup environment for wiki requests, start timers.
     """
-    if request and is_static_content(request.path):
+    if request and (is_static_content(request.path) or request.path == "+cspreport/log"):
         logging.debug(f"skipping before_wiki for {request.path}")
         return
 

--- a/src/moin/apps/admin/views.py
+++ b/src/moin/apps/admin/views.py
@@ -4,7 +4,7 @@
 # Copyright: 2009 MoinMoin:EugeneSyromyatnikov
 # Copyright: 2010 MoinMoin:DiogenesAugusto
 # Copyright: 2010 MoinMoin:ReimarBauer
-# Copyright: 2024 MoinMoin:UlrichB
+# Copyright: 2024-2025 MoinMoin:UlrichB
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -27,7 +27,7 @@ from whoosh.query import Term, And, Not
 from moin.i18n import _, L_
 from moin.themes import render_template, get_editor_info
 from moin.apps.admin import admin
-from moin.apps.frontend.views import _using_moin_auth
+from moin.apps.frontend.views import _using_moin_auth, add_csp_headers
 from moin import user
 from moin.constants.keys import (
     NAME,
@@ -621,3 +621,8 @@ def modify_acl(item_name):
             "error",
         )
     return redirect(url_for(".item_acl_report"))
+
+
+@admin.after_request
+def add_security_headers(resp):
+    return add_csp_headers(resp)

--- a/src/moin/config/default.py
+++ b/src/moin/config/default.py
@@ -637,6 +637,13 @@ options_no_group_name = {
                 [],
                 "List of available content types for new items. Default: [] (all types enabled).",
             ),
+            ("content_security_policy", "", "Content security policy."),
+            (
+                "content_security_policy_report_only",
+                "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self';",
+                "Content security policy in report-only mode.",
+            ),
+            ("content_security_policy_limit_per_day", 100, "Limit of reports logged per day."),
         ),
     ),
 }

--- a/src/moin/config/wikiconfig.py
+++ b/src/moin/config/wikiconfig.py
@@ -137,6 +137,13 @@ class Config(DefaultConfig):
     # for users who self-register
     user_email_verification = False
 
+    # content_security_policy = ""  # Content security policy, setting will be enforced
+    # if value is empty, CSP header will not be set at all
+    # Content security policy in report-only mode, the report_uri directive will be added automatically
+    # content_security_policy_report_only = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self';"
+    # see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for configuration details
+    # content_security_policy_limit_per_day = 100  # Limit of reports logged per day, 0 equals unlimited
+
     # Define the super user who will have access to administrative functions like user registration,
     # password reset, disabling users, etc.
     acl_functions = "YOUR-SUPER-USER-NAME:superuser"


### PR DESCRIPTION
Related to #1816.

This implementation uses 'report-uri'. Many tests with 'report-to' did not provide the expected results.

Successfully tested with Chromium 133.0.6943.53 and Firefox 135.0-2.
Tests included items Home, help-en/Home and +admin.

