### PR TITLE
Make help link look like link

### DIFF
--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -682,7 +682,7 @@ figcaption { font-weight: bold; }
 .moin-edit-no-help:before { content: url("../img/icons/icon-info.png"); padding-right: 1em; }
 .moin-autosize { min-height: 10em; }
 .moin-edit-help { float: right; }
-.moin-edit-help a { color: var(--primary); }
+.moin-edit-help a { text-decoration: revert; color: var(--primary); }
 /* ckeditor hides textarea, this prevents editor help link overlaying ckeditor controls */
 #cke_f_content_form_data_text { clear: both; }
 

--- a/src/moin/templates/utils.html
+++ b/src/moin/templates/utils.html
@@ -114,7 +114,7 @@
     {% if help %}
         {% if isinstance(help, tuple) %}
             {# display nice button with link to internal help: moinwiki, creole, markdown... #}
-            <span class="moin-edit-help moin-button"><a href="{{ help[0] }}">{{ help[1] }}</a></span>
+            <span class="moin-edit-help"><a href="{{ help[0] }}">{{ help[1] }}</a></span>
         {% else %}
             {# no help, one sentence help, or link to help in external site: CSV, images, binary... #}
             <span class="moin-edit-no-help"> {{ help|safe }} </span>

--- a/src/moin/themes/focus/static/css/theme.css
+++ b/src/moin/themes/focus/static/css/theme.css
@@ -155,8 +155,7 @@ header a, header a:link, header a:visited,
 .moin-form dd input[type="checkbox"] { width: 12pt; }
 .moin-edit-help { float: unset; padding: 0pt; }
 .moin-edit-help.moin-button { display: block; }
-.moin-edit-help a { height: 100%; width: 100%; display: flex; align-items: center;
-    padding: 0pt 6pt; }
+.moin-edit-help a { height: 100%; width: 100%; }
 .moin-form .submit-buttons { display: flex; column-gap: 8pt; justify-content: end;
     margin: 12pt 0;
     float: right;


### PR DESCRIPTION
Before this PR the help link looked like a button and only if you hovered over it you saw that it is a link. This could confuse users because they expected different behavior.

Before:
![before](https://github.com/user-attachments/assets/9ef908d6-fb73-4047-80df-54a8cad07397)

After:
![after](https://github.com/user-attachments/assets/6f31470b-15bd-491c-bf15-72843e4958fa)
