### PR TITLE
Improve existing test code

### DIFF
--- a/src/moin/_tests/test_forms.py
+++ b/src/moin/_tests/test_forms.py
@@ -5,6 +5,8 @@
     MoinMoin - moin.forms tests.
 """
 
+import pytest
+
 import datetime
 import json
 from calendar import timegm
@@ -51,6 +53,7 @@ def test_datetimeunix():
     assert d.u == ""
 
 
+@pytest.mark.usefixtures("_req_ctx")
 def test_validjson():
     """
     Tests for changes to metadata when modifying an item.

--- a/src/moin/_tests/test_test_environ.py
+++ b/src/moin/_tests/test_test_environ.py
@@ -17,7 +17,9 @@ from moin._tests import wikiconfig
 import pytest
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestStorageEnvironWithoutConfig:
+
     def setup_method(self, method):
         self.class_level_value = 123
 
@@ -53,6 +55,7 @@ class TestStorageEnvironWithConfig:
 
         return Config
 
+    @pytest.mark.usefixtures("_app_ctx")
     def test_config(self):
         assert isinstance(app.cfg, wikiconfig.Config)
         assert app.cfg.default_acl == DEFAULT_ACL

--- a/src/moin/_tests/test_user.py
+++ b/src/moin/_tests/test_user.py
@@ -18,6 +18,7 @@ from moin.constants.keys import ITEMID, ITEMTYPE, NAME, NAMEPREFIX, NAMERE, NAME
 import pytest
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestSimple:
     def test_create_retrieve(self):
         name = "foo"
@@ -41,9 +42,10 @@ class TestSimple:
         assert u.profile[REV_NUMBER] == 1
 
 
+@pytest.mark.usefixtures("_req_ctx", "saved_user")
 class TestUser:
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture
     def saved_user(self):
         orig_user = flaskg.user
         flaskg.user = user.User()
@@ -274,15 +276,17 @@ class TestUser:
 
 class TestGroupName:
 
-    def testGroupNames(self):
+    @pytest.mark.usefixtures("_app_ctx")
+    def test_group_names(self):
         """User: isValidName: reject group names."""
         test = "AdminGroup"
         assert not user.isValidName(test)
 
 
+@pytest.mark.usefixtures("_app_ctx")
 class TestIsValidName:
 
-    def testNonAlnumCharacters(self):
+    def test_non_alnum_characters(self):
         """User: isValidName: reject Unicode non-alphanumeric characters.
 
         ':' and ',' are used in ACL rules; we might add more characters to the syntax.
@@ -293,13 +297,13 @@ class TestIsValidName:
             name = base.format(c)
             assert not user.isValidName(name)
 
-    def testWhitespace(self):
+    def test_whitespace(self):
         """User: isValidName: reject leading, trailing, or multiple whitespace."""
         cases = (" User Name", "User Name ", "User   Name")
         for test in cases:
             assert not user.isValidName(test)
 
-    def testValid(self):
+    def test_valid(self):
         """User: isValidName: accept names in any language, with spaces."""
         cases = (
             "Jürgen Hermann",  # German

--- a/src/moin/_tests/test_wikiutil.py
+++ b/src/moin/_tests/test_wikiutil.py
@@ -18,7 +18,7 @@ from typing import cast
 
 
 class TestCleanInput:
-    def testCleanInput(self):
+    def test_clean_input(self):
         tests = [
             ("", ""),  # empty
             ("aaa\r\n\tbbb", "aaa   bbb"),  # ws chars -> blanks
@@ -83,9 +83,10 @@ class TestRelativeTools:
         assert relative_page == wikiutil.RelItemName(current_page, absolute_page)
 
 
+@pytest.mark.usefixtures("_app_ctx")
 class TestNormalizePagename:
 
-    def testPageInvalidChars(self):
+    def test_page_invalid_chars(self):
         """Request: normalize pagename: remove invalid Unicode chars.
 
         Assume the default setting.
@@ -95,7 +96,7 @@ class TestNormalizePagename:
         result = wikiutil.normalize_pagename(test, app.cfg)
         assert result == expected
 
