### PR TITLE
rST documentation fixes, part 1: preparation

### DIFF
--- a/docs/user/rest.rst
+++ b/docs/user/rest.rst
@@ -3,8 +3,9 @@ reST (reStructuredText) Markup
 ===============================
 
 ..
- This document is duplicated within Moin2 as `/docs/user/rest.rst` and
- `contrib/sample/rst.data`. Please update both.
+ This document is duplicated within the Moin2 repository as
+ `docs/user/rest.rst` and `src/moin/help/help-en/rst.data`.
+ Please update both.
 
 Depending on your source, this document may have been created by
 the Moin2 reST parser (Docutils) or the Sphinx reST parser. These parsers
@@ -96,11 +97,11 @@ The following is a table of inline markup that can be used to format text in Moi
 Markup                                   Result
 ======================================== ====================================
 ``**Bold Text**``                        **Bold text**
-                                         
+
 ``*Italic*``                             *Italic*
-                                         
+
 ````Inline Literals````                  ``Inline Literals``
-                                         
+
 ``***nested markup is not supported***`` ***nested markup is not supported***
 ======================================== ====================================
 
@@ -127,7 +128,8 @@ Markup                                                            Result
 Internal Links
 --------------
 
-The examples below use the "help-en" and "help-common" namespaces to separate these help pages from the main wiki content.
+The examples below use the "help-en" and "help-common" namespaces
+to separate these help pages from the main wiki content.
 Some target pages may be missing from the default namespace.
 
 Within the rst syntax:

--- a/src/moin/help/help-en/rst.data
+++ b/src/moin/help/help-en/rst.data
@@ -3,8 +3,9 @@ reST (reStructuredText) Markup
 ===============================
 
 ..
- This document is duplicated within Moin2 as `/docs/user/rest.rst` and
- `contrib/sample/rst.data`. Please update both.
+ This document is duplicated within the Moin2 repository as
+ `docs/user/rest.rst` and `src/moin/help/help-en/rst.data`.
+ Please update both.
 
 Depending on your source, this document may have been created by
 the Moin2 reST parser (Docutils) or the Sphinx reST parser. These parsers
@@ -96,11 +97,11 @@ The following is a table of inline markup that can be used to format text in Moi
 Markup                                   Result
 ======================================== ====================================
 ``**Bold Text**``                        **Bold text**
-                                         
+
 ``*Italic*``                             *Italic*
-                                         
+
 ````Inline Literals````                  ``Inline Literals``
-                                         
+
 ``***nested markup is not supported***`` ***nested markup is not supported***
 ======================================== ====================================
 
@@ -127,7 +128,7 @@ Markup                                                            Result
 Internal Links
 --------------
 
-The examples below use the "help-en" and "help-common" namespaces 
+The examples below use the "help-en" and "help-common" namespaces
 to separate these help pages from the main wiki content.
 Some target pages may be missing from the default namespace.
 

--- a/src/moin/help/help-en/rst.meta
+++ b/src/moin/help/help-en/rst.meta
@@ -5,9 +5,9 @@
   "contenttype": "text/x-rst;charset=utf-8",
   "dataid": "c7f47fd6eaaa4e518c2bd32d741073f8",
   "externallinks": [
-    "http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#enumerated-lists",
     "http://moinmo.in/",
-    "http://www.python.org/"
+    "http://www.python.org/",
+    "https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#enumerated-lists"
   ],
   "itemid": "412d0e59c79147058ef2e947d1772d5f",
   "itemlinks": [
@@ -29,8 +29,8 @@
   "namespace": "help-en",
   "rev_number": 1,
   "revid": "fd40283c31464441a3734ba512b7cfb0",
-  "sha1": "40abb7437b6bd5234f58644114cef02eaa7a7b83",
-  "size": 21443,
+  "sha1": "d71e4e1f1e978714550ab1c0f80033cc3d3e182c",
+  "size": 19176,
   "summary": "",
   "tags": [
     "parser",


### PR DESCRIPTION
Simplify the markup and merge changes in the rST markup help, so that
`/docs/user/rest.rst` and  `moin/src/moin/help/help-en/rst.data` are again in sync.

More extensive updates/fixes to follow.
Can we use a symlink instead of manually maintaining 2 files?