### PR TITLE
add timezone_default to config/wikiconfig.py; fixes #1887

### DIFF
--- a/src/moin/config/wikiconfig.py
+++ b/src/moin/config/wikiconfig.py
@@ -86,9 +86,11 @@ class Config(DefaultConfig):
     # Sitename is displayed in the heading of all wiki pages
     sitename = "My MoinMoin"
 
+    # search "pytz timezones" for values; logged-in users can choose a timezone by updating Settings > Personal
+    timezone_default = "UTC"
+
     # See https://www.moinmo.in/ThemeMarket for contributed Moin 2 themes
-    # default theme is topside
-    # theme_default = "modernized"  # or basic or topside_cms
+    theme_default = "topside"  # suported themes include modernized, focus, basic, topside_cms
 
     # Prevent multiple users from editing an item at the same time
     edit_locking_policy = "lock"


### PR DESCRIPTION
wiki admins must merge config/wikiconfig.py into wikiconfig.py