### PR TITLE
Workaround for bug in Sphinx LaTeX writer

### DIFF
--- a/docs/user/rest.rst
+++ b/docs/user/rest.rst
@@ -123,9 +123,10 @@ Markup                                    Result
 * The :raw: role is disabled in Moin.
 
 * TODO:
-  Some standard roles and all `custom interpreted text roles`_
-  are currently ignored by Moin. Content is shown without processing:
+  Some standard roles are currently ignored by Moin.
+  Content is shown without processing.
 
+..
   =====================  =================
   ``:ab:`abbr.```        :ab:`abbr.`
   ``:ac:`AC`/:ac:`DC```  :ac:`AC`/:ac:`DC`


### PR DESCRIPTION
Building the LaTeX docs at "readthedocs" fails with
  NotImplementedError: <class 'sphinx.writers.latex.LaTeXTranslator'>
  departing unknown node type: acronym

cf. Sphinx issue https://github.com/sphinx-doc/sphinx/issues/14050

Comment out the sample showing how Moin renders the `:acronym:` (or `:ac:`) role in the documentation.
(It does not add much help for users, anyway.)

Fixes issue #2035 "readthedocs build fails".