-    def testNormalizeSlashes(self):
+    def test_normalize_slashes(self):
         """Request: normalize pagename: normalize slashes."""
         cases = (
             ("/////", ""),
@@ -108,7 +109,7 @@ class TestNormalizePagename:
             result = wikiutil.normalize_pagename(test, app.cfg)
             assert result == expected
 
-    def testNormalizeWhitespace(self):
+    def test_normalize_whitespace(self):
         """Request: normalize pagename: normalize whitespace."""
         cases = (
             ("         ", ""),
@@ -123,7 +124,7 @@ class TestNormalizePagename:
             result = wikiutil.normalize_pagename(test, app.cfg)
             assert result == expected
 
-    def testUnderscoreTestCase(self):
+    def test_underscore_test_case(self):
         """Request: normalize pagename: convert underscores to spaces and normalize whitespace.
 
         Underscores should convert to spaces, then spaces should be
@@ -141,9 +142,10 @@ class TestNormalizePagename:
             assert result == expected
 
 
+@pytest.mark.usefixtures("_app_ctx")
 class TestGroupItems:
 
-    def testNormalizeGroupName(self):
+    def test_normalize_group_name(self):
         """Request: normalize itemname: restrict groups to alphanumeric Unicode.
 
         Spaces should be normalized after invalid chars are removed!
@@ -161,7 +163,7 @@ class TestGroupItems:
                 assert result == expected
 
 
-def testParentItemName():
+def test_ParentItemName():
     # with no parent
     result = wikiutil.ParentItemName("itemname")
     expected = ""
@@ -172,7 +174,7 @@ def testParentItemName():
     assert result == expected
 
 
-def testdrawing2fname():
+def test_drawing2fname():
     # with extension not in DRAWING_EXTENSIONS
     result = wikiutil.drawing2fname("Moin_drawing.txt")
     expected = "Moin_drawing.txt.svgdraw"
@@ -183,7 +185,7 @@ def testdrawing2fname():
     assert result == expected
 
 
-def testgetUnicodeIndexGroup():
+def test_getUnicodeIndexGroup():
     result = wikiutil.getUnicodeIndexGroup(["moin-2", "MoinMoin"])
     expected = "MOIN-2"
     assert result == expected
@@ -192,7 +194,7 @@ def testgetUnicodeIndexGroup():
         result = wikiutil.getUnicodeIndexGroup("")
 
 
-def testis_URL():
+def test_is_URL():
     sample_schemes = ["http", "https", "ftp", "ssh"]
     for scheme in sample_schemes:
         result = wikiutil.is_URL(scheme + ":MoinMoin")
@@ -206,7 +208,7 @@ def testis_URL():
     assert not result
 
 
-def testcontainsConflictMarker():
+def test_containsConflictMarker():
     # text with conflict marker
     result = wikiutil.containsConflictMarker("/!\\ '''Edit conflict - Conflict marker is present")
     assert result
@@ -216,7 +218,7 @@ def testcontainsConflictMarker():
     assert not result
 
 
-def testsplit_anchor():
+def test_split_anchor():
     """
     TODO: add a test for split_anchor when we have a better
           approach to deal with problems like "#MoinMoin#" returning ("#MoinMoin", "")
@@ -234,7 +236,7 @@ def testsplit_anchor():
     assert result == expected
 
 
-def testfile_headers():
+def test_file_headers():
     test_headers = [
         # test_file, content_type
         ("imagefile.gif", "image/gif"),
@@ -255,6 +257,7 @@ def testfile_headers():
     assert result == expected
 
 
+@pytest.mark.usefixtures("_app_ctx")
 @pytest.mark.parametrize(
     "url,expected",
     [

--- a/src/moin/apps/_tests/__init__.py
+++ b/src/moin/apps/_tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright: 2025 MoinMoin project
+# License: GNU GPL v2 (or any later version), see LICENSE.txt for details.

--- a/src/moin/apps/_tests/utils.py
+++ b/src/moin/apps/_tests/utils.py
@@ -1,0 +1,77 @@
+# Copyright: 2025 MoinMoin project
+# License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from flask import url_for
+
+from moin import user
+from moin.constants.itemtypes import ITEMTYPE_DEFAULT
+from moin.constants.keys import ITEMID
+
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
+    from werkzeug.test import TestResponse
+
+
+def set_user_in_client_session(client: FlaskClient, user: user.User) -> None:
+    # the test configuration has MoinAuth enabled
+    with client.session_transaction() as session:
+        session["user.itemid"] = user.profile[ITEMID]
+        session["user.trusted"] = False
+        session["user.auth_method"] = "moin"
+        session["user.auth_attribs"] = tuple()
+        session["user.session_token"] = user.get_session_token()
+
+
+def create_user(name: str, password: str, pwencoded: bool = False, email: str | None = None) -> None:
+    """
+    Helper to create test user
+    """
+    if email is None:
+        email = "user@example.org"
+    user.create_user(name, password, email, is_encrypted=pwencoded)
+
+
+def login(client: FlaskClient, username: str, password: str, next: str = "http://localhost/Home") -> None:
+    response = client.post(
+        url_for("frontend.login"),
+        follow_redirects=False,
+        data={"login_username": username, "login_password": password, "login_nexturl": next, "login_submit": "1"},
+    )
+    assert response.status_code == 302
+    assert response.location == next
+    assert client.get_cookie("session")
+
+
+def modify_item(
+    client: FlaskClient, item_name: str, data: dict[str, Any], expected_status_code: int = 302
+) -> TestResponse:
+    response = client.post(url_for("frontend.modify_item", item_name=item_name), data=data)
+    assert response.status_code == expected_status_code
+    return response
+
+
+def make_modify_form_data(
+    item_name: str,
+    *,
+    content: str = "",
+    comment: str = "",
+    contenttype: str = "text/x.moin.wiki;charset=utf-8",
+    **kwargs,
+):
+    return {
+        "itemtype": ITEMTYPE_DEFAULT,
+        "template": "",
+        "contenttype": contenttype,
+        "content_form_data_text": content,
+        "content_form_data_file": content.encode(encoding="utf-8"),
+        "comment": comment,
+        "meta_form_acl": "None",
+        "meta_form_name": item_name,
+        "meta_form_summary": "",
+        "meta_form_tags": "",
+        "submit": "OK",
+    } | kwargs

--- a/src/moin/apps/admin/_tests/test_admin.py
+++ b/src/moin/apps/admin/_tests/test_admin.py
@@ -6,9 +6,9 @@
 MoinMoin - Tests for admin views
 """
 
-from flask import url_for
-
 import pytest
+
+from flask import url_for
 
 
 @pytest.mark.parametrize(
@@ -24,10 +24,9 @@ import pytest
         ({"endpoint": "admin.itemsize"}, "403 FORBIDDEN", ("<html>", "</html>")),
     ),
 )
-def test_admin(app, url_for_args, status, data):
-    with app.test_client() as client:
-        rv = client.get(url_for(**url_for_args))
-        assert rv.status == status
-        assert rv.headers["Content-Type"] == "text/html; charset=utf-8"
-        for item in data:
-            assert item.encode() in rv.data
+def test_admin(client, url_for_args, status, data):
+    rv = client.get(url_for(**url_for_args))
+    assert rv.status == status
+    assert rv.headers["Content-Type"] == "text/html; charset=utf-8"
+    for item in data:
+        assert item.encode() in rv.data

--- a/src/moin/apps/feed/_tests/test_feed.py
+++ b/src/moin/apps/feed/_tests/test_feed.py
@@ -5,37 +5,46 @@
 MoinMoin - Tests for feeds
 """
 
+from __future__ import annotations
+
 from flask import url_for
 
-from moin.constants.keys import COMMENT
-from moin._tests import update_item
+from moin.apps._tests.utils import create_user, login, modify_item, make_modify_form_data
 
 
-class TestFeeds:
-    def test_global_atom(self, app):
-        with app.test_client() as client:
-            rv = client.get(url_for("feed.atom"))
-            assert rv.status == "200 OK"
-            assert rv.headers["Content-Type"] == "application/atom+xml"
-            assert rv.data.startswith(b"<?xml")
-            assert b'<feed xmlns="http://www.w3.org/2005/Atom">' in rv.data
-            assert b"</feed>" in rv.data
+def test_global_atom(client):
+    rv = client.get(url_for("feed.atom"))
+    assert rv.status_code == 200
+    assert rv.headers["Content-Type"] == "application/atom+xml"
+    assert rv.text.startswith("<?xml")
+    assert '<feed xmlns="http://www.w3.org/2005/Atom">' in rv.text
+    assert "</feed>" in rv.text
 
-    def test_global_atom_with_an_item(self, app):
-        basename = "Foo"
-        update_item(basename, {COMMENT: "foo data for feed item"}, "")
-        with app.test_client() as client:
-            rv = client.get(url_for("feed.atom"))
-            assert rv.status == "200 OK"
-            assert rv.headers["Content-Type"] == "application/atom+xml"
-            assert rv.data.startswith(b"<?xml")
-            assert b"foo data for feed item" in rv.data
 
-        # Test cache invalidation
-        update_item(basename, {COMMENT: "checking if the cache invalidation works"}, "")
-        with app.test_client() as client:
-            rv = client.get(url_for("feed.atom"))
-            assert rv.status == "200 OK"
-            assert rv.headers["Content-Type"] == "application/atom+xml"
-            assert rv.data.startswith(b"<?xml")
-            assert b"checking if the cache invalidation works" in rv.data
+def test_global_atom_with_an_item(client):
+
+    create_user("moin", "Xiwejr622")
+
+    login(client, "moin", "Xiwejr622")
+
+    item_name = "Foo"
+
+    response = modify_item(client, item_name, make_modify_form_data(item_name, comment="foo data for feed item"))
+    assert response.status_code == 302
+
+    rv = client.get(url_for("feed.atom"))
+    assert rv.status_code == 200
+    assert rv.headers["Content-Type"] == "application/atom+xml"
+    assert rv.text.startswith("<?xml")
+    assert "foo data for feed item" in rv.text
+
+    # Test cache invalidation
+    response = modify_item(
+        client, item_name, make_modify_form_data(item_name, comment="checking if the cache invalidation works")
+    )
+
+    rv = client.get(url_for("feed.atom"))
+    assert rv.status_code == 200
+    assert rv.headers["Content-Type"] == "application/atom+xml"
+    assert rv.text.startswith("<?xml")
+    assert "checking if the cache invalidation works" in rv.text

--- a/src/moin/apps/misc/_tests/test_misc.py
+++ b/src/moin/apps/misc/_tests/test_misc.py
@@ -8,18 +8,16 @@ MoinMoin - Tests for misc views
 from flask import url_for
 
 
-class TestMisc:
-    def test_global_sitemap(self, app):
-        with app.test_client() as client:
-            rv = client.get(url_for("misc.sitemap"))
-            assert rv.status == "200 OK"
-            assert rv.headers["Content-Type"] == "text/xml; charset=utf-8"
-            assert rv.data.startswith(b"<?xml")
-            assert b'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' in rv.data
-            assert b"</urlset>" in rv.data
+def test_global_sitemap(client):
+    rv = client.get(url_for("misc.sitemap"))
+    assert rv.status == "200 OK"
+    assert rv.headers["Content-Type"] == "text/xml; charset=utf-8"
+    assert rv.data.startswith(b"<?xml")
+    assert b'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' in rv.data
+    assert b"</urlset>" in rv.data
 
-    def test_urls_names(self, app):
-        with app.test_client() as client:
-            rv = client.get(url_for("misc.urls_names"))
-            assert rv.status == "200 OK"
-            assert rv.headers["Content-Type"] == "text/plain; charset=utf-8"
+
+def test_urls_names(client):
+    rv = client.get(url_for("misc.urls_names"))
+    assert rv.status == "200 OK"
+    assert rv.headers["Content-Type"] == "text/plain; charset=utf-8"

--- a/src/moin/apps/serve/_tests/test_serve.py
+++ b/src/moin/apps/serve/_tests/test_serve.py
@@ -8,16 +8,14 @@ MoinMoin - Tests for the serve app
 from flask import url_for
 
 
-class TestServe:
-    def test_index(self, app):
-        with app.test_client() as client:
-            rv = client.get(url_for("serve.index"))
-            assert rv.status == "200 OK"
-            assert rv.headers["Content-Type"] == "text/plain"
+def test_index(client):
+    rv = client.get(url_for("serve.index"))
+    assert rv.status == "200 OK"
+    assert rv.headers["Content-Type"] == "text/plain"
 
-    def test_files(self, app):
-        with app.test_client() as client:
-            rv = client.get(url_for("serve.files", name="DoesntExist"))
-            assert rv.status == "404 NOT FOUND"
-            assert rv.headers["Content-Type"] == "text/html; charset=utf-8"
-            assert rv.text.startswith("<!doctype html")
+
+def test_files(client):
+    rv = client.get(url_for("serve.files", name="DoesntExist"))
+    assert rv.status == "404 NOT FOUND"
+    assert rv.headers["Content-Type"] == "text/html; charset=utf-8"
+    assert rv.text.startswith("<!doctype html")

--- a/src/moin/auth/_tests/test_auth.py
+++ b/src/moin/auth/_tests/test_auth.py
@@ -25,6 +25,7 @@ class TestConfiguredGivenAuth:
 
         return Config
 
+    @pytest.mark.usefixtures("_req_ctx")
     def test(self):
         assert flaskg.user.name == ["JoeDoe"]
 
@@ -48,6 +49,7 @@ class TestGivenAuth:
         result = givenauth_obj.transform_username("testDomain\\test name@moinmoin.org")
         assert result == "TestName"
 
+    @pytest.mark.usefixtures("_req_ctx")
     def test_request(self):
         givenauth_obj = GivenAuth()
         flaskg.user.auth_method = "given"
@@ -62,6 +64,7 @@ class TestGivenAuth:
         assert test_user.name == ["Test_User"]
 
 
+@pytest.mark.usefixtures("_req_ctx")
 def test_handle_login():
     # no messages in the beginning
     assert not flaskg._login_messages
@@ -84,6 +87,7 @@ def test_handle_login():
     assert test_user2.valid
 
 
+@pytest.mark.usefixtures("_req_ctx")
 def test_get_multistage_continuation_url():
     test_url = get_multistage_continuation_url(
         "test_auth_name", extra_fields={"password": "test_pass", "test_key": "test_value"}

--- a/src/moin/auth/_tests/test_http.py
+++ b/src/moin/auth/_tests/test_http.py
@@ -6,6 +6,8 @@
 Tests for auth.http.
 """
 
+import pytest
+
 from flask import g as flaskg
 from flask import request as flask_request
 
@@ -13,13 +15,12 @@ from moin.user import create_user
 from moin.auth.http import HTTPAuthMoin
 from moin.constants.misc import ANON
 
-import pytest
 
-
+@pytest.mark.usefixtures("_req_ctx", "custom_setup")
 class TestHTTPAuthMoin:
     """Tests for HTTPAuthMoin."""
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture
     def custom_setup(self):
         class Auth:
             def __init__(self):

--- a/src/moin/auth/_tests/test_log.py
+++ b/src/moin/auth/_tests/test_log.py
@@ -5,6 +5,7 @@
 Tests for auth.log.
 """
 
+import pytest
 
 from flask import g as flaskg
 
@@ -16,6 +17,7 @@ from moin import log
 logging = log.getLogger(__name__)
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestAuthLog:
     """Tests for AuthLog."""
 

--- a/src/moin/config/_tests/test_defaultconfig.py
+++ b/src/moin/config/_tests/test_defaultconfig.py
@@ -11,6 +11,7 @@ import pytest
 from flask import current_app as app
 
 
+@pytest.mark.usefixtures("_app_ctx")
 class TestPasswordChecker:
     username = "SomeUser"
     tests_builtin = [

--- a/src/moin/converters/_tests/test_creole_in.py
+++ b/src/moin/converters/_tests/test_creole_in.py
@@ -75,6 +75,7 @@ class TestConverter:
         ("----", '<page><body><separator class="moin-hr3" /></body></page>'),
     ]
 
+    @pytest.mark.usefixtures("_app_ctx")
     @pytest.mark.parametrize("input,output", data)
     def test_base(self, input, output):
         self.do(input, output)

--- a/src/moin/converters/_tests/test_everything.py
+++ b/src/moin/converters/_tests/test_everything.py
@@ -32,6 +32,7 @@ def serialize_strip(elem, **options):
     return output_re.sub("", result)
 
 
+@pytest.mark.usefixtures("_app_ctx")
 @pytest.mark.parametrize(
     "input,output",
     [

--- a/src/moin/converters/_tests/test_include.py
+++ b/src/moin/converters/_tests/test_include.py
@@ -5,6 +5,7 @@
 MoinMoin - moin.converters.include tests.
 """
 
+import pytest
 
 from moin.converters.include import XPointer
 from moin.items import Item
@@ -12,6 +13,7 @@ from moin.constants.keys import CONTENTTYPE, ACL
 from moin._tests import wikiconfig, update_item
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestInclude:
     class Config(wikiconfig.Config):
         """

--- a/src/moin/converters/_tests/test_link.py
+++ b/src/moin/converters/_tests/test_link.py
@@ -5,12 +5,14 @@
 MoinMoin - moin.converters.link tests.
 """
 
+import pytest
+
 from emeraldtree import ElementTree as ET
+
+from flask import current_app as app
 
 from moin.converters.link import ConverterExternOutput, xlink, ConverterItemRefs
 from moin.utils.iri import Iri
-
-import pytest
 
 
 @pytest.fixture
@@ -18,6 +20,7 @@ def conv():
     return ConverterExternOutput()
 
 
+@pytest.mark.usefixtures("_app_ctx")
 @pytest.mark.parametrize(
     "input_,output",
     (
@@ -29,7 +32,7 @@ def conv():
         ("wiki://MoinMoin/Test", "http://moinmo.in/Test"),
     ),
 )
-def test_wiki(app, conv, input_, output):
+def test_wiki(conv, input_, output):
     assert "MoinMoin" in app.cfg.interwiki_map
 
     elem = ET.Element(None)
@@ -37,6 +40,7 @@ def test_wiki(app, conv, input_, output):
     assert elem.get(xlink.href) == output
 
 
+@pytest.mark.usefixtures("_req_ctx")
 @pytest.mark.parametrize(
     "input_,page,output",
     (
@@ -72,6 +76,7 @@ def test_wikiexternal(conv, input_, output):
     assert str(href) == output
 
 
+@pytest.mark.usefixtures("_app_ctx")
 @pytest.mark.parametrize(
     "tree_xml,links_expected,transclusions_expected,external_expected",
     (

--- a/src/moin/converters/_tests/test_moinwiki19_in.py
+++ b/src/moin/converters/_tests/test_moinwiki19_in.py
@@ -39,6 +39,7 @@ class TestConverter:
         ("foo@bar", "<page><body><p>foo@bar</p></body></page>"),  # Moin 1.9 requires a domain
     ]
 
+    @pytest.mark.usefixtures("_app_ctx")
     @pytest.mark.parametrize("input,output", data)
     def test_freelink(self, input, output):
         self.do(input, output)

--- a/src/moin/converters/_tests/test_moinwiki19_in_20_out.py
+++ b/src/moin/converters/_tests/test_moinwiki19_in_20_out.py
@@ -53,6 +53,7 @@ class TestConverter:
         # ('../SisterPage', '[[../SisterPage]]\n'),
     ]
 
+    @pytest.mark.usefixtures("_app_ctx")
     @pytest.mark.parametrize("input,output", data)
     def test_link(self, input, output):
         self.do(input, output)

--- a/src/moin/converters/_tests/test_moinwiki_in.py
+++ b/src/moin/converters/_tests/test_moinwiki_in.py
@@ -5,15 +5,13 @@
 MoinMoin - moin.converters.moinwiki_in tests.
 """
 
-
 import pytest
 
 from . import serialize, XMLNS_RE
 
-from moin.utils.tree import moin_page, xlink, html, xinclude
-
-from moin.converters.moinwiki_in import Converter
 from moin.converters._args import Arguments
+from moin.converters.moinwiki_in import Converter
+from moin.utils.tree import moin_page, xlink, html, xinclude
 
 
 class TestConverter:
@@ -84,6 +82,7 @@ class TestConverter:
         ("----", '<page><body><separator class="moin-hr1" /></body></page>'),
     ]
 
+    @pytest.mark.usefixtures("_app_ctx")
     @pytest.mark.parametrize("args", data)
     def test_base(self, args):
         self.do(*args)
@@ -429,6 +428,7 @@ class TestConverter:
         ),
     ]
 
+    @pytest.mark.usefixtures("_app_ctx")
     @pytest.mark.parametrize("input,output", data)
     def test_table_attributes(self, input, output):
         self.do(input, output)
@@ -565,6 +565,7 @@ class TestConverter:
         ),
     ]
 
+    @pytest.mark.usefixtures("_app_ctx")
     @pytest.mark.parametrize("input,output", data)
     def test_interwiki(self, input, output):
         self.do(input, output)

--- a/src/moin/converters/_tests/test_moinwiki_in_out.py
+++ b/src/moin/converters/_tests/test_moinwiki_in_out.py
@@ -234,6 +234,7 @@ continuation of no bullet list""",
         ),
     ]
 
+    @pytest.mark.usefixtures("_app_ctx")
     @pytest.mark.parametrize("input,output", data)
     def test_link(self, input, output):
         self.do(input, output)

--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -284,6 +284,7 @@ text""",
         ),
     ]
 
+    @pytest.mark.usefixtures("_app_ctx")
     @pytest.mark.parametrize("input,output", data)
     def test_link(self, input, output):
         self.do(input, output)

--- a/src/moin/datastructures/backends/_tests/__init__.py
+++ b/src/moin/datastructures/backends/_tests/__init__.py
@@ -8,6 +8,7 @@
 MoinMoin - moin.datastructures.backends base test classes.
 """
 
+import pytest
 
 from pytest import raises
 
@@ -18,6 +19,7 @@ from moin.security import AccessControlList
 from moin.datastructures import GroupDoesNotExistError
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class GroupsBackendTest:
 
     test_groups = {
@@ -139,6 +141,7 @@ class GroupsBackendTest:
         assert not acl.may("Someone", "write")
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class DictsBackendTest:
 
     dicts = {

--- a/src/moin/datastructures/backends/_tests/test_composite_dicts.py
+++ b/src/moin/datastructures/backends/_tests/test_composite_dicts.py
@@ -6,12 +6,11 @@
 MoinMoin - moin.datastructures.backends.composite_dicts tests.
 """
 
+import pytest
 
 from moin.datastructures.backends._tests import DictsBackendTest
 from moin.datastructures import ConfigDicts, CompositeDicts
 from moin._tests import wikiconfig
-
-import pytest
 
 
 class TestCompositeDict(DictsBackendTest):

--- a/src/moin/datastructures/backends/_tests/test_composite_groups.py
+++ b/src/moin/datastructures/backends/_tests/test_composite_groups.py
@@ -5,16 +5,13 @@
 MoinMoin - moin.datastructures.backends.composite_groups tests.
 """
 
-
-from pytest import raises
+import pytest
 
 from flask import g as flaskg
 
 from moin.datastructures.backends._tests import GroupsBackendTest
 from moin.datastructures import ConfigGroups, CompositeGroups, GroupDoesNotExistError
 from moin._tests import wikiconfig
-
-import pytest
 
 
 class TestCompositeGroupsBackend(GroupsBackendTest):
@@ -31,6 +28,7 @@ class TestCompositeGroupsBackend(GroupsBackendTest):
         return Config
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestCompositeGroup:
 
     @pytest.fixture
@@ -67,7 +65,7 @@ class TestCompositeGroup:
         return Config
 
     def test_getitem(self):
-        raises(GroupDoesNotExistError, lambda: flaskg.groups["NotExistingGroup"])
+        pytest.raises(GroupDoesNotExistError, lambda: flaskg.groups["NotExistingGroup"])
 
     def test_clashed_getitem(self):
         """

--- a/src/moin/datastructures/backends/_tests/test_config_dicts.py
+++ b/src/moin/datastructures/backends/_tests/test_config_dicts.py
@@ -5,12 +5,11 @@
 MoinMoin - moin.datastructures.backends.config_dicts tests.
 """
 
+import pytest
 
 from moin.datastructures.backends._tests import DictsBackendTest
 from moin.datastructures import ConfigDicts
 from moin._tests import wikiconfig
-
-import pytest
 
 
 class TestConfigDictsBackend(DictsBackendTest):

--- a/src/moin/datastructures/backends/_tests/test_config_groups.py
+++ b/src/moin/datastructures/backends/_tests/test_config_groups.py
@@ -5,12 +5,11 @@
 MoinMoin - moin.datastructures.backends.config_groups tests.
 """
 
-
-from moin.datastructures.backends._tests import GroupsBackendTest
-from moin.datastructures import ConfigGroups
-from moin._tests import wikiconfig
-
 import pytest
+
+from moin._tests import wikiconfig
+from moin.datastructures import ConfigGroups
+from moin.datastructures.backends._tests import GroupsBackendTest
 
 
 class TestConfigGroupsBackend(GroupsBackendTest):

--- a/src/moin/datastructures/backends/_tests/test_lazy_config_groups.py
+++ b/src/moin/datastructures/backends/_tests/test_lazy_config_groups.py
@@ -5,13 +5,12 @@
 MoinMoin - moin.datastructures.backends.config_lazy_groups tests.
 """
 
+import pytest
 
+from moin._tests import wikiconfig
+from moin.datastructures import ConfigGroups, CompositeGroups
 from moin.datastructures.backends._tests import GroupsBackendTest
 from moin.datastructures.backends.config_lazy_groups import ConfigLazyGroups
-from moin.datastructures import ConfigGroups, CompositeGroups
-from moin._tests import wikiconfig
-
-import pytest
 
 
 class TestLazyConfigGroups(GroupsBackendTest):

--- a/src/moin/datastructures/backends/_tests/test_wiki_dicts.py
+++ b/src/moin/datastructures/backends/_tests/test_wiki_dicts.py
@@ -8,24 +8,24 @@
 MoinMoin - moin.datastructures.backends.wiki_dicts tests.
 """
 
-
-from moin.datastructures.backends._tests import DictsBackendTest
-from moin.datastructures.backends import wiki_dicts
-from moin.constants.keys import WIKIDICT
-from moin._tests import become_trusted, update_item
-
 import pytest
+
+from moin._tests import become_trusted, update_item
+from moin.constants.keys import WIKIDICT
+from moin.datastructures.backends import wiki_dicts
+from moin.datastructures.backends._tests import DictsBackendTest
 
 
 DATA = "This is a dict item."
 
 
+@pytest.mark.usefixtures("_req_ctx", "custom_setup")
 class TestWikiDictsBackend(DictsBackendTest):
 
     # Suppose that default configuration for the dicts is used which
     # is WikiDicts backend.
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture
     def custom_setup(self):
         become_trusted()
 

--- a/src/moin/datastructures/backends/_tests/test_wiki_groups.py
+++ b/src/moin/datastructures/backends/_tests/test_wiki_groups.py
@@ -9,28 +9,28 @@
 MoinMoin - moin.datastructures.backends.wiki_groups tests.
 """
 
-
 import pytest
 
 from flask import current_app as app
 from flask import g as flaskg
 
+from moin._tests import become_trusted, create_random_string_list, update_item
+from moin.constants.keys import NAME, USERGROUP
 from moin.datastructures.backends._tests import GroupsBackendTest
 from moin.datastructures import GroupDoesNotExistError
-from moin.constants.keys import NAME, USERGROUP
 from moin.security import AccessControlList
-from moin._tests import become_trusted, create_random_string_list, update_item
 
 
 DATA = "This is a group item"
 
 
+@pytest.mark.usefixtures("_req_ctx", "custom_setup")
 class TestWikiGroupBackend(GroupsBackendTest):
 
     # Suppose that default configuration for the groups is used which
     # is WikiGroups backend.
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture
     def custom_setup(self):
         become_trusted()
         for group, members in self.test_groups.items():

--- a/src/moin/items/_tests/test_Content.py
+++ b/src/moin/items/_tests/test_Content.py
@@ -37,6 +37,7 @@ class TestContent:
             content = Content.create(contenttype)
             assert isinstance(content, ExpectedClass)
 
+    @pytest.mark.usefixtures("_req_ctx")
     def test_get_templates(self):
         item_name1 = "Template_Item1"
         item1 = Item.create(item_name1)
@@ -66,6 +67,7 @@ class TestContent:
         assert result2 == [item_name3]
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestTarItems:
     """
     Tests for container items
@@ -106,6 +108,7 @@ class TestTarItems:
         assert item.content.get_member("example1.txt").read() == filecontent
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestZipMixin:
     """Tests for zip-like items"""
 
@@ -119,6 +122,7 @@ class TestZipMixin:
             item.content.put_member("example1.txt", filecontent, content_length, expected_members=members)
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestTransformableBitmapImage:
 
     def test__transform(self):
@@ -180,6 +184,7 @@ class TestTransformableBitmapImage:
             pass
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestText:
 
     def test_data_conversion(self):

--- a/src/moin/items/_tests/test_Item.py
+++ b/src/moin/items/_tests/test_Item.py
@@ -123,6 +123,7 @@ def fix_meta(files, builds):
     return fix_files, fix_builds
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestItem:
 
     def testNonExistent(self):

--- a/src/moin/macros/_tests/test_Date.py
+++ b/src/moin/macros/_tests/test_Date.py
@@ -6,9 +6,9 @@
 MoinMoin - tests for moin.macros.Date.
 """
 
+import pytest
 import time
 
-import pytest
 from flask import g as flaskg
 
 from moin.macros.Date import MacroDateTimeBase, Macro
@@ -16,6 +16,7 @@ from moin.utils import utcfromtimestamp
 from moin.utils.show_time import format_date_time, format_date
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestMacroDateTimeBase:
     def test_parse_time(self):
         MacroDateTimeBase_obj = MacroDateTimeBase()
@@ -41,6 +42,7 @@ class TestMacroDateTimeBase:
             MacroDateTimeBase_obj.parse_time("12011-08-07T11:11:11")
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestMacro:
     def test_macro(self):
         flaskg.user.valid = True  # show_time creates ISO 8601 dates if user is not logged in

--- a/src/moin/macros/_tests/test_DateTime.py
+++ b/src/moin/macros/_tests/test_DateTime.py
@@ -6,6 +6,7 @@
 MoinMoin - tests for moin.macros.DateTime.
 """
 
+import pytest
 import time
 
 from flask import g as flaskg
@@ -15,6 +16,7 @@ from moin.utils import utcfromtimestamp
 from moin.utils.show_time import format_date_time
 
 
+@pytest.mark.usefixtures("_req_ctx")
 def test_Macro():
     """Test Macro.macro."""
     flaskg.user.valid = True  # show_time creates ISO 8601 dates if user is not logged in

--- a/src/moin/macros/_tests/test_GetVal.py
+++ b/src/moin/macros/_tests/test_GetVal.py
@@ -6,6 +6,7 @@ MoinMoin - tests for moin.macros.GetVal.
 """
 
 import pytest
+
 from flask import g as flaskg
 
 from moin.macros.GetVal import Macro
@@ -13,6 +14,7 @@ from moin.constants.keys import WIKIDICT
 from moin._tests import become_trusted, update_item
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestMacro:
     @pytest.fixture
     def test_dict(self):

--- a/src/moin/macros/_tests/test_ItemList.py
+++ b/src/moin/macros/_tests/test_ItemList.py
@@ -5,6 +5,8 @@
 MoinMoin - tests for moin.macros.ItemList.
 """
 
+import pytest
+
 from moin.items import Item
 from moin.constants.keys import CONTENTTYPE, ITEMTYPE, REV_NUMBER
 from moin._tests import wikiconfig, update_item
@@ -12,6 +14,7 @@ from moin._tests import wikiconfig, update_item
 meta = {CONTENTTYPE: "text/x.moin.wiki;charset=utf-8", ITEMTYPE: "default", REV_NUMBER: 1}
 
 
+@pytest.mark.usefixtures("_req_ctx")
 class TestItemListMacro:
     """
     Call the ItemList macro and test the output.

--- a/src/moin/macros/_tests/test_MonthCalendar.py
+++ b/src/moin/macros/_tests/test_MonthCalendar.py
@@ -41,6 +41,7 @@ def test_parseargs_two():
     assert args == (["WikiWorkingGroup", "WikiMacrosSpecialInterestGroup"], 2020, 3, -4, True, False)
 
 
+@pytest.mark.usefixtures("_req_ctx")
 def test_Macro():
     """
     Call the MonthCalendar macro and test some attributes of the resulting table.

--- a/src/moin/macros/_tests/test_ShowIcons.py
+++ b/src/moin/macros/_tests/test_ShowIcons.py
@@ -5,6 +5,7 @@
 MoinMoin - tests for moin.macros.ShowIcons.
 """
 
+import pytest
 import re
 import os
 from moin.macros.ShowIcons import Macro
@@ -12,15 +13,20 @@ from moin.macros.ShowIcons import Macro
 my_dir = os.path.abspath(os.path.dirname(__file__))
 
 
+@pytest.mark.usefixtures("_app_ctx")
 def test_ShowIconsMacro():
-    """Call the ShowIcons macro and test the output."""
+    """
+    Call the ShowIcons macro and test the output.
+    """
     test_icons = ["admon-note", "angry", "biggrin", "frown", "moin-rss", "smile3", "star_off"]
     expected_namespace = "{http://moinmo.in/namespaces/page}"
     expected_tags = set(f"{expected_namespace}{el_name}" for el_name in ["table", "table-header", "table-row"])
     expected_texts = set(f"<<Icon({icon_name}.png)>>" for icon_name in test_icons)
-    expected_paths = set(f"/static/img/icons/{icon_name}.png" for icon_name in test_icons)
+    expected_paths = set(f"http://localhost:8080/static/img/icons/{icon_name}.png" for icon_name in test_icons)
+
     macro_obj = Macro()
     macro_out = macro_obj.macro("content", None, "page_url", "alternative")
+
     result_tags = set()
     result_texts = set()
     result_paths = set()

--- a/src/moin/macros/_tests/test_ShowSmileys.py
+++ b/src/moin/macros/_tests/test_ShowSmileys.py
@@ -5,9 +5,12 @@
 MoinMoin - tests for moin.macros.ShowSmileys.
 """
 
+import pytest
+
 from moin.macros.ShowSmileys import Macro
 
 
+@pytest.mark.usefixtures("_app_ctx")
 def test_Macro():
     """Test Macro.macro."""
     expected_text = ["X-(", "angry", ":D", "biggrin", "<:(", "frown", "{o}", "star_off"]

--- a/src/moin/search/_tests/test_analyzers.py
+++ b/src/moin/search/_tests/test_analyzers.py
@@ -5,15 +5,17 @@
 MoinMoin - tests for moin.search.analyzers.
 """
 
+import pytest
 
 from flask import current_app as app
 
 from moin.search.analyzers import MimeTokenizer, AclTokenizer, item_name_analyzer
 
 
+@pytest.mark.usefixtures("_app_ctx")
 class TokenizerTestBase:
 
-    def testTokenizer(self):
+    def test_tokenizer(self):
         """Analyzers: verify that obtained tokens match expected values."""
         tokenizer = self.make_tokenizer()
         for value, expected_tokens in self.test_cases_query:
@@ -158,7 +160,8 @@ class TestMimeTokenizer(TokenizerTestBase):
         return MimeTokenizer()
 
 
-class TestItemNameAnalyzer(TokenizerTestBase):
+@pytest.mark.usefixtures("_app_ctx")
+class TestItemNameAnalyzer:
     """Analyzers: test item_name analyzer."""
 
     test_cases_query = [
@@ -180,7 +183,7 @@ class TestItemNameAnalyzer(TokenizerTestBase):
     def make_tokenizer(self):
         return item_name_analyzer()
 
-    def testTokenizer(self):
+    def test_tokenizer(self):
         """Analyzers: test item name analyzer with 'query' and 'index' modes."""
         tokenizer = self.make_tokenizer()
         for value, expected_tokens in self.test_cases_query:

--- a/src/moin/storage/backends/_tests/__init__.py
+++ b/src/moin/storage/backends/_tests/__init__.py
@@ -25,6 +25,7 @@ class BackendTestBase:
         """
         self.be.close()
 
+    @pytest.mark.usefixtures("_app_ctx")
     def test_getrevision_raises(self):
         with pytest.raises(KeyError):
             self.be.retrieve("doesnotexist")
@@ -46,10 +47,6 @@ class MutableBackendTestBase(BackendTestBase):
         """
         self.be.close()
         self.be.destroy()
-
-    def test_getrevision_raises(self):
-        with pytest.raises(KeyError):
-            self.be.retrieve("doesnotexist")
 
     def test_store_get_del(self):
         meta = dict(foo="bar")

--- a/src/moin/storage/middleware/_tests/test_serialization.py
+++ b/src/moin/storage/middleware/_tests/test_serialization.py
@@ -43,12 +43,12 @@ def source(request, tmpdir):
 
 
 @pytest.fixture
-def target(request, tmpdir):
+def target(request: pytest.FixtureRequest, tmpdir):
     # Scenario
     return make_middleware(request, tmpdir)
 
 
-def make_middleware(request, tmpdir):
+def make_middleware(request: pytest.FixtureRequest, tmpdir):
     # Scenario
     meta_store = BytesStore()
     data_store = FileStore()
@@ -69,6 +69,7 @@ def make_middleware(request, tmpdir):
     return mw
 
 
+@pytest.mark.usefixtures("_app_ctx")
 def test_serialize_deserialize(source, target):
     i = 0
     for name, meta, data in contents:

--- a/src/moin/themes/_tests/test_navi_bar.py
+++ b/src/moin/themes/_tests/test_navi_bar.py
@@ -6,6 +6,7 @@
 MoinMoin - Tests for the navigation bar
 """
 
+import pytest
 
 from flask import current_app as app
 
@@ -13,9 +14,8 @@ from moin._tests import wikiconfig
 from moin.themes import ThemeSupport
 from moin import themes
 
-import pytest
 
-
+@pytest.mark.usefixtures("_req_ctx")
 class TestNaviBar:
     @pytest.fixture
     def cfg(self):

--- a/src/moin/themes/_tests/test_theme_support.py
+++ b/src/moin/themes/_tests/test_theme_support.py
@@ -32,6 +32,7 @@ def theme_supp():
     return ThemeSupport(app.cfg)
 
 
+@pytest.mark.usefixtures("_req_ctx", "_test_user")
 def test_get_user_home(_test_user, theme_supp):
     wiki_href, display_name, title, exists = theme_supp.userhome()
     assert wiki_href == "/users/lemmy"

--- a/src/moin/user.py
+++ b/src/moin/user.py
@@ -135,7 +135,7 @@ space between words. Group page name is not allowed."""
 
 
 def get_user_backend():
-    return flaskg.unprotected_storage
+    return app.storage
 
 
 def update_user_query(**q):

--- a/src/moin/utils/_tests/test_interwiki.py
+++ b/src/moin/utils/_tests/test_interwiki.py
@@ -29,6 +29,7 @@ from moin.app import before_wiki
 
 
 class TestInterWiki:
+
     @pytest.fixture
     def cfg(self):
         class Config(wikiconfig.Config):
@@ -42,6 +43,7 @@ class TestInterWiki:
 
         return Config
 
+    @pytest.mark.usefixtures("_req_ctx")
     def test_url_for_item(self):
         before_wiki()
         revid = "cdc431e0fc624d6fb8372152dcb66457"
@@ -121,6 +123,7 @@ class TestInterWiki:
             assert _split_namespace(map, markup) == (namespace, pagename)
             namespace, pagename = _split_namespace(map, markup)
 
+    @pytest.mark.usefixtures("_req_ctx")
     def test_split_interwiki(self):
         app.cfg.namespace_mapping = [
             ("", "default_backend"),
@@ -157,7 +160,7 @@ class TestInterWiki:
             assert isinstance(field, str)
             assert isinstance(wikiname, str)
 
-    def testJoinWiki(self):
+    def test_join_wiki(self):
         tests = [
             (("http://example.org/", "SomePage", "", ""), "http://example.org/SomePage"),
             (("", "SomePage", "", ""), "SomePage"),
@@ -191,6 +194,7 @@ class TestInterWiki:
         for (baseurl, pagename, field, namespace), url in tests:
             assert join_wiki(baseurl, pagename, field, namespace) == url
 
+    @pytest.mark.usefixtures("_app_ctx")
     def test_split_fqname(self):
         app.cfg.namespace_mapping = [
             ("", "default_backend"),
@@ -209,6 +213,7 @@ class TestInterWiki:
         for url, (namespace, field, pagename) in tests:
             assert split_fqname(url) == (namespace, field, pagename)
 
+    @pytest.mark.usefixtures("_app_ctx")
     def test_get_interwiki_home(self):
         assert getInterwikiHome("frodo") == ("Self", "users/frodo")
 

--- a/src/moin/utils/_tests/test_notifications.py
+++ b/src/moin/utils/_tests/test_notifications.py
@@ -20,10 +20,12 @@ from moin.utils.interwiki import split_fqname
 import pytest
 
 
+@pytest.mark.usefixtures("_req_ctx", "custom_setup")
 class TestNotifications:
+
     reinit_storage = True
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture
     def custom_setup(self):
         self.imw = flaskg.unprotected_storage
         self.item_name = "foo"

--- a/src/moin/utils/_tests/test_pysupport.py
+++ b/src/moin/utils/_tests/test_pysupport.py
@@ -24,15 +24,15 @@ class TestImportNameFromMoin:
     We do not test files here, assuming that the moin package is not broken.
     """
 
-    def testNonExistingModule(self):
+    def test_non_existing_module(self):
         """pysupport: import nonexistent module raises ImportError"""
         pytest.raises(ImportError, pysupport.importName, "moin.utils.nonexistent", "importName")
 
-    def testNonExistingAttribute(self):
+    def test_non_existing_attribute(self):
         """pysupport: import nonexistent attribute raises AttributeError"""
         pytest.raises(AttributeError, pysupport.importName, "moin.utils.pysupport", "nonexistent")
 
-    def testExisting(self):
+    def test_existing(self):
         """pysupport: import name from existing module"""
         from moin.utils.pysupport import importName
 
@@ -40,12 +40,13 @@ class TestImportNameFromMoin:
         assert importName is t
 
 
+@pytest.mark.usefixtures("_app_ctx", "custom_setup")
 class TestImportNameFromPlugin:
     """Base class for import plugin tests"""
 
     name = "Parser"
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture
     def custom_setup(self):
         """Check for valid plugin package"""
         self.pluginDirectory = os.path.join(app.cfg.data_dir, "plugin", "parser")
@@ -67,7 +68,7 @@ class TestImportNonExisting(TestImportNameFromPlugin):
 
     plugin = "NonExistingWikiPlugin"
 
-    def testNonExisting(self):
+    def test_non_existing(self):
         """pysupport: import nonexistent wiki plugin fails"""
         if self.pluginExists():
             pytest.skip(f"plugin exists: {self.plugin}")
@@ -79,7 +80,8 @@ class TestImportExisting(TestImportNameFromPlugin):
     plugin = "AutoCreatedMoinMoinTestPlugin"
     shouldDeleteTestPlugin = True
 
-    def testExisting(self):
+    @pytest.mark.usefixtures("_app_ctx")
+    def test_existing(self):
         """pysupport: import existing wiki plugin
 
         Tests whether a module can be imported from an arbitrary path,

--- a/src/moin/utils/_tests/test_send_file.py
+++ b/src/moin/utils/_tests/test_send_file.py
@@ -29,6 +29,7 @@ class TestFuid:
         f.write(content)
         f.close()
 
+    @pytest.mark.usefixtures("_req_ctx")
     def test_temptest(self):
         self.makefile(self.fname, "test_content")
         result = send_file.send_file(self.fname, as_attachment=True, conditional=True)

--- a/src/moin/utils/_tests/test_show_time.py
+++ b/src/moin/utils/_tests/test_show_time.py
@@ -4,6 +4,9 @@
 """
 MoinMoin - tests for moin.utils.show_time.
 """
+
+import pytest
+
 from flask import g as flaskg
 
 from moin.utils import show_time
@@ -31,6 +34,7 @@ class TestShowTime:
             result = show_time.duration(seconds)
             assert result == expected
 
+    @pytest.mark.usefixtures("_req_ctx")
     def test_show_time_datetime(self):
         """Users who are not logged in get ISO 8601 Zulu dates."""
         formatted_date = show_time.format_date(utc_dt=0)
@@ -40,6 +44,7 @@ class TestShowTime:
         formatted_date_time = show_time.format_date_time(utc_dt=0)
         assert formatted_date_time == "1970-01-01 00:00:00z"
 
+    @pytest.mark.usefixtures("_req_ctx")
     def test_show_time_datetime_logged_in_utc(self):
         """Users who are logged in, selected the UTC time zone, and enabled ISO 8601 get ISO 8601 Zulu dates."""
         flaskg.user.valid = True
@@ -53,6 +58,7 @@ class TestShowTime:
         formatted_date_time = show_time.format_date_time(utc_dt=0)
         assert formatted_date_time == "1970-01-01 00:00:00z"
 
+    @pytest.mark.usefixtures("_req_ctx")
     def test_show_time_datetime_logged_in_local(self):
         """Users who are logged in with ISO 8601 disabled get dates based on locale and time zone."""
         flaskg.user.valid = True

--- a/src/moin/utils/_tests/test_subscriptions.py
+++ b/src/moin/utils/_tests/test_subscriptions.py
@@ -39,6 +39,7 @@ class TestSubscriptions:
         item._save(meta)
         return Item.create(item_name)
 
+    @pytest.mark.usefixtures("_req_ctx")
     def test_get_subscribers(self, item, item_name, namespace, tag_name):
         users = get_subscribers(**item.meta)
         assert users == set()
@@ -84,6 +85,7 @@ class TestSubscriptions:
         subscribers = get_subscribers(**item.meta)
         assert {subscriber.name for subscriber in subscribers} == {user2.name0}
 
+    @pytest.mark.usefixtures("_req_ctx")
     def test_get_matched_subscription_patterns(self, item, namespace):
         meta = item.meta
         patterns = get_matched_subscription_patterns([], **meta)
@@ -103,6 +105,7 @@ class TestSubscriptions:
         patterns = get_matched_subscription_patterns(non_matching_patterns + matching_patterns, **meta)
         assert patterns == matching_patterns
 
+    @pytest.mark.usefixtures("_req_ctx")
     def test_perf_get_subscribers(self):
         pytest.skip("Usually we do not run performance tests.")
         password = "password"

--- a/src/moin/utils/_tests/test_tree.py
+++ b/src/moin/utils/_tests/test_tree.py
@@ -10,7 +10,7 @@ from emeraldtree import ElementTree as ET
 from moin.utils.tree import Name, Namespace, html, moin_page
 
 
-def test_Name():
+def test_name():
     uri = "uri:a"
 
     name = Name("a", uri)
@@ -24,7 +24,7 @@ def test_Name():
     assert element.tag == name
 
 
-def test_Namespace():
+def test_namespace():
     uri = "uri:a"
 
     namespace = Namespace(uri)

--- a/src/moin/utils/_tests/test_util.py
+++ b/src/moin/utils/_tests/test_util.py
@@ -11,7 +11,7 @@ from moin import utils
 
 class TestUtil:
 
-    def testRangeList(self):
+    def test_rangelist(self):
         """utils.rangelist: test correct behavior for various input values"""
         result = utils.rangelist([])
         expected = ""

--- a/src/moin/utils/notifications.py
+++ b/src/moin/utils/notifications.py
@@ -11,9 +11,10 @@ from io import BytesIO
 from blinker import ANY
 from urllib.parse import urljoin
 
-from flask import url_for, g as flaskg
-from flask import abort
+from flask import abort, g as flaskg, url_for
+from flask_babel import force_locale
 
+from moin import log
 from moin.constants.keys import (
     ACTION_COPY,
     ACTION_RENAME,
@@ -25,7 +26,6 @@ from moin.constants.keys import (
     REVID,
 )
 from moin.i18n import _, L_
-from moin.i18n import force_locale
 from moin.items.content import Content
 from moin.mail.sendmail import sendmail
 from moin.themes import render_template
@@ -33,8 +33,6 @@ from moin.signalling.signals import item_modified
 from moin.utils.subscriptions import get_subscribers
 from moin.utils.diff_datastruct import make_text_diff, diff as dict_diff
 from moin.utils.interwiki import url_for_item
-
-from moin import log
 
 logging = log.getLogger(__name__)
 


### PR DESCRIPTION
* remove moin.i18n.force_locale; use force_locale provided by flask_babel; make existing test case run by default
* replace setup_class methods used in test_markdown_in(_out) with pytest fixtures performing orderly cleanup
* correct tests in TestProtectedIndexingMiddleware (unprotected middleware was used instead of the protected one)
* get rid off autouse fixture app; use @pytest.mark.usefixtures annotation in test cases to make the required context explicit; this change also avoids having to instantiate an application context for every unit test execution
* avoid autouse class method fixtures; use mark.usefixtures (possibly with more than one argument)
* change names of test methods along the way to be conformant to the usual naming conventions
* provide utils in moin.apps._tests.utils to be used with new pytest fixture client for writing tests using the Flask test client
* fixtures returning None are prefixed with an underscore
* get rid of "_dummy" test methods in TestProtectingMiddleware by introducing base class TestIndexingMiddlewareBase