### PR TITLE
Fix code accessing the no longer existing configuration setting 'item_root'

### DIFF
--- a/docs/admin/configure.rst
+++ b/docs/admin/configure.rst
@@ -1454,7 +1454,7 @@ To configure custom namespaces, find the section in wikiconfig.py that looks sim
             hierarchic=False, ),
     }
     namespace_mapping, backend_mapping, acl_mapping = create_mapping(uri, namespaces, backends, acls, )
-    # define mapping of namespaces to unique item_roots (home pages within namespaces).
+    # define mapping of namespaces to unique root items (home pages within namespaces).
     root_mapping = {'users': 'UserHome', }
     # default root, use this value by default for all namespaces
     default_root = 'Home'

--- a/src/moin/_tests/wikiconfig.py
+++ b/src/moin/_tests/wikiconfig.py
@@ -25,7 +25,7 @@ class Config(DefaultConfig):
     data_dir = join(_here, "wiki", "data")  # needed for plugins package TODO
     index_storage = "FileStorage", (join(_here, "wiki", "index"),), {}
     default_acl = None
-    item_root = "FrontPage"
+    default_root = "FrontPage"
     interwikiname = "MoinTest"
     interwiki_map = dict(Self="http://localhost:8080/", MoinMoin="http://moinmo.in/")
     interwiki_map[interwikiname] = "http://localhost:8080/"

--- a/src/moin/config/default.py
+++ b/src/moin/config/default.py
@@ -546,7 +546,7 @@ options_no_group_name = {
                 "Home",
                 "Default root, use this value in case no match is found in root_mapping. [Unicode]",
             ),
-            ("root_mapping", {}, "mapping of namespaces to item_roots."),
+            ("root_mapping", {}, "mapping of namespaces to unique root items."),
             # the following regexes should match the complete name when used in free text
             # the group 'all' shall match all, while the group 'key' shall match the key only
             # e.g. FooGroup -> group 'all' ==  FooGroup, group 'key' == Foo

--- a/src/moin/config/wikiconfig.py
+++ b/src/moin/config/wikiconfig.py
@@ -236,7 +236,7 @@ class Config(DefaultConfig):
     # TODO If there is a future change that requires wiki admins to merge this wikiconfig with the customized wikiconfig
     # then remove the "uri" parameter in create mapping below and in storage/__init__.py.
     namespace_mapping, backend_mapping, acl_mapping = create_mapping(uri, namespaces, backends, acls)
-    # define mapping of namespaces to unique item_roots (home pages within namespaces).
+    # define mapping of namespaces to unique root items (home pages within namespaces).
     root_mapping = {"users": "UserHome"}
     # default root, use this value by default for all namespaces
     default_root = "Home"

--- a/src/moin/templates/layout.html
+++ b/src/moin/templates/layout.html
@@ -30,7 +30,7 @@
                     {{ utils.user_login_logoff() }}
                 </ul>
                 {% if cfg.sitename %}
-                    <a class="moin-sitename" href="{{ url_for('frontend.show_item', item_name=cfg.item_root) }}">
+                    <a class="moin-sitename" href="{{ url_for('frontend.show_item', item_name=cfg.default_root) }}">
                         {{ cfg.sitename }}
                     </a>
                 {% endif %}

--- a/src/moin/themes/basic/templates/layout.html
+++ b/src/moin/themes/basic/templates/layout.html
@@ -74,7 +74,7 @@
             <header class="moin-sidebar flex-grow-0" lang="{{ theme_supp.user_lang }}" dir="{{ theme_supp.user_dir }}">
                 <div class="moin-logo">
                     {% if logo %}
-                        <a href="{{ url_for('frontend.show_item', item_name=cfg.item_root) }}">
+                        <a href="{{ url_for('frontend.show_item', item_name=cfg.root_mapping.get('', cfg.default_root)) }}">
                             {{ logo }}
                         </a>
                     {% endif %}
@@ -131,7 +131,7 @@
                             </button>
 
                             {% if cfg.sitename %}
-                                <a class="navbar-brand" href="{{ url_for('frontend.show_item', item_name=cfg.item_root) }}">
+                                <a class="navbar-brand" href="{{ url_for('frontend.show_item', item_name=cfg.default_root) }}">
                                     {{ cfg.sitename }}
                                 </a>
                             {% endif %}

--- a/src/moin/themes/focus/templates/layout.html
+++ b/src/moin/themes/focus/templates/layout.html
@@ -25,7 +25,7 @@
                             </div>
                         {% endif %}
                         {% if cfg.sitename %}
-                            <a class="moin-sitename" href="{{ url_for('frontend.show_item', item_name=cfg.item_root) }}">
+                            <a class="moin-sitename" href="{{ url_for('frontend.show_item', item_name=cfg.default_root) }}">
                                 {{ cfg.sitename }}
                             </a>
                         {% endif %}

--- a/src/moin/themes/topside/templates/layout.html
+++ b/src/moin/themes/topside/templates/layout.html
@@ -22,7 +22,7 @@
                     </div>
                 {%- endif %}
                 {%- if cfg.sitename %}
-                    <a class="moin-sitename" href="{{ url_for('frontend.show_item', item_name=cfg.item_root) }}">
+                    <a class="moin-sitename" href="{{ url_for('frontend.show_item', item_name=cfg.default_root) }}">
                         {{ cfg.sitename }}
                     </a>
                 {%- endif %}

--- a/src/moin/utils/interwiki.py
+++ b/src/moin/utils/interwiki.py
@@ -190,8 +190,7 @@ class CompositeName(namedtuple("CompositeName", "namespace, field, value")):
 
     def get_root_fqname(self):
         """
-        Set value to the item_root of that namespace, and return
-        the new CompositeName.
+        Determine the root item of the namespace of this composite name and return it as new CompositeName instance.
         """
         return CompositeName(self.namespace, NAME_EXACT, app.cfg.root_mapping.get(self.namespace, app.cfg.default_root))
 


### PR DESCRIPTION
Fix code and jinja templates accessing the no longer existing wiki configuration setting 'item_root'.

Also change documentation and comments mentioning 'item_root'.