### PR TITLE
Fix download link for binary content (missing namespace)

### DIFF
--- a/src/moin/converters/_tests/test_everything.py
+++ b/src/moin/converters/_tests/test_everything.py
@@ -1,0 +1,51 @@
+# Copyright: 2025 MoinMoin
+# License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
+
+"""
+MoinMoin - Tests for moin.converters.everything
+"""
+
+import pytest
+
+from . import serialize, XMLNS_RE
+
+from moin.constants.keys import CONTENTTYPE, ITEMTYPE, REV_NUMBER
+from moin.converters.everything import Converter
+from moin.items.content import Content
+
+from moin.utils.interwiki import split_fqname
+
+from moin.items import Item
+from moin.utils.tree import moin_page, xlink, html, xinclude
+
+from unittest.mock import Mock
+
+namespaces = {moin_page: "", xlink: "xlink", html: "xhtml", xinclude: "xinclude"}
+
+meta = {CONTENTTYPE: "binary/blob", ITEMTYPE: "default", REV_NUMBER: 1}
+
+output_re = XMLNS_RE
+
+
+def serialize_strip(elem, **options):
+    result = serialize(elem, namespaces=namespaces, **options)
+    return output_re.sub("", result)
+
+
+@pytest.mark.parametrize(
+    "input,output",
+    [
+        (
+            "machines/nuc/fw2.blob",
+            '<page><body><a xlink:href="wiki:///machines/nuc/fw2.blob?do=get&amp;rev=691da3aa1dd146d296bcd9ac92b25be5">Download machines/nuc/fw2.blob.</a></body></page>',
+        )
+    ],
+)
+def test_conv(input, output):
+    rev = Mock()
+    rev.meta = meta
+    rev.revid = "691da3aa1dd146d296bcd9ac92b25be5"
+    rev.item = Item(split_fqname(input), rev=rev, content=Content.create(meta[CONTENTTYPE]))
+    conv = Converter()
+    out = conv(rev, rev.item.contenttype)
+    assert serialize_strip(out) == output

--- a/src/moin/converters/everything.py
+++ b/src/moin/converters/everything.py
@@ -37,7 +37,7 @@ class Converter:
             body = moin_page.body(children=(admonition,))
             return moin_page.page(children=(body,))
         attrib = {xlink.href: Iri(scheme="wiki", authority="", path="/" + item_name, query=f"do=get&rev={rev.revid}")}
-        a = moin_page.a(attrib=attrib, children=[f"Download {item_name}."])
+        a = moin_page.a(attrib=attrib, children=[_("Download {item_name}.").format(item_name=item_name)])
         body = moin_page.body(children=(a,))
         return moin_page.page(children=(body,))
 

--- a/src/moin/converters/everything.py
+++ b/src/moin/converters/everything.py
@@ -27,7 +27,7 @@ class Converter:
 
     def __call__(self, rev, contenttype=None, arguments=None):
         try:
-            item_name = rev.item.name or rev.meta["name"][0]
+            item_name = rev.item.fqname.fullname or rev.meta["name"][0]
         except IndexError:
             # item is deleted
             message = _(


### PR DESCRIPTION
The converter for binary content (moin.converters.everything) in moin version 2.0.0b2 ignores the item namespace when creating the dom content. The result is an invalid download link when viewing the subitem.

Downloads are working when using the fully qualified item name.

Question in this context: shouldn't the link text created for downloading be localized? Currently it seems to hard-coded to "Download \<item-name\>."