### PR TITLE
babel: move config to pyproject.toml

### DIFF
--- a/babel.cfg
+++ b/babel.cfg
@@ -1,9 +1,0 @@
-[python: **/**.py]
-encoding = utf-8
-
-[jinja2: **/templates/**.html]
-encoding = utf-8
-
-[jinja2: **/templates/dictionary.js]
-# all JS translatable strings must be defined here for jQuery i18n plugin
-encoding = utf-8

--- a/docs/devel/translate.rst
+++ b/docs/devel/translate.rst
@@ -138,7 +138,7 @@ string replacement.
 If you made changes to any gettext() string, please update the .pot file
 using::
 
-    pybabel extract -F babel.cfg -o src/moin/translations/MoinMoin.pot \
+    pybabel extract -F pyproject.toml -o src/moin/translations/MoinMoin.pot \
             -k "_ gettext L_ lazy_gettext N_ ngettext" \
             --msgid-bugs-address "English <moin-user@python.org>" \
             --copyright-holder "Moin Core Team, see http://moinmo.in/MoinCoreTeamGroup" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Text Processing :: Markup",
 ]
 dependencies = [
-    "Babel >= 2.10.0",  # internationalization support
+    "Babel >= 2.16.0",  # internationalization support
     "blinker >= 1.6.2",  # event signalling (e.g. for change notification trigger)
     "docutils >= 0.18.1",  # reST markup processing
     "Markdown >= 3.4.1",  # Markdown markup processing
@@ -188,3 +188,17 @@ change_dir = ""
 commands = [
     ["ruff", "check", "."]
 ]
+
+[tool.babel.extractors]
+# python works by default
+jinja2 = "jinja2.ext:babel_extract"
+
+[[tool.babel.mappings]]
+method = "python"
+pattern = "**/*.py"
+encoding = "utf-8"
+
+[[tool.babel.mappings]]
+method = "jinja2"
+pattern = ["**/templates/**/*.html", "**/templates/dictionary.js"]
+encoding = "utf-8"


### PR DESCRIPTION
Babel >= 2.16.0 (from 2024-08) supports this.

https://github.com/python-babel/babel/pull/1108