### PR TITLE
Fix History Page Crash (Issue #1886)

### DIFF
--- a/src/moin/themes/__init__.py
+++ b/src/moin/themes/__init__.py
@@ -610,26 +610,33 @@ def get_editor_info(meta, external=False):
 
     userid = meta.get(USERID)
     if userid:
-        u = user.User(userid)
-        name = u.name0
-        text = u.display_name or name
-        display_name = u.display_name or name
-        if title:
-            # we already have some address info
-            title = f"{display_name} @ {title}"
-        else:
-            title = display_name
-        if u.mailto_author and u.email:
-            email = u.email
-            css = "editor mail"
-        else:
-            homewiki = app.cfg.user_homewiki
-            if is_local_wiki(homewiki):
-                css = "editor homepage local"
+        try:
+            u = user.User(userid)
+            name = u.name0
+            text = u.display_name or name
+            display_name = u.display_name or name
+            if title:
+                # we already have some address info
+                title = f"{display_name} @ {title}"
             else:
-                css = "editor homepage interwiki"
-            uri = url_for_item(name, wiki_name=homewiki, _external=external, namespace=NAMESPACE_USERS)
-
+                title = display_name
+            if u.mailto_author and u.email:
+                email = u.email
+                css = "editor mail"
+            else:
+                homewiki = app.cfg.user_homewiki
+                if is_local_wiki(homewiki):
+                    css = "editor homepage local"
+                else:
+                    css = "editor homepage interwiki"
+                uri = url_for_item(name, wiki_name=homewiki, _external=external, namespace=NAMESPACE_USERS)
+        except Exception:
+            # Fall back to default values if user profile loading fails
+            name = "Unknown"
+            text = "anonymous"
+            title = "Unknown User"
+            css = "editor unknown"
+            
     result = dict(name=name, text=text, css=css, title=title)
     if uri:
         result["uri"] = uri

--- a/src/moin/themes/_tests/test_get_editor_info.py
+++ b/src/moin/themes/_tests/test_get_editor_info.py
@@ -1,0 +1,36 @@
+import pytest
+from moin.themes import get_editor_info
+
+def test_get_editor_info_anonymous():
+    meta = {}  # Simulate revision with no USERID or ADDRESS
+    result = get_editor_info(meta)
+    assert result["text"] == "anonymous"
+    assert result["title"] == ""
+    assert result["css"] == "editor"
+    assert result["name"] is None
+
+def test_get_editor_info_with_address():
+    meta = {"address": "192.168.1.1"}
+    result = get_editor_info(meta)
+    assert result["text"] == "192.168.1.1"
+    assert result["title"] == "[192.168.1.1]"
+    assert result["css"] == "editor ip"
+
+def test_get_editor_info_invalid_user(monkeypatch):
+    # Simulate a USERID but make user.User(userid) raise an Exception
+    class DummyUser:
+        def __init__(self, userid):
+            raise ValueError("Simulated broken profile")
+
+    from moin import themes
+    from moin import user as real_user_module
+
+    monkeypatch.setattr(themes.user, "User", DummyUser)
+
+    meta = {"userid": "fake-id"}
+    result = get_editor_info(meta)
+
+    assert result["text"] == "anonymous"
+    assert result["title"] == "Unknown User"
+    assert result["css"] == "editor unknown"
+    assert result["name"] == "Unknown"


### PR DESCRIPTION
Fix the history page crash for malformed user profiles and add a test

- Wrapped `user.User(userid)` logic in `get_editor_info` with a try-except block to prevent crashes when encountering broken or malformed user profile metadata.
- Added fallback values ("anonymous", "Unknown", etc.) to ensure graceful degradation in the UI.
- Created a new unit test `test_get_editor_info.py` to verify behavior with both valid and invalid metadata.

Fixes #1886