### PR TITLE
Bandit check in CI workflow: raise codeql-action to v4

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -40,6 +40,6 @@ jobs:
         run: bandit -c pyproject.toml -r src/moin -f sarif -o results.sarif || true
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Fixes #2049.