### PR TITLE
Search does not support namespaces fixes #1907

### DIFF
--- a/src/moin/templates/ajaxsearch.html
+++ b/src/moin/templates/ajaxsearch.html
@@ -45,7 +45,7 @@
             </p>
         {%- endif %}
         {%- if omitted_words %}
-            <p class="moin-suggestions"> {{ _("Common words omitted from query:") }}
+            <p class="moin-suggestions"> {{ _("Common words omitted from content field query:") }}
                 <span class="moin-suggestion-terms">{{ omitted_words }} </span>
             </p>
         {%- endif %}


### PR DESCRIPTION
reworked frontend/views.py searching

User can enter leading namespace in simple query string. 
Converted confusing use of filters to plain query.
Eliminated use of item_name in URL.
Removed non-working code to search transcluded items.