### PR TITLE
search query: add some more clickable options, fixes #60

### DIFF
--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -7,10 +7,12 @@ Entering search queries
 
 To start a search, enter a query into the short query input field and type
 enter or click the search icon. By default, the names, summary, tags, content, namengram,
-summaryngram, and contentngram fields are searched.
+summaryngram, and contentngram fields of each item's last revisions are searched.
+Deleted items (trash) are excluded.
 
 The search results view provides a form for refining the search through
-ajax updates. A transaction is started each time a character is added or removed
+ajax updates. Click the `More Search Options` link to see the form.
+A transaction is started each time a character is added or removed
 in the search field. If keying is rapid, it is possible that results will
 processed out of order. The `Whoosh query` shows the last term processed.
 

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -389,27 +389,6 @@ def add_file_filters(_filter, filetypes):
     return _filter
 
 
-def add_namespaces(_namespaces, namespaces):
-    """
-    Add user selected namespaces to the search query.
-
-    :param _namespaces: the current list of namespaces, usually []
-    :param namespaces: list of user selected namespaces
-    :returns: an Or list of namespaces enclosed within an And
-    """
-    name_spaces = []
-    valid_ns = app.cfg.namespace_mapping
-    for ns in namespaces:
-        if ns in valid_ns:
-            name_spaces.append(Term("namespace", ns))
-        else:
-            if ns == NAMESPACE_UI_DEFAULT:
-                name_spaces.append(Term("namespace", ""))
-    name_spaces = Or(name_spaces)
-    _namespaces = And(namespaces)
-    return _namespaces
-
-
 def add_facets(facets, time_sorting):
     """
     Adds various facets for the search features.
@@ -455,7 +434,7 @@ def search(item_name):
     time_sorting = False
     filetypes = []
     namespaces = []
-    trash = True  # show deleted items
+    trash = request.args.get("trash", "false")
     best_match = False
     terms = []
     if ajax:
@@ -466,13 +445,13 @@ def search(item_name):
             time_sorting = False
         filetypes = request.args.get("filetypes")
         namespaces = request.args.get("namespaces")
-        trash = request.args.get("trash")
         is_ticket = bool(request.args.get("is_ticket"))
         # remove the extra ',' at the end of the filetyes and namespaces strings
         if filetypes:
             filetypes = filetypes.split(",")[:-1]
         if namespaces:
             namespaces = namespaces.split(",")[:-1]
+            namespaces = ["" if ns == NAMESPACE_UI_DEFAULT else ns for ns in namespaces]
     else:
         # not ajax, the form has only the search string q as keyed by the user
         query = search_form["q"].value or ""

--- a/src/moin/constants/namespaces.py
+++ b/src/moin/constants/namespaces.py
@@ -6,6 +6,7 @@ MoinMoin - namespaces related constants
 """
 
 NAMESPACE_DEFAULT = ""
+NAMESPACE_UI_DEFAULT = "~"  # use this when showing default namespace placeholder within UI
 NAMESPACE_USERPROFILES = "userprofiles"
 NAMESPACE_USERS = "users"
 NAMESPACE_HELP_COMMON = "help-common"

