### PR TITLE
Add custom.css feature

### DIFF
--- a/docs/admin/configure.rst
+++ b/docs/admin/configure.rst
@@ -158,7 +158,10 @@ If desired, the name of this directory may be changed or a separate subdirectory
 for template files may be created by editing
 the wikiconfig file and changing the line that defines `template_dirs`::
 
-    template_dirs = [os.path.join(wikiconfig_dir, 'wiki_local'), ]
+    template_dirs = [os.path.join(wikiconfig_dir, "wiki_local")]
+
+Simple customizations using CSS can be made by providing a file named `custom.css`
+in the `wiki_local` subdirectory.
 
 Using a custom snippets.html template
 -------------------------------------

--- a/src/moin/app.py
+++ b/src/moin/app.py
@@ -193,6 +193,7 @@ def create_app_ext(
     if app.cfg.template_dirs:
         app.jinja_env.loader = ChoiceLoader([FileSystemLoader(app.cfg.template_dirs), app.jinja_env.loader])
     app.register_error_handler(403, themed_error)
+    app.cfg.custom_css_path = os.path.isfile("wiki_local/custom.css")
     clock.stop("create_app flask-theme")
     # create global counter to limit content security policy reports, prevent spam
     app.csp_count = 0

--- a/src/moin/templates/base.html
+++ b/src/moin/templates/base.html
@@ -66,6 +66,9 @@
                 {%- if user.valid and user.css_url -%}
                     <link media="all" rel="stylesheet" title="{{ user.name }}'s stylesheet" href="{{ user.css_url }}">
                 {%- endif -%}
+                {%- if cfg.custom_css_path -%}
+                    <link media="all" rel="stylesheet" href="{{ url_for('serve.files', name='wiki_local', filename='custom.css') }}">
+                {%- endif -%}
             {%- endblock -%}
         {%- endblock %}
     </head>


### PR DESCRIPTION
This is related to #1956:

> Another option would be to add a check for a custom.css file in wiki_local at startup. This avoids adding further options to wikiconfig.py.
