### PR TITLE
Exclude UI tests in the bandit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,9 @@ repos:
   - id: bandit
     args: ["-c", "pyproject.toml"]
     additional_dependencies: ["bandit[toml]"]
+    exclude: |
+      (?x)(
+        ^quickinstall.py|
+        /_tests/|
+        ^_ui_tests/
+      )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ unfixable = []
 "src/moin/datastructures/__init__.py" = ["F401"]
 
 [tool.bandit]
-exclude_dirs = ["quickinstall.py", "*/_tests/*"]
+exclude_dirs = ["quickinstall.py", "*/_tests/*", "*/_ui_tests/*"]
 skips = ["B101", "B105", "B106", "B307", "B311", "B403", "B608"]
 
 [tool.tox]


### PR DESCRIPTION
Changing the pre-commit config is required in addition because files passed by the commit hook to bandit via the command line are always checked despite being excluded by the configuration.

See: [Skip tests folder on pre-commit](https://github.com/PyCQA/bandit/issues/912)