### PR TITLE
Configuration option for markdown extensions

### DIFF
--- a/docs/user/markdown.rst
+++ b/docs/user/markdown.rst
@@ -753,3 +753,15 @@ The following types are supported:
 
 .. note::
    You should note that the title will be automatically capitalized.
+
+Instance-specific extensions
+----------------------------
+
+You can specify a list of additional extensions to the markdown parser per instance.
+A list of potentially interesting extensions can be access in `Python-markdown's wiki <https://github.com/Python-Markdown/markdown/wiki/Third-Party-Extensions>`_.
+
+For example, to automatically link URLs: ::
+
+    class Config(DefaultConfig):
+        ...
+        markdown_extensions = ['pymdownx.magiclink']

--- a/src/moin/config/default.py
+++ b/src/moin/config/default.py
@@ -54,6 +54,7 @@ class ConfigFunctionality:
     auth_have_login = None
     auth_login_inputs = None
     _site_plugin_lists = None
+    markdown_extensions = []
 
     def __init__(self):
         """Init Config instance"""

--- a/src/moin/converters/markdown_in.py
+++ b/src/moin/converters/markdown_in.py
@@ -17,6 +17,7 @@ from moin.utils.tree import moin_page, xml, html, xlink, xinclude
 from ._util import decode_data
 from moin.utils.iri import Iri
 from moin.converters.html_in import Converter as HTML_IN_Converter
+from flask import current_app
 
 from emeraldtree import ElementTree as ET
 
@@ -558,8 +559,12 @@ class Converter:
                 self.convert_invalid_p_nodes(child)
 
     def __init__(self):
+        # The Moin configuration
+        self.app_configuration = current_app.cfg
+
         self.markdown = Markdown(
-            extensions=[ExtraExtension(), CodeHiliteExtension(guess_lang=False), "mdx_wikilink_plus", "admonition"],
+            extensions=[ExtraExtension(), CodeHiliteExtension(guess_lang=False), "mdx_wikilink_plus", "admonition"]
+            + self.app_configuration.markdown_extensions,
             extension_configs={
                 "mdx_wikilink_plus": {
                     "html_class": None,


### PR DESCRIPTION
Introduces a new optional configuration parameter to specify any
instance-specific extensions for the markdown parser

implements https://github.com/moinwiki/moin/issues/1957