### PR TITLE
Next set of fixes for the reStructuredText import.

### DIFF
--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -382,9 +382,10 @@ text""",
         # Moin uses admonitions also for system messages
         (
             "Unbalanced *inline markup.",
-            "<page><body><p>Unbalanced *inline markup.</p>"
+            '<page><body><p>Unbalanced <span id="problematic-1" /><a xhtml:class="red" xlink:href="#system-message-1">*</a>inline markup.</p>'
             '<span id="system-message-1" /><admonition type="caution">'
-            '<p><strong xhtml:class="title">System Message: WARNING/2</strong> (rST input line 1)</p>'
+            '<p><strong xhtml:class="title">System Message: WARNING/2</strong> (rST input line 1) '
+            '<span id="system-message-1" /><a xlink:href="#problematic-1">backlink</a></p>'
             "<p>Inline emphasis start-string without end-string.</p>"
             "</admonition></body></page>",
         ),


### PR DESCRIPTION
Next set of fixes for the reStructuredText import.

* Support custom "interpreted text roles"
  Pass on CSS class arguments from `<inline>` elements to support "custom interpreted text roles"
(https://docutils.sourceforge.io/docs/ref/rst/directives.html#role)
  Add special handling for "del" and "ins" roles, so that they will become `<del>` and `<ins>` in HTML.

* Support a custom start value for ordered lists.

* Run "transform" to filter INFO-level messages. 
  (Unless the ["report-level" configuration setting](https://docutils.sourceforge.io/docs/user/config.html#report-level) is changed to keep them.)

* More informative system messages: include severity level, line of occurence and (if applicable) a back-link to the problematic text when reporting a parser issue.

Documentation will follow once the current doc PR is handled.