### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             - os: windows-latest
               python-version: '3.11'
             - os: ubuntu-22.04
-              python-version: '3.9'
+              python-version: '3.10'
             - os: ubuntu-latest
               python-version: '3.12'
             - os: ubuntu-latest

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -159,8 +159,8 @@ Before you can run moin, you need to install it.
 
 Using your standard user account, run the following command
 from the project root directory. Replace <python> in the command
-below with the path to a python 3.9+ executable. This is usually
-just "python", but may be "python3", "python3.9", "/opt/pypy/bin/pypy"
+below with the path to a python 3.10+ executable. This is usually
+just "python", but may be "python3", "python3.10", "/opt/pypy/bin/pypy"
 or even <some-other-path-to-python>:
 
 ::

--- a/docs/admin/requirements.rst
+++ b/docs/admin/requirements.rst
@@ -2,11 +2,11 @@
 Requirements
 ============
 
-MoinMoin requires Python 3.9+. A CPython distribution is
+MoinMoin requires Python 3.10+. A CPython distribution is
 recommended because it will likely be the fastest and most stable.
 Most developers use a CPython distribution for testing.
-Typical Linux distributions will either have Python 3.9+ installed by
-default or will have a package manager that will install Python 3.9+
+Typical Linux distributions will either have Python 3.10+ installed by
+default or will have a package manager that will install Python 3.10+
 as a secondary Python.
 Windows users may download CPython distributions from https://www.python.org/ or
 https://www.activestate.com/.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "MoinMoin is an easy to use, full-featured and extensible wiki sof
 readme = {file="README.md", content-type="text/markdown"}
 license = "GPL-2.0-or-later"
 license-files = ["LICENSE.txt"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["wiki", "web"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -24,7 +24,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -109,7 +108,7 @@ norecursedirs = [".git", "_build", "tmp*", "env*", "dlc", "wiki", "support"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py310"
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -157,13 +156,13 @@ skips = ["B101", "B105", "B106", "B307", "B311", "B403", "B608"]
 
 # run like this:
 # tox
-# tox run -e py39
+# tox run -e py310
 # tox -- -v -k test_wikiutil
 # tox -- -v
 
 [tool.tox]
 requires = ["tox>=4.21"]
-envlist = ["3.9", "3.10", "3.11", "3.12", "3.13", "ruff"]
+envlist = ["3.10", "3.11", "3.12", "3.13", "ruff"]
 
 [tool.tox.env_run_base]
 description = "Run tests under {base_python}"

--- a/quickinstall.py
+++ b/quickinstall.py
@@ -8,9 +8,9 @@ Create a virtual environment and install Moin 2 and all requirements in developm
 
 Usage for installation:
 
-    <python> quickinstall.py (where <python> is any Python 3.9+ executable)
+    <python> quickinstall.py (where <python> is any Python 3.10+ executable)
 
-Requires: Python 3.9+, pip
+Requires: Python 3.10+, pip
 
 The first run of quickinstall.py creates these files or symlinks in the repo root:
 
@@ -47,8 +47,8 @@ from collections import Counter
 import venv
 
 
-if sys.hexversion < 0x3090000:
-    sys.exit("Error: MoinMoin requires Python 3.9+, current version is %s\n" % (platform.python_version(),))
+if sys.hexversion < 0x30A0000:
+    sys.exit("Error: MoinMoin requires Python 3.10+, current version is %s\n" % (platform.python_version(),))
 
 
 WIN_INFO = "m.bat, activate.bat, and deactivate.bat are created by quickinstall.py"

--- a/src/moin/__init__.py
+++ b/src/moin/__init__.py
@@ -16,5 +16,5 @@ from ._version import version  # noqa
 project = "MoinMoin"
 
 
-if sys.hexversion < 0x3090000:
-    sys.exit("Error: %s requires Python 3.9 or later; current version is %s\n" % (project, platform.python_version()))
+if sys.hexversion < 0x30A0000:
+    sys.exit("Error: %s requires Python 3.10 or later; current version is %s\n" % (project, platform.python_version()))


### PR DESCRIPTION
Python 3.9 reached its end-of-life (EOL) on October 5, 2025.

See <https://versionlog.com/python/3.9/>