### PR TITLE
Re-enable "Wiki links".

### DIFF
--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -219,6 +219,14 @@ c</p></list-item-body></list-item><list-item><list-item-body><p>b</p><p>d</p></l
             '<page><body><p>Abra <a xlink:href="wiki.local:#example">example</a> arba</p><span id="example" /><p>text</p></body></page>',
         ),
         (
+            "A reference_ with no matching target links to a local Wiki item.",
+            '<page><body><p>A <a xlink:href="wiki.local:reference">reference</a> with no matching target links to a local Wiki item.</p></body></page>',
+        ),
+        (
+            "`Whitespace   is\nnormalized & Case is KEPT.`_",
+            '<page><body><p><a xlink:href="wiki.local:Whitespace%20is%20normalized%20&amp;%20Case%20is%20KEPT.">Whitespace   is\nnormalized &amp; Case is KEPT.</a></p></body></page>',
+        ),
+        (
             "http://www.python.org/",
             '<page><body><p><a xlink:href="http://www.python.org/">http://www.python.org/</a></p></body></page>',
         ),

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -18,7 +18,7 @@ Works with docutils version 0.5 (2008-06-25) or higher.
 import re
 
 import docutils
-from docutils import nodes, utils, writers, core
+from docutils import core, nodes, transforms, utils, writers
 from docutils.nodes import reference, literal_block
 from docutils.parsers.rst import directives, roles
 
@@ -31,6 +31,7 @@ except ImportError:
 from moin.utils.iri import Iri
 from moin.utils.tree import html, moin_page, xlink, xinclude
 from moin.utils.mime import Type, type_moin_document
+from moin.wikiutil import normalize_pagename
 
 from . import default_registry
 from ._util import allowed_uri_scheme, decode_data, normalize_split_text
@@ -781,7 +782,55 @@ def walkabout(node, visitor):
     return stop
 
 
+class Parser(docutils.parsers.rst.Parser):
+    """reStructuredText parser for the MoinMoin wiki.
+
+    Registers a "transform__" for hyperlink references
+    without matching target__.
+
+    __ https://docutils.sourceforge.io/docs/api/transforms.html
+    """
+
+    config_section = "MoinMoin parser"
+    config_section_dependencies = ("parsers", "restructuredtext parser")
+
+    def get_transforms(self):
+        """Add WikiReferences to the registered transforms."""
+        return super().get_transforms() + [WikiReferences]
+
+
+class WikiReferences(transforms.Transform):
+    """Resolve references without matching target as local wiki references.
+
+    Set the "refuri" attribute to refer to a local wiki item.
+    The value is derived from the node's text content with
+    `moin.wikiutil.normalize_pagename()`.
+
+    Cf. https://docutils.sourceforge.io/docs/api/transforms.html#docinfo.
+    """
+
+    default_priority = 775
+    # Apply between `InternalTargets` (660) and `DanglingReferences` (850)
+
+    def apply(self) -> None:
+        for node in self.document.findall(nodes.reference):
+            print(node.resolved, node)
+            # Skip resolved references, unresolvable references, and references with matching target:
+            if node.resolved or "refname" not in node or self.document.nameids.get(node["refname"]):
+                continue
+            # Get the name from the link text (the "refname" attribute is lowercased).
+            wikiname = normalize_pagename(node.astext(), None)  # second arg is ignored
+            # Skip references whose "refname" attribute differs from the wikiname (exept for case):
+            if normalize_pagename(node["refname"], None) != wikiname.lower():
+                continue
+            # Resolve the reference:
+            node["refuri"] = wikiname
+            del node["refname"]
+            node.resolved = True
+
+
 class Writer(writers.Writer):
+    # Ignored! In moin 2.0, the conversion does not use a Writer component.
 
     supported = ("moin-x-document",)
     config_section = "MoinMoin writer"
@@ -924,7 +973,7 @@ class Converter:
         while True:
             input = "\n".join(input)
             try:
-                docutils_tree = core.publish_doctree(source=input)
+                docutils_tree = core.publish_doctree(source=input, source_path="rST input", parser=Parser())
             except utils.SystemMessage as inst:
                 string_numb = re.match(
                     re.compile(r"<string>:([0-9]*):\s*\(.*?\)\s*(.*)", re.X | re.U | re.M | re.S), str(inst)


### PR DESCRIPTION
In Moin 1.9, hyperlink references without target default to items of the local wiki. Port this feature to Moin 2.0.
Adapt to the new program structure:

Define a "transform" that resolves hyperlink references without a matching target.

Define a custom parser to register the "transform". (The `Writer` component is not used in Moin 2.0)

Call `docutils.core.publish_doctree()` with the custom parser. Also specify a "source_path" identifier (for improved error messages).