### PR TITLE
Correct template rendering

### DIFF
--- a/src/moin/apps/admin/templates/admin/group_acl_report.html
+++ b/src/moin/apps/admin/templates/admin/group_acl_report.html
@@ -11,7 +11,7 @@
 #}
 
 {% extends theme("layout.html") %}
-{% import "utils.html" as utils %}
+{% import "utils.html" as utils with context %}
 {% block content %}
     <h1>{{ _("Group ACL Report") }}</h1>
     <h2>{{ _("Group Name") }}: {{ group_name }}</h2>

--- a/src/moin/apps/admin/templates/admin/groupbrowser.html
+++ b/src/moin/apps/admin/templates/admin/groupbrowser.html
@@ -1,5 +1,5 @@
 {% extends theme("layout.html") %}
-{% import "utils.html" as utils %}
+{% import "utils.html" as utils with context %}
 {% block content %}
     <h1>{{ _("Groups") }}</h1>
     <table id="moin-group-browser" class="zebra moin-sortable" data-sortlist="[[0,0]]">

--- a/src/moin/apps/admin/templates/admin/register_new_user.html
+++ b/src/moin/apps/admin/templates/admin/register_new_user.html
@@ -4,7 +4,7 @@
 #}
 
 {% extends theme("layout.html") %}
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% block content %}
     <h1>{{ _("Register New User") }}</h1>

--- a/src/moin/apps/admin/templates/admin/trash.html
+++ b/src/moin/apps/admin/templates/admin/trash.html
@@ -1,5 +1,5 @@
 {% extends theme("layout.html") %}
-{% import "utils.html" as utils %}
+{% import "utils.html" as utils with context %}
 {% block content %}
     {% if headline %}
         <h1>{{ headline }}</h1>

--- a/src/moin/apps/admin/templates/admin/user_acl_report.html
+++ b/src/moin/apps/admin/templates/admin/user_acl_report.html
@@ -11,7 +11,7 @@
 #}
 
 {% extends theme("layout.html") %}
-{% import "utils.html" as utils %}
+{% import "utils.html" as utils with context %}
 {% block content %}
     <h1>{{ _("User ACL Report") }}</h1>
     <h2>{{ _("User Names") }}: {{ user_names|join(', ') }}</h2>

--- a/src/moin/apps/admin/templates/user/highlighterhelp.html
+++ b/src/moin/apps/admin/templates/user/highlighterhelp.html
@@ -1,4 +1,4 @@
-{% import "utils.html" as utils %}
+{% import "utils.html" as utils with context %}
 {% extends theme("layout.html") %}
 {% block content %}
     <h1>{{ _("Highlighters") }}</h1>

--- a/src/moin/apps/admin/templates/user/interwikihelp.html
+++ b/src/moin/apps/admin/templates/user/interwikihelp.html
@@ -1,4 +1,4 @@
-{% import "utils.html" as utils %}
+{% import "utils.html" as utils with context %}
 {% extends theme("layout.html") %}
 {% block content %}
     <h1>{{ _("InterWiki Names") }}</h1>

--- a/src/moin/apps/admin/templates/user/itemsize.html
+++ b/src/moin/apps/admin/templates/user/itemsize.html
@@ -1,4 +1,4 @@
-{% import "utils.html" as utils %}
+{% import "utils.html" as utils with context %}
 {% extends theme("layout.html") %}
 {% block content %}
     <h1>{{ _("Item Sizes (last revision)") }}</h1>

--- a/src/moin/templates/404.html
+++ b/src/moin/templates/404.html
@@ -5,7 +5,7 @@
         abort(404, item_name)  # where item_name is the local item name
 #}
 
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 {% extends theme("layout.html") %}
 
 {% block content %}

