### PR TITLE
Persist view state of sidebar elements in browser local storage

### DIFF
--- a/src/moin/templates/modify_text.html
+++ b/src/moin/templates/modify_text.html
@@ -17,7 +17,7 @@
 {% macro data_editor(form, item_name) %}
     {% set textarea_rows = '1' if edit_rows == '0' else edit_rows %}
     {% set cls = 'moin-edit-content moin-autosize' if edit_rows == '0' else 'moin-edit-content' %}
-    <input type="button" onclick="moinFontChange()" value="{{ _('Toggle font width') }}" class="moin-button moin-textarea-font" >
+    <input type="button" id="moin-toggle-fixed-font-button" value="{{ _('Toggle font width') }}" class="moin-button moin-textarea-font" >
     {{ gen.textarea(form['data_text'], rows=textarea_rows|string, class=cls, **kwargs) }}
     {{ base_editor(form) }}
     <br>

--- a/src/moin/themes/basic/templates/modify_text.html
+++ b/src/moin/themes/basic/templates/modify_text.html
@@ -1,7 +1,7 @@
 {% from "modify_binary.html" import data_editor as base_editor %}
 
 {% macro basic_data_editor(form, item_name) %}
-    <input type="button" onclick="moinFontChange()" value="{{ _('Toggle font width') }}" class="moin-button moin-textarea-font" >
+    <input type="button" id="moin-toggle-fixed-font-button" value="{{ _('Toggle font width') }}" class="moin-button moin-textarea-font" >
     {{ gen.textarea(form['data_text'], rows=form.rows|string, cols=form.cols|string, class="moin-edit-content", **kwargs) }}
     {{ base_editor(form) }}
     <br>


### PR DESCRIPTION
Picking up the suggestion made in https://github.com/moinwiki/moin/issues/1770.