### PR TITLE
Make getInterwikiHome() return a fqname

### DIFF
--- a/src/moin/themes/__init__.py
+++ b/src/moin/themes/__init__.py
@@ -393,7 +393,7 @@ class ThemeSupport:
         else:
             # We cannot check if wiki pages exists in remote wikis
             exists = True
-        wiki_href = url_for_item(itemname, wiki_name=wikiname, namespace=NAMESPACE_USERS)
+        wiki_href = url_for_item(itemname, wiki_name=wikiname)
         return wiki_href, display_name, title, exists
 
     def split_navilink(self, text):

--- a/src/moin/themes/_tests/test_theme_support.py
+++ b/src/moin/themes/_tests/test_theme_support.py
@@ -1,0 +1,40 @@
+# Copyright: 2025 MoinMoin Project
+# License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
+
+import pytest
+
+from flask import current_app as app
+from flask import g as flaskg
+
+from moin._tests import wikiconfig
+from moin.themes import ThemeSupport
+from moin.user import User
+
+
+@pytest.fixture
+def _test_user():
+    orig_user = flaskg.user
+    flaskg.user = User(name="lemmy")
+    yield
+    flaskg.user = orig_user
+
+
+@pytest.fixture
+def cfg():
+    class Config(wikiconfig.Config):
+        interwiki_map = dict(Self="http://localhost:8080/", MoinMoin="http://moinmo.in/")
+
+    return Config
+
+
+@pytest.fixture
+def theme_supp():
+    return ThemeSupport(app.cfg)
+
+
+def test_get_user_home(_test_user, theme_supp):
+    wiki_href, display_name, title, exists = theme_supp.userhome()
+    assert wiki_href == "/users/lemmy"
+    assert display_name == "lemmy"
+    assert title == "lemmy @ Self"
+    assert not exists

--- a/src/moin/utils/_tests/test_interwiki.py
+++ b/src/moin/utils/_tests/test_interwiki.py
@@ -15,7 +15,15 @@ import re
 import pytest
 from flask import current_app as app
 
-from moin.utils.interwiki import split_interwiki, join_wiki, InterWikiMap, url_for_item, _split_namespace, split_fqname
+from moin.utils.interwiki import (
+    split_interwiki,
+    join_wiki,
+    InterWikiMap,
+    url_for_item,
+    _split_namespace,
+    split_fqname,
+    getInterwikiHome,
+)
 from moin._tests import wikiconfig
 from moin.constants.keys import CURRENT
 from moin.app import before_wiki
@@ -205,6 +213,9 @@ class TestInterWiki:
         ]
         for url, (namespace, field, pagename) in tests:
             assert split_fqname(url) == (namespace, field, pagename)
+
+    def test_get_interwiki_home(self):
+        assert getInterwikiHome("frodo") == ("Self", "users/frodo")
 
 
 class TestInterWikiMapBackend:

--- a/src/moin/utils/interwiki.py
+++ b/src/moin/utils/interwiki.py
@@ -16,6 +16,7 @@ from collections import namedtuple
 
 from moin.constants.keys import CURRENT, FIELDS, NAME_EXACT, NAMESPACE
 from moin.constants.contenttypes import CHARSET
+from moin.constants.namespaces import NAMESPACE_USERS
 
 from moin import log
 
@@ -320,7 +321,7 @@ def getInterwikiHome(username):
     homewiki = app.cfg.user_homewiki
     if is_local_wiki(homewiki):
         homewiki = "Self"
-    return homewiki, username
+    return homewiki, get_fqname(username, NAME_EXACT, NAMESPACE_USERS)
 
 
 class InterWikiMap:


### PR DESCRIPTION
This fixes an issue mentioned in #1770

> On top banner near Settings/Logout, current user's name is displayed in red, whether user's home page exists or not. Link is to user's home page in users namespace.