--- a/src/moin/templates/atom.html
+++ b/src/moin/templates/atom.html
@@ -1,4 +1,4 @@
-{% import "utils.html" as utils %}
+{% import "utils.html" as utils with context %}
 
 {# A few style rules to ensure the content doesn't overflow #}
 {% macro atom_style() %}

--- a/src/moin/templates/base.html
+++ b/src/moin/templates/base.html
@@ -8,7 +8,7 @@
 {#- This allows child templates passing their header_search macro to the common layout (eg blog).
    If there is no header_search macro defined in child templates use the default one. #}
 {%- if not header_search %}
-    {%- from "utils.html" import header_search %}
+    {%- from "utils.html" import header_search with context %}
 {%- endif -%}
 
 <html>

--- a/src/moin/templates/blog/layout.html
+++ b/src/moin/templates/blog/layout.html
@@ -1,6 +1,6 @@
 {% extends theme("show.html") %}
 {% import theme("blog/utils.html") as blog_utils with context %}
-{% import "utils.html" as utils %}
+{% import "utils.html" as utils with context %}
 {% import "itemviews.html" as itemviews with context %}
 
 {% if blog_item %}

--- a/src/moin/templates/blog/modify_entry_meta.html
+++ b/src/moin/templates/blog/modify_entry_meta.html
@@ -1,4 +1,4 @@
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% macro meta_editor(form, may_admin) %}
     <h2>Blog entry metadata</h2>

--- a/src/moin/templates/blog/modify_main_meta.html
+++ b/src/moin/templates/blog/modify_main_meta.html
@@ -1,4 +1,4 @@
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% macro meta_editor(form, may_admin) %}
     <h2>Blog metadata</h2>

--- a/src/moin/templates/blog/utils.html
+++ b/src/moin/templates/blog/utils.html
@@ -1,5 +1,5 @@
-{% import "forms.html" as forms %}
-{% import "utils.html" as utils %}
+{% import "forms.html" as forms with context %}
+{% import "utils.html" as utils with context %}
 
 {% macro show_blog_entry(entry_item) %}
     {% set summary = entry_item.meta['summary'] %}

--- a/src/moin/templates/convert.html
+++ b/src/moin/templates/convert.html
@@ -3,7 +3,7 @@
     an item to a different text markup language.
 #}
 
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 {% extends theme("show.html") %}
 
 {% set title = _("Convert '{item_name}'").format(item_name=item.fqname|shorten_fqname) %}

--- a/src/moin/templates/create_new_item.html
+++ b/src/moin/templates/create_new_item.html
@@ -5,7 +5,7 @@ the +index Create dialog or the browsers address/url field.
 The process rendering this template should have flashed a message describing the error.
 #}
 
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 {% extends theme("layout.html") %}
 
 {% set title = _("Create New Item") %}

--- a/src/moin/templates/delete.html
+++ b/src/moin/templates/delete.html
@@ -5,7 +5,7 @@
     The revision's meta data and rendered content is displayed for user review.
 #}
 
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 {% extends theme("show.html") %}
 
 {% if alias_names %}

--- a/src/moin/templates/destroy.html
+++ b/src/moin/templates/destroy.html
@@ -7,7 +7,7 @@
     is removed from storage so server log is only record of the transaction.
 #}
 
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 {% extends theme("show.html") %}
 
 {% if alias_names %}

--- a/src/moin/templates/diff_text_atom.html
+++ b/src/moin/templates/diff_text_atom.html
@@ -1,4 +1,4 @@
-{% import "utils.html" as utils %}
+{% import "utils.html" as utils with context %}
 
 <table class="moin-diff" style="width: 100%;">
     {% for llineno, lcontent, rlineno, rcontent in diffs %}

--- a/src/moin/templates/global_history.html
+++ b/src/moin/templates/global_history.html
@@ -12,7 +12,7 @@
 #}
 
 {% extends theme("layout.html") %}
-{% import "utils.html" as utils %}
+{% import "utils.html" as utils with context %}
 
 {# map meta.action to font awesome classes #}
 {% set awesome_class = {

--- a/src/moin/templates/login.html
+++ b/src/moin/templates/login.html
@@ -1,5 +1,5 @@
 {% extends theme("layout.html") %}
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% block content %}
     <div class="moin-form">

--- a/src/moin/templates/lookup.html
+++ b/src/moin/templates/lookup.html
@@ -1,6 +1,6 @@
 {% extends theme("layout.html") %}
-{% import "utils.html" as utils %}
-{% import "forms.html" as forms %}
+{% import "utils.html" as utils with context %}
+{% import "forms.html" as forms with context %}
 {% block content %}
     {% if results is not defined %}
         <h1>{{ _("Lookup") }}</h1>

--- a/src/moin/templates/lostpass.html
+++ b/src/moin/templates/lostpass.html
@@ -1,5 +1,5 @@
 {% extends theme("layout.html") %}
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% block content %}
     <h1>{{ _("Lost Password") }}</h1>

--- a/src/moin/templates/modify.html
+++ b/src/moin/templates/modify.html
@@ -12,8 +12,8 @@
         * select edit "from scratch" or "from template"
 #}
 
-{% import "forms.html" as forms %}
-{% import "utils.html" as utils %}
+{% import "forms.html" as forms with context %}
+{% import "utils.html" as utils with context %}
 
 {% extends theme("show.html") %}
 

--- a/src/moin/templates/modify_binary.html
+++ b/src/moin/templates/modify_binary.html
@@ -5,7 +5,7 @@
     As binary items cannot be edited by moin, the only choice given is to upload a file.
 #}
 
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% macro data_editor(form, item_name) %}
     <dl>