--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -274,9 +274,7 @@ a.moin-item-overlay-lr:hover { opacity: .8; background-color: var(--bg-trans-hov
 #moin-long-searchform div { margin: 0; }
 #moin-long-searchform .moin-search-query { width: 90%; margin-left: 0; }
 .moin-search-option-bar { font-size: 1.25em; font-weight: bold; cursor: pointer;  color: var(--link); }
-.moin-searchopt-tab > th:nth-child(1),
-.moin-searchopt-tab > th:nth-child(2) { width: 20%; }
-.moin-searchopt-tab > th:nth-child(3) { width: 60%; }
+.moin-search-options-table td { vertical-align: top; }
 .moin-search-hit-info { display: inline; }
 .moin-search-hits { font-weight: bold; }
 .moin-search-results { font-size: .92em; }

--- a/src/moin/static/js/search.js
+++ b/src/moin/static/js/search.js
@@ -16,10 +16,6 @@ $(document).ready(function(){
     // user friendly browsers may retain form state after a reload, we want form defaults
     // select the first radio buttons; Latest in Revisions and Highest Score in Sort By
     $("input[type=radio]:first").attr("checked", true);
-    // select the last checkbox All in Content Types
-    $("input[type=checkbox]:checked").removeAttr("checked");
-    $("input[type=checkbox]:last").prop("checked", true)
-
     // kill form action on pressing Enter, all transactions are ajax
     $('#moin-long-searchform').submit(function(e){
         e.preventDefault();
@@ -36,12 +32,12 @@ $(document).ready(function(){
     $('.moin-loginsettings').addClass('navbar-right');
 
     // execute ajax transaction and replace old ajaxsearch.html content with updated ajaxsearch.html results
-    function ajaxify(query, allrevs, time_sorting, filetypes, is_ticket) {
+    function ajaxify(query, allrevs, time_sorting, filetypes, namespaces, trash, is_ticket) {
         var wiki_root = $('#moin-wiki-root').val();
         $.ajax({
             type: "GET",
             url: wiki_root + "/+search",
-            data: { q: query, history: allrevs, time_sorting: time_sorting, filetypes: filetypes, boolajax: true, is_ticket: is_ticket }
+            data: { q: query, history: allrevs, time_sorting: time_sorting, filetypes: filetypes, namespaces: namespaces, trash: trash, boolajax: true, is_ticket: is_ticket }
         }).done(function(data) {
             if (data.search(/doctype/i) > 0) {
                 // this is a full page with a flash error message, replace everything
@@ -66,16 +62,24 @@ $(document).ready(function(){
     // detects change in search text field, or is called by function above. Collects form data and passes it to `ajaxify` function above
     $('.moin-search-query').keyup(function() {
         var allrev, time_sorting;
-        var filetypes= '';
-        var is_ticket = '';
+        var filetypes = "";
+        var namespaces = "";
+        var trash = "";
+        var is_ticket = "";
         if( $('input[name="meta_summary"]').length ){
             is_ticket = true;
         }
         allrev = $('[name="history"]:checked').val() === "all";
+        trash = $('[name="trash"]:checked').val() === "include";
         time_sorting = $('[name="modified_time"]:checked').val();
         $('[name="itemtype"]:checked').each(function() {
             filetypes += $(this).val() + ',';
         });
-        ajaxify($(this).val(), allrev, time_sorting, filetypes, is_ticket);
+
+        $('[name="namespace"]:checked').each(function() {
+            namespaces += $(this).val() + ',';
+        });
+
+        ajaxify($(this).val(), allrev, time_sorting, filetypes, namespaces, trash, is_ticket);
     });
 });

--- a/src/moin/templates/search.html
+++ b/src/moin/templates/search.html
@@ -32,13 +32,15 @@
             <a href="/+serve/docs/user/search.html">Local docs</a> or
             <a href="https://moin-20.readthedocs.io/en/latest/user/search.html">Internet docs.</a>
         </div>
-        <p class="moin-search-option-bar"><i class="fa fa-chevron-down"></i> {{ _("Search Options") }}</p>
+        <p class="moin-search-option-bar"><i class="fa fa-chevron-down"></i> {{ _("More Search Options") }}</p>
         <div class="moin-searchoptions hidden">
-            <table>
+            <table class="moin-search-options-table">
                 <tr class="moin-searchopt-tab">
                     <th>Revisions</th>
                     <th>Sort By</th>
-                    <th colspan="3">Content Types</th>
+                    <th>Content Types</th>
+                    <th>Namespace</th>
+                    <th>Trash</th>
                 </tr>
                 <tr>
                     <td>
@@ -55,16 +57,21 @@
                         <label><input type="checkbox" name="itemtype" value="markup"> Markup Text</label><br>
                         <label><input type="checkbox" name="itemtype" value="text"> Other Text</label><br>
                         <label><input type="checkbox" name="itemtype" value="image"> Image</label><br>
-                    </td>
-                    <td>
                         <label><input type="checkbox" name="itemtype" value="audio"> Audio</label><br>
                         <label><input type="checkbox" name="itemtype" value="video"> Video</label><br>
                         <label><input type="checkbox" name="itemtype" value="drawing"> Drawing</label><br>
-                    </td>
-                    <td>
                         <label><input type="checkbox" name="itemtype" value="other"> Other</label><br>
                         <label><input type="checkbox" name="itemtype" value="unknown"> Unknown</label><br>
-                        <label><input type="checkbox" name="itemtype" value="all" checked="checked"> All</label><br>
+                        {# <label><input type="checkbox" name="itemtype" value="all" checked="checked"> All</label><br> #}
+                    </td>
+                    <td>
+                        {%- for namespace, root in theme_supp.get_namespaces() %}
+                            <label><input type="checkbox" name="namespace" value="{{namespace}}"> {{namespace}}</label><br>
+                        {%- endfor -%}
+                    </td>
+                    <td>
+                        <label><input type="radio" name="trash" value="include" checked="checked"> Include</label><br>
+                        <label><input type="radio" name="trash" value="exclude"> Exclude</label><br>
                     </td>
                 </tr>
             </table>

--- a/src/moin/templates/search.html
+++ b/src/moin/templates/search.html
@@ -66,12 +66,12 @@
                     </td>
                     <td>
                         {%- for namespace, root in theme_supp.get_namespaces() %}
-                            <label><input type="checkbox" name="namespace" value="{{namespace}}"> {{namespace}}</label><br>
+                            <label><input type="checkbox" name="namespace" value="{{ namespace }}"> {{ namespace }}</label><br>
                         {%- endfor -%}
                     </td>
                     <td>
-                        <label><input type="radio" name="trash" value="include" checked="checked"> Include</label><br>
-                        <label><input type="radio" name="trash" value="exclude"> Exclude</label><br>
+                        <label><input type="radio" name="trash" value="exclude" checked="checked"> Exclude</label><br>
+                        <label><input type="radio" name="trash" value="include" > Include</label><br>
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
added clickable options for namespaces and trash