### PR TITLE
Correct cspreport log path used in before_wiki (add leading slash)

### DIFF
--- a/src/moin/app.py
+++ b/src/moin/app.py
@@ -317,7 +317,7 @@ def before_wiki():
     """
     Setup environment for wiki requests, start timers.
     """
-    if request and (is_static_content(request.path) or request.path == "+cspreport/log"):
+    if request and (is_static_content(request.path) or request.path == "/+cspreport/log"):
         logging.debug(f"skipping before_wiki for {request.path}")
         return
 


### PR DESCRIPTION
Processing done in before_wiki wasn't skipped as desired .