--- a/src/moin/templates/modify_meta.html
+++ b/src/moin/templates/modify_meta.html
@@ -5,7 +5,7 @@
     The macro defines a portion of a form enabling a user to modify selected meta data.
 #}
 
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% macro meta_editor(form, may_admin) %}
     <dl>

--- a/src/moin/templates/modify_text.html
+++ b/src/moin/templates/modify_text.html
@@ -12,7 +12,7 @@
     value and textarea scroll bars will be used as needed.
 #}
 
-{% from "modify_binary.html" import data_editor as base_editor %}
+{% from "modify_binary.html" import data_editor as base_editor with context %}
 
 {% macro data_editor(form, item_name) %}
     {% set textarea_rows = '1' if edit_rows == '0' else edit_rows %}

--- a/src/moin/templates/mychanges.html
+++ b/src/moin/templates/mychanges.html
@@ -5,7 +5,7 @@
 #}
 
 {% extends theme("layout.html") %}
-{% import "utils.html" as utils %}
+{% import "utils.html" as utils with context %}
 
 {% block content %}
     <h1>{{ _('My Changes') }}</h1>

--- a/src/moin/templates/recoverpass.html
+++ b/src/moin/templates/recoverpass.html
@@ -1,5 +1,5 @@
 {% extends theme("layout.html") %}
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% block content %}
     <h1>{{ _("Recover Password") }}</h1>

--- a/src/moin/templates/register.html
+++ b/src/moin/templates/register.html
@@ -1,5 +1,5 @@
 {% extends theme("layout.html") %}
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% block content %}
     <h1>{{ _("Create Account") }}</h1>

--- a/src/moin/templates/rename.html
+++ b/src/moin/templates/rename.html
@@ -4,7 +4,7 @@
     The item's meta data and rendered content is displayed for user review.
 #}
 
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 {% extends theme("show.html") %}
 
 {% set title = _("Rename '{item_name}'").format(item_name=item.fqname|shorten_fqname) %}

--- a/src/moin/templates/revert.html
+++ b/src/moin/templates/revert.html
@@ -4,8 +4,8 @@
     The revision's meta data and rendered content is displayed for user review.
 #}
 
-{% import "forms.html" as forms %}
-{% import "utils.html" as utils %}
+{% import "forms.html" as forms with context %}
+{% import "utils.html" as utils with context %}
 {% extends theme("layout.html") %}
 
 {% block content %}

--- a/src/moin/templates/search.html
+++ b/src/moin/templates/search.html
@@ -7,8 +7,8 @@
 #}
 
 {% extends theme("layout.html") %}
