### PR TITLE
Fix: Missing redirect to previous page after page subscription (#1841)

### DIFF
--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -2006,7 +2006,8 @@ def subscribe_item(item_name):
             msg = _("You could not get subscribed to this item."), "error"
     if msg:
         flash(*msg)
-    return redirect(url_for_item(item_name))
+    next_url = request.referrer or url_for_item(item_name)
+    return redirect(next_url)
 
 
 class ValidRegistration(Validator):


### PR DESCRIPTION
This PR fixes the issue  #1841.

Make use of Referrer request header value (if available) when redirecting from subscribe.