### PR TITLE
Pass variable 'subitem_target' instead of 'item_name' into search templates.

### DIFF
--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -548,7 +548,7 @@ def search():
                     history=history,
                     whoosh_query=q,
                     flaskg=flaskg,
-                    item_name=item_name,
+                    subitem_target=item_name,
                     is_ticket=is_ticket,
                 )
             else:
@@ -560,12 +560,12 @@ def search():
                     history=history,
                     whoosh_query=q,
                     flaskg=flaskg,
-                    item_name=item_name,
+                    subitem_target=item_name,
                     medium_search_form=search_form,
                 )
             flaskg.clock.stop("search render")
     else:
-        html = render_template("search.html", query=query, medium_search_form=search_form, item_name=item_name)
+        html = render_template("search.html", query=query, medium_search_form=search_form, subitem_target=item_name)
     return html
 
 

--- a/src/moin/templates/blog/utils.html
+++ b/src/moin/templates/blog/utils.html
@@ -61,7 +61,7 @@
             {{ forms.render_errors(form) }}
             <br>
             <input type="checkbox" id="moin-blog-search-this"
-            onclick="$('#moin-searchform').attr('action', this.checked ? '{{ url_for('frontend.search', item_name=blog_name) }}' : '{{ url_for('frontend.search') }}' );">
+            onclick="$('#moin-searchform').attr('action', this.checked ? '{{ url_for('frontend.search', q='>'~blog_name) }}' : '{{ url_for('frontend.search') }}' );">
             {{ _("only this blog") }}
     {{ gen.form.close() }}
 {% endmacro %}

--- a/src/moin/templates/search.html
+++ b/src/moin/templates/search.html
@@ -19,10 +19,10 @@
 
 {%- block content %}
     <h1>{{ _("Search") }}</h1>
-    {%- if item_name %}
-        <h2>Search "{{ item_name }}" Subitems and Transclusions</h2>
+    {%- if subitem_target %}
+        <h2>Search "{{ subitem_target }}" Subitems and Transclusions</h2>
     {%- endif %}
-    {{ gen.form.open(medium_search_form, id='moin-long-searchform', method='get', action=url_for('frontend.search', item_name=item_name)) }}
+    {{ gen.form.open(medium_search_form, id='moin-long-searchform', method='get', action=url_for('frontend.search')) }}
         <p>
             {{ forms.render(medium_search_form['q']) }}
         </p>

--- a/src/moin/themes/basic/templates/layout.html
+++ b/src/moin/themes/basic/templates/layout.html
@@ -14,7 +14,7 @@
 {% set user_actions, item_navigation, item_actions = theme_supp.get_local_panel(fqname) %}
 {% set current_url = request.url %}
 {% set current_path = request.path %}
-{% set current_url_showview = url_for_item(endpoint='frontend.show_item', item_name=item_name) %}
+{% set current_url_showview = url_for_item(item_name) if item_name else '' %}
 {% set login_url = theme_supp.login_url() %}
 
 {# Helper macro to generate the local panel #}


### PR DESCRIPTION
Variable 'item_name' is already used for other purposes in layout.html.

Note that 'item_name' might be undefined when navigating to a non item-related view like search. This required an additional change in file layout.html of the basic theme.