-{% import "forms.html" as forms %}
-{% import "utils.html" as utils %}
+{% import "forms.html" as forms with context %}
+{% import "utils.html" as utils with context %}
 
 {%- set search_form = None %} {# layout will not show search form in header #}
 

--- a/src/moin/templates/ticket/advanced.html
+++ b/src/moin/templates/ticket/advanced.html
@@ -1,7 +1,7 @@
 {# Display a form to search for tickets using meta data such tags, priority, etc. #}
 
 {% extends theme("layout.html") %}
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% set title = _("Advanced Search") %}
 {% block content %}

--- a/src/moin/templates/ticket/modify.html
+++ b/src/moin/templates/ticket/modify.html
@@ -2,7 +2,7 @@
 
 {% extends "ticket/base.html" %}
 
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 {% import "ticket/ticket_macros.html" as ticket_macros with context %}
 
 {% block title_text %}

--- a/src/moin/templates/ticket/submit.html
+++ b/src/moin/templates/ticket/submit.html
@@ -2,7 +2,7 @@
 
 {% extends "ticket/base.html" %}
 
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 {% import "ticket/ticket_macros.html" as ticket_macros with context %}
 
 {% block title_text %}

--- a/src/moin/templates/usersettings.html
+++ b/src/moin/templates/usersettings.html
@@ -13,7 +13,7 @@
 #}
 
 {% extends theme("layout.html") %}
-{% import "usersettings_forms.html" as user_forms %}
+{% import "usersettings_forms.html" as user_forms with context %}
 
 {% block content %}
     <h1>{{ _("User Settings") }}</h1>

--- a/src/moin/templates/usersettings_ajax.html
+++ b/src/moin/templates/usersettings_ajax.html
@@ -2,7 +2,7 @@
     This template returns the updates for one usersettings form processed as part of an XHR request.
 #}
 
-{% import "usersettings_forms.html" as user_forms %}
+{% import "usersettings_forms.html" as user_forms with context %}
 
 {% if part == 'personal' %}
     {{ user_forms.personal(form) }}

--- a/src/moin/templates/usersettings_forms.html
+++ b/src/moin/templates/usersettings_forms.html
@@ -6,7 +6,7 @@
     Updates to the forms will be processed as XHR requests.
 #}
 
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% macro personal(form) %}
     {{ gen.form.open(form, id="usersettings_personal", method="post", action=url_for('frontend.usersettings')) }}

--- a/src/moin/templates/utils.html
+++ b/src/moin/templates/utils.html
@@ -4,7 +4,7 @@
     Original Moin code should be added here. Macros derived from Flatland should be added to forms.html.
 #}
 
