### PR TITLE
Fix crash caused by use of unbound local variables

### DIFF
--- a/src/moin/items/__init__.py
+++ b/src/moin/items/__init__.py
@@ -1304,19 +1304,20 @@ class Item:
             fullnames = rev[NAME]
             for fullname in fullnames:
                 prefix = self.get_prefix_match(fullname, prefixes)
-                if prefix is not None:
-                    fullname_fqname = CompositeName(rev[NAMESPACE], NAME_EXACT, fullname)
-                    relname = fullname[len(prefix) :]
-                    if "/" in relname:
-                        # Search for the ancestor of current item. E.g. assuming the index root is 'foo' and
-                        # the current item (`rev`) is 'foo/bar/lorem/ipsum', 'foo/bar/lorem' will be found.
-                        direct_relname = relname.rpartition("/")[0]
-                        direct_relname_fqname = CompositeName(rev[NAMESPACE], NAME_EXACT, direct_relname)
-                        if direct_relname_fqname not in added_dir_relnames:
-                            added_dir_relnames.add(direct_relname_fqname)
-                            direct_fullname = prefix + direct_relname
-                            direct_fullname_fqname = CompositeName(rev[NAMESPACE], NAME_EXACT, direct_fullname)
-                            dirs.append(IndexEntry(direct_relname, direct_fullname_fqname, {}))
+                if prefix is None:
+                    continue
+                fullname_fqname = CompositeName(rev[NAMESPACE], NAME_EXACT, fullname)
+                relname = fullname[len(prefix) :]
+                if "/" in relname:
+                    # Search for the ancestor of current item. E.g. assuming the index root is 'foo' and
+                    # the current item (`rev`) is 'foo/bar/lorem/ipsum', 'foo/bar/lorem' will be found.
+                    direct_relname = relname.rpartition("/")[0]
+                    direct_relname_fqname = CompositeName(rev[NAMESPACE], NAME_EXACT, direct_relname)
+                    if direct_relname_fqname not in added_dir_relnames:
+                        added_dir_relnames.add(direct_relname_fqname)
+                        direct_fullname = prefix + direct_relname
+                        direct_fullname_fqname = CompositeName(rev[NAMESPACE], NAME_EXACT, direct_fullname)
+                        dirs.append(IndexEntry(direct_relname, direct_fullname_fqname, {}))
                 mini_meta = {key: rev[key] for key in (CONTENTTYPE, ITEMTYPE, SIZE, MTIME, REV_NUMBER, NAMESPACE)}
                 if TAGS in rev and rev[TAGS]:
                     mini_meta[TAGS] = rev[TAGS]


### PR DESCRIPTION
Happened when viewing subitems of a wiki page with alias names. Variables 'relname' and 'fullname_fqname' were undefined.

```
Nov 18 17:31:56 reckoner moin2[92705]: 2025-11-18 16:31:56,811 ERROR moin.signalling.log:31 cannot access local variable 'relname' where it is not associated with a value
Nov 18 17:31:56 reckoner moin2[92705]: Traceback (most recent call last):
Nov 18 17:31:56 reckoner moin2[92705]:   File "/usr/local/lib/python3.13/site-packages/flask/app.py", line 1511, in wsgi_app
Nov 18 17:31:56 reckoner moin2[92705]:     response = self.full_dispatch_request()
Nov 18 17:31:56 reckoner moin2[92705]:   File "/usr/local/lib/python3.13/site-packages/flask/app.py", line 919, in full_dispatch_request
Nov 18 17:31:56 reckoner moin2[92705]:     rv = self.handle_user_exception(e)
Nov 18 17:31:56 reckoner moin2[92705]:   File "/usr/local/lib/python3.13/site-packages/flask/app.py", line 917, in full_dispatch_request
Nov 18 17:31:56 reckoner moin2[92705]:     rv = self.dispatch_request()
Nov 18 17:31:56 reckoner moin2[92705]:   File "/usr/local/lib/python3.13/site-packages/flask/app.py", line 902, in dispatch_request
Nov 18 17:31:56 reckoner moin2[92705]:     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
Nov 18 17:31:56 reckoner moin2[92705]:            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
Nov 18 17:31:56 reckoner moin2[92705]:   File "/usr/local/lib/python3.13/site-packages/moin/apps/frontend/views.py", line 1524, in index
Nov 18 17:31:56 reckoner moin2[92705]:     dirs, files = item.get_index(startswith, selected_groups, short=True)
Nov 18 17:31:56 reckoner moin2[92705]:                   ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Nov 18 17:31:56 reckoner moin2[92705]:   File "/usr/local/lib/python3.13/site-packages/moin/items/__init__.py", line 1381, in get_index
Nov 18 17:31:56 reckoner moin2[92705]:     return self.make_flat_index(revs, isglobalindex)
Nov 18 17:31:56 reckoner moin2[92705]:            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
Nov 18 17:31:56 reckoner moin2[92705]:   File "/usr/local/lib/python3.13/site-packages/moin/items/__init__.py", line 1325, in make_flat_index
Nov 18 17:31:56 reckoner moin2[92705]:     files.append(IndexEntry(relname, fullname_fqname, mini_meta))
Nov 18 17:31:56 reckoner moin2[92705]:                             ^^^^^^^
Nov 18 17:31:56 reckoner moin2[92705]: UnboundLocalError: cannot access local variable 'relname' where it is not associated with a value
```

To reproduce the issue:

* create a page "Home/Subitem" and enter the three names "Home/Subitem, Yello, Home/Subitem/Me" in the metadata field Names
* open the Index page
* visit "Home/Subitem"
* click on "Subitems" in the navigation area
