### PR TITLE
Add FullSearch macro migration for moin1.9 categories

### DIFF
--- a/src/moin/cli/migration/moin19/macros/FullSearch.py
+++ b/src/moin/cli/migration/moin19/macros/FullSearch.py
@@ -1,0 +1,73 @@
+# Copyright: 2025 MoinMoin:UlrichB
+# License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
+
+"""
+MoinMoin CLI - Migration of FullSearch macro (moin1.9) to new ItemList macro (moin2) if possible
+"""
+
+from moin.cli.migration.moin19 import macro_migration
+from moin.utils.tree import moin_page
+
+CONTENT_TYPE_MACRO_FORMATTER = "x-moin/macro;name={}"
+MACRO_NAME_FULLSEARCH = "FullSearch"
+MACRO_NAME_FULLSEARCH_CACHED = "FullSearchCached"
+
+
+def convert_fullsearch_macro_to_item_list(node):
+    """Convert the given FullSearch macro node to an ItemList macro in-place
+
+    The moin1.9 FullSearch macro is used in various situations. One case
+    is the listing of all pages for a specific category. In moin2, the
+    categories are replaced by tags. Therefore, all macro calls related to
+    categories are converted to the moin2 macro ItemList.
+
+    In all other cases, the FullSearch macro call is not changed.
+    The same applies to the FullSearchCached macro.
+
+    Example conversions:
+
+    | PageList macro (moin1.9)                | ItemList macro (moin2)                       |
+    |-----------------------------------------|----------------------------------------------|
+    | <<FullSearch(CategorySample)>>          | <<ItemList(item="/", tag="CategorySample")>> |
+    | <<FullSearch(category:CategorySample)>> | <<ItemList(item="/", tag="CategorySample")>> |
+
+    :param node: the DOM node matching the FullSearch macro content type
+    :type node: emeraldtree.tree.Element
+    """
+
+    # arguments
+    args_before = None
+    for elem in node.iter_elements():
+        if elem.tag.name == "arguments":
+            args_before = elem.text
+    if args_before and args_before.startswith("Category"):
+        # argument is a category name, lets migrate to ItemList macro
+        args_after = f'item="/", tag="{args_before}"'
+    elif args_before and args_before.startswith("category:"):
+        # argument is a category name, strip keyword and migrate to ItemList macro
+        args_after = f'item="/", tag="{args_before[9:]}"'
+    else:
+        # argument is not a category or empty, we keep the old FullSearch macro
+        return
+
+    # content type
+    new_content_type = CONTENT_TYPE_MACRO_FORMATTER.format("ItemList")
+    node.set(moin_page.content_type, new_content_type)
+
+    for elem in node.iter_elements():
+        if elem.tag.name == "arguments":
+            elem.clear()
+            elem.append(args_after)
+
+    # 'alt' attribute
+    new_alt = f"<<ItemList({args_after})>>"
+    node.set(moin_page.alt, new_alt)
+
+
+macro_migration.register_macro_migration(
+    CONTENT_TYPE_MACRO_FORMATTER.format(MACRO_NAME_FULLSEARCH), convert_fullsearch_macro_to_item_list
+)
+
+macro_migration.register_macro_migration(
+    CONTENT_TYPE_MACRO_FORMATTER.format(MACRO_NAME_FULLSEARCH_CACHED), convert_fullsearch_macro_to_item_list
+)

--- a/src/moin/cli/migration/moin19/macros/_tests/test_FullSearch_migration.py
+++ b/src/moin/cli/migration/moin19/macros/_tests/test_FullSearch_migration.py
@@ -1,0 +1,57 @@
+# Copyright: 2025 MoinMoin:UlrichB
+# License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
+
+"""
+    MoinMoin - moin.cli.migration.moin19.macros Test FullSearch
+"""
+
+import pytest
+
+from moin.converters.moinwiki19_in import ConverterFormat19
+
+from moin.cli.migration.moin19 import import19
+from moin.cli.migration.moin19.macro_migration import migrate_macros
+
+from moin.utils.tree import moin_page
+
+
+@pytest.mark.parametrize(
+    "legacy_macro,expected_args",
+    [
+        ("<<FullSearch(CategorySample)>>", 'item="/", tag="CategorySample"'),
+        ("<<FullSearch(category:CategorySample)>>", 'item="/", tag="CategorySample"'),
+        ("<<FullSearchCached(CategoryTest)>>", 'item="/", tag="CategoryTest"'),
+    ],
+)
+def test_macro_conversion_itemlist(legacy_macro, expected_args):
+    # macro calls for Categories
+    converter = ConverterFormat19()
+    dom = converter(legacy_macro, import19.CONTENTTYPE_MOINWIKI)
+    migrate_macros(dom)  # in-place conversion
+
+    body = list(dom)[0]
+    part = list(body)[0]
+
+    assert part.get(moin_page.content_type) == "x-moin/macro;name=ItemList"
+    assert part.get(moin_page.alt) == f"<<ItemList({expected_args})>>"
+
+
+@pytest.mark.parametrize(
+    "legacy_macro,expected_args",
+    [
+        ("<<FullSearch()>>", ""),
+        ("<<FullSearch(Calendar/2025-01-01)>>", "Calendar/2025-01-01"),
+        ("<<FullSearch('AnyText')>>", "'AnyText'"),
+    ],
+)
+def test_macro_conversion_fullsearch(legacy_macro, expected_args):
+    # macro calls other than Categories are not changed
+    converter = ConverterFormat19()
+    dom = converter(legacy_macro, import19.CONTENTTYPE_MOINWIKI)
+    migrate_macros(dom)  # in-place conversion
+
+    body = list(dom)[0]
+    part = list(body)[0]
+
+    assert part.get(moin_page.content_type) == "x-moin/macro;name=FullSearch"
+    assert part.get(moin_page.alt) == f"<<FullSearch({expected_args})>>"

--- a/src/moin/macros/ItemList.py
+++ b/src/moin/macros/ItemList.py
@@ -127,8 +127,10 @@ class Macro(MacroPageLinkListBase):
             if item.startswith("+modify/"):
                 item = item.split("/", 1)[1]
 
+        if item == "/":
+            item = ""
         # verify item exists and current user has read permission
-        if item != "":
+        elif item != "":
             if not flaskg.storage.get_item(**(split_fqname(item).query)):
                 err_msg = _("Item does not exist or read access blocked by ACLs: {0}").format(item)
                 return fail_message(err_msg, alternative)


### PR DESCRIPTION
Related to #1585.

The moin1.9 FullSearch macro is used in various situations. One case is the listing of all pages for a specific category. In moin2, the categories are replaced by tags. Therefore, all macro calls related to categories are converted to the moin2 macro ItemList.

In all other cases, the FullSearch macro call is not changed. The same applies to the FullSearchCached macro.

In moin1.9 it is possible to use Categories written as a link, e.g.

```
----

[[CategorySample]]
```

In this case the import19 migration keeps the opening brackets in the item and adds the closing brackets to the category name. This is also fixed with this PR.