-{% import 'forms.html' as forms %}
+{% import "forms.html" as forms with context %}
 
 {# "item" must be passed because of flakey jinja2 context passing #}
 {% macro rev_navigation(rev_navigation_ids_dates, fqname, view='frontend.show_item', item=item) %}

--- a/src/moin/themes/__init__.py
+++ b/src/moin/themes/__init__.py
@@ -34,7 +34,6 @@ from moin.constants.contenttypes import CONTENTTYPES_MAP, CONTENTTYPE_MARKUP, CO
 from moin.constants.misc import FLASH_REPEAT, ICON_MAP
 from moin.constants.namespaces import NAMESPACE_DEFAULT, NAMESPACE_USERS, NAMESPACE_USERPROFILES, NAMESPACE_ALL
 from moin.constants.rights import SUPERUSER
-from moin.search import SearchForm
 from moin.user import User
 from moin.utils.interwiki import (
     split_interwiki,
@@ -46,7 +45,6 @@ from moin.utils.interwiki import (
     split_fqname,
     get_fqname,
 )
-from moin.utils.forms import make_generator
 from moin.utils.clock import timed
 from moin.utils.mime import Type
 from moin.utils import show_time
@@ -763,19 +761,19 @@ def time_datetime(dt):
     return show_time.format_date_time(dt)
 
 
-def setup_jinja_env():
-    app.jinja_env.filters["shorten_fqname"] = shorten_fqname
-    app.jinja_env.filters["shorten_item_name"] = shorten_item_name
-    app.jinja_env.filters["shorten_id"] = shorten_id
-    app.jinja_env.filters["contenttype_to_class"] = contenttype_to_class
-    app.jinja_env.filters["json_dumps"] = dumps
-    app.jinja_env.filters["shorten_ctype"] = shorten_ctype
-    app.jinja_env.filters["time_hh_mm"] = time_hh_mm
-    app.jinja_env.filters["time_datetime"] = time_datetime
+def setup_jinja_env(jinja_env):
+    jinja_env.filters["shorten_fqname"] = shorten_fqname
+    jinja_env.filters["shorten_item_name"] = shorten_item_name
+    jinja_env.filters["shorten_id"] = shorten_id
+    jinja_env.filters["contenttype_to_class"] = contenttype_to_class
+    jinja_env.filters["json_dumps"] = dumps
+    jinja_env.filters["shorten_ctype"] = shorten_ctype
+    jinja_env.filters["time_hh_mm"] = time_hh_mm
+    jinja_env.filters["time_datetime"] = time_datetime
     # please note that these filters are installed by flask-babel:
     # datetimeformat, dateformat, timeformat, timedeltaformat
 
-    app.jinja_env.globals.update(
+    jinja_env.globals.update(
         {
             # please note that flask-babel/jinja2.ext installs:
             # _, gettext, ngettext
@@ -784,19 +782,11 @@ def setup_jinja_env():
             "Type": Type,
             # please note that flask-theme installs:
             # theme, theme_static
-            "theme_supp": ThemeSupport(app.cfg),
-            "user": flaskg.user,
-            "storage": flaskg.storage,
-            "clock": flaskg.clock,
-            "cfg": app.cfg,
-            "item_name": request.view_args.get("item_name", ""),
             "url_for_item": url_for_item,
             "get_fqname": get_fqname,
             "get_editor_info": lambda meta: get_editor_info(meta),
             "get_assigned_to_info": lambda meta: get_assigned_to_info(meta),
             "utctimestamp": lambda dt: utctimestamp(dt),
-            "gen": make_generator(),
-            "search_form": SearchForm.from_defaults(),
         }
     )
 

--- a/src/moin/themes/basic/templates/modify.html
+++ b/src/moin/themes/basic/templates/modify.html
@@ -1,9 +1,9 @@
 {% extends theme("layout.html") %}
-{% import "forms.html" as forms %}
-{% import "utils.html" as utils %}
-{% from theme(form.meta_template) import basic_meta_editor %}
+{% import "forms.html" as forms with context %}
+{% import "utils.html" as utils with context %}
+{% from theme(form.meta_template) import basic_meta_editor with context %}
 {% import theme("itemviews.html") as itemviews with context %}
-{% import theme(form['content_form'].template) as content_template %}
+{% import theme(form['content_form'].template) as content_template with context %}
 {% set extra_head = content_template.extra_head %}
 {% if content_template.basic_data_editor is defined %}
     {% set data_editor = content_template.basic_data_editor %}

--- a/src/moin/themes/basic/templates/modify_binary.html
+++ b/src/moin/themes/basic/templates/modify_binary.html
@@ -1,4 +1,4 @@
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% macro basic_data_editor(form, item_name, class) %}
     {{ forms.render(form['data_file']) }}

--- a/src/moin/themes/basic/templates/modify_meta.html
+++ b/src/moin/themes/basic/templates/modify_meta.html
@@ -1,4 +1,4 @@
-{% import "forms.html" as forms %}
+{% import "forms.html" as forms with context %}
 
 {% macro basic_meta_editor(form) %}
     {% for e in [

--- a/src/moin/themes/basic/templates/modify_text.html
+++ b/src/moin/themes/basic/templates/modify_text.html
@@ -1,4 +1,4 @@
-{% from "modify_binary.html" import data_editor as base_editor %}
+{% from "modify_binary.html" import data_editor as base_editor with context %}
 
 {% macro basic_data_editor(form, item_name) %}
     <input type="button" id="moin-toggle-fixed-font-button" value="{{ _('Toggle font width') }}" class="moin-button moin-textarea-font" >

--- a/src/moin/themes/focus/templates/modify.html
+++ b/src/moin/themes/focus/templates/modify.html
@@ -12,8 +12,8 @@
         * select edit "from scratch" or "from template"
 #}
 
-{% import "forms.html" as forms %}
-{% import "utils.html" as utils %}
+{% import "forms.html" as forms with context %}
+{% import "utils.html" as utils with context %}
 
 {% extends theme("show.html") %}
 


### PR DESCRIPTION
No longer modify the Jinja environment globals with each request processing. Doing otherwise caused issues with objects not being released as expected (e.g. "clock") because they were still being referenced somewhere in cached content created by the rendering engine.

> Environment globals should not be changed after loading any templates, and template globals should not be changed at any time after loading the template. Changing globals after loading a template will result in unexpected behavior as they may be shared between the environment and other templates.

See <https://jinja.palletsprojects.com/en/stable/api/#the-global-namespace>

A context procesor is used instead to inject common variables to the rendering engine. Template import statements must specify "with context" when accessing context variables like e.g. "gen".