### PR TITLE
use spdx license metadata in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ maintainers = [
 ]
 description = "MoinMoin is an easy to use, full-featured and extensible wiki software package"
 readme = {file="README.md", content-type="text/markdown"}
+license = "GPL-2.0-or-later"
+license-files = ["LICENSE.txt"]
 requires-python = ">=3.9"
 keywords = ["wiki", "web"]
 classifiers = [
@@ -18,7 +20,6 @@ classifiers = [
     "Intended Audience :: Information Technology",
     "Intended Audience :: Other Audience",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License (GPL)",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
@@ -33,7 +34,6 @@ classifiers = [
     "Topic :: Office/Business :: Groupware",
     "Topic :: Text Processing :: Markup",
 ]
-license = {text="GNU GPL v2 (or any later version)"}
 dependencies = [
     "Babel >= 2.10.0",  # internationalization support
     "blinker >= 1.6.2",  # event signalling (e.g. for change notification trigger)
@@ -93,7 +93,7 @@ include-package-data = true
 where = ["src"]
 
 [build-system]
-requires = ["setuptools", "setuptools_scm[toml] >= 6.2"]
+requires = ["setuptools >= 77.0.3", "setuptools_scm[toml] >= 6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Updated `setuptools` minimum version with spdx support in build-system requirements.

This gets rid of this warning:
```
  Running command Building editable for moin (pyproject.toml)
  /private/var/folders/61/qtqwzmxd7t1fb19zck5k3q0h0000gn/T/pip-build-env-bohc36n9/overlay/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
  !!

          ********************************************************************************
          Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

          By 2026-Feb-18, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.

          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************

  !!
    corresp(dist, value, root_dir)
  /private/var/folders/61/qtqwzmxd7t1fb19zck5k3q0h0000gn/T/pip-build-env-bohc36n9/overlay/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
  !!

          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:

          License :: OSI Approved :: GNU General Public License (GPL)

          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************

  !!
    dist._finalize_license_expression()
  /private/var/folders/61/qtqwzmxd7t1fb19zck5k3q0h0000gn/T/pip-build-env-bohc36n9/overlay/lib/python3.13/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
  !!

          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:

          License :: OSI Approved :: GNU General Public License (GPL)

          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************

  !!
    self._finalize_license_expression()
```