### PR TITLE
Rst fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ wiki_local/
 *.pyo
 *.orig
 *.rej
+*~
 # files created by quickinstall.py
 activate.bat
 deactivate.bat

--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -242,11 +242,57 @@ class TestConverter:
     def test_footnote(self, input, output):
         self.do(input, output)
 
+    # Field Lists, Option Lists:
+    # TODO: currently rendered as table (like Docutils html4css1 writer),
+    #       use a description-list instead (like Docutils html5 writer)?
     data = [
         (
-            ":Date: 2001-08-16\n:Version: 1\n:Authors: Joe Doe",
-            "<page><body><table><table-body>2001-08-16<table-row><table-cell><strong>Version:</strong></table-cell><table-cell>1</table-cell></table-row><table-row><table-cell><strong>Author:</strong></table-cell><table-cell>Joe Doe</table-cell></table-row></table-body></table></body></page>",
-        )
+            "Leading text\n\n:Last Changed: 2001-08-16\n:*Version*: 1\n:Name: Joe Doe",
+            "<page><body><p>Leading text</p>"
+            '<table xhtml:class="moin-rst-fieldlist"><table-body>'
+            "<table-row><table-cell><strong>Last Changed:</strong></table-cell>"
+            "<table-cell><p>2001-08-16</p></table-cell></table-row>"
+            "<table-row><table-cell><strong><emphasis>Version</emphasis>:</strong></table-cell>"
+            "<table-cell><p>1</p></table-cell></table-row>"
+            "<table-row><table-cell><strong>Name:</strong></table-cell>"
+            "<table-cell><p>Joe Doe</p></table-cell></table-row>"
+            "</table-body></table></body></page>",
+        ),
+        # A field list at the start of a page is transformed into a "docinfo"
+        # bibliographic data (visible meta-data)
+        (
+            ":Date: 2001-08-16\n:Author: Joe Doe\n:Version:  $Revision: 1.17 $\n",
+            '<page><body><table xhtml:class="moin-rst-fieldlist"><table-body>'
+            "<table-row><table-cell><strong>Date:</strong></table-cell><table-cell>2001-08-16</table-cell></table-row>"
+            "<table-row><table-cell><strong>Author:</strong></table-cell><table-cell>Joe Doe</table-cell></table-row>"
+            "<table-row><table-cell><strong>Version:</strong></table-cell><table-cell>1.17</table-cell></table-row>"
+            "</table-body></table></body></page>",
+        ),
+        (
+            ":Authors: Pat, Patagon\n:Copyright: ©\n:Test: t",
+            '<page><body><table xhtml:class="moin-rst-fieldlist"><table-body>'
+            "<table-row><table-cell><strong>Authors:</strong></table-cell>"
+            "<table-cell><p>Pat</p><p>Patagon</p></table-cell></table-row>"
+            "<table-row><table-cell><strong>Copyright:</strong></table-cell><table-cell>©</table-cell></table-row>"
+            '<table-row xhtml:class="test"><table-cell><strong>Test:</strong></table-cell>'
+            "<table-cell><p>t</p></table-cell></table-row>"
+            "</table-body></table></body></page>",
+        ),
+        # option list
+        (
+            "-a           Output all.\n"
+            "--print arg  Output just arg.\n"
+            "-f FILE, --file=FILE  These two options are synonyms;\n"
+            "                      both have arguments.\n",
+            '<page><body><table xhtml:class="moin-rst-optionlist"><table-body>'
+            '<table-row><table-cell><span xhtml:class="kbd option">-a</span></table-cell>'
+            "<table-cell><p>Output all.</p></table-cell></table-row>"
+            '<table-row><table-cell><span xhtml:class="kbd option">--print arg</span></table-cell>'
+            "<table-cell><p>Output just arg.</p></table-cell></table-row>"
+            '<table-row><table-cell><span xhtml:class="kbd option">-f FILE</span>, <span xhtml:class="kbd option">--file=FILE</span></table-cell>'
+            "<table-cell><p>These two options are synonyms;\nboth have arguments.</p></table-cell></table-row>"
+            "</table-body></table></body></page>",
+        ),
     ]
 
     @pytest.mark.parametrize("input,output", data)
@@ -407,11 +453,6 @@ text""",
         self.do(input, output)
 
     data = [
-        # bibliographic data (visible meta-data)
-        (
-            ":Author: Test\n:Version:  $Revision: 1.17 $\n:Copyright: c\n:Test: t",
-            '<page><body><table><table-body><table-row><table-cell><strong>Author:</strong></table-cell><table-cell>Test</table-cell></table-row><table-row><table-cell><strong>Version:</strong></table-cell><table-cell>1.17</table-cell></table-row><table-row><table-cell><strong>Copyright:</strong></table-cell><table-cell>c</table-cell></table-row><table-row xhtml:class="test"><table-cell><strong>Test:</strong></table-cell><table-cell><p>t</p></table-cell></table-row></table-body></table></body></page>',
-        ),
         # admonitions (hint, info, warning, error, ...)
         (
             '.. note::\n   :name: note-id\n\n   An admonition of type "note"',

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -95,7 +95,6 @@ class NodeVisitor:
         pass
 
     def open_moin_page_node(self, mointree_element, node=None):
-        # `mointree_element` can also be a `str` (text)
         if flaskg and getattr(flaskg, "add_lineno_attr", False):
             # add data-lineno attribute for auto-scrolling edit textarea
             if self.last_lineno < self.current_lineno:
@@ -184,6 +183,12 @@ class NodeVisitor:
 
     depart_warning = depart_admonition
 
+    def visit_address(self, node):
+        self.visit_docinfo_item(node, "address")
+
+    def depart_address(self, node):
+        self.depart_docinfo_item(node)
+
     def visit_block_quote(self, node):
         self.open_moin_page_node(moin_page.blockquote())
 
@@ -222,7 +227,7 @@ class NodeVisitor:
         self.close_moin_page_node()
 
     def visit_docinfo(self, node):
-        self.open_moin_page_node(moin_page.table())
+        self.open_moin_page_node(moin_page.table(attrib={html.class_: "moin-rst-fieldlist"}))
         self.open_moin_page_node(moin_page.table_body())
 
     def depart_docinfo(self, node):
@@ -230,34 +235,22 @@ class NodeVisitor:
         self.close_moin_page_node()
 
     def visit_author(self, node):
-        self.open_moin_page_node(moin_page.table_row())
-        self.open_moin_page_node(moin_page.table_cell())
-        self.open_moin_page_node(moin_page.strong())
-        # TODO: i18n for docutils:
-        self.open_moin_page_node("Author:")
-        self.close_moin_page_node()
-        self.close_moin_page_node()
-        self.close_moin_page_node()
-        self.open_moin_page_node(moin_page.table_cell())
+        if isinstance(node.parent, nodes.authors):
+            self.open_moin_page_node(moin_page.p(), node)
+        else:
+            self.visit_docinfo_item(node, "author")
 
     def depart_author(self, node):
-        self.close_moin_page_node()
-        self.close_moin_page_node()
+        if isinstance(node.parent, nodes.authors):
+            self.close_moin_page_node()
+        else:
+            self.depart_docinfo_item(node)
 
-    def visit_version(self, node):
-        self.open_moin_page_node(moin_page.table_row())
-        self.open_moin_page_node(moin_page.table_cell())
-        self.open_moin_page_node(moin_page.strong())
-        # TODO: i18n for docutils:
-        self.open_moin_page_node("Version:")
-        self.close_moin_page_node()
-        self.close_moin_page_node()
-        self.close_moin_page_node()
-        self.open_moin_page_node(moin_page.table_cell())
+    def visit_authors(self, node):
+        self.visit_docinfo_item(node, "authors")
 
-    def depart_version(self, node):
-        self.close_moin_page_node()
-        self.close_moin_page_node()
+    def depart_authors(self, node):
+        self.depart_docinfo_item(node)
 
     def visit_caption(self, node):
         self.open_moin_page_node(moin_page.figcaption())
@@ -266,19 +259,10 @@ class NodeVisitor:
         self.close_moin_page_node()
 
     def visit_copyright(self, node):
-        self.open_moin_page_node(moin_page.table_row())
-        self.open_moin_page_node(moin_page.table_cell())
-        self.open_moin_page_node(moin_page.strong())
-        # TODO: i18n for docutils:
-        self.open_moin_page_node("Copyright:")
-        self.close_moin_page_node()
-        self.close_moin_page_node()
-        self.close_moin_page_node()
-        self.open_moin_page_node(moin_page.table_cell())
+        self.visit_docinfo_item(node, "copyright")
 
     def depart_copyright(self, node):
-        self.close_moin_page_node()
-        self.close_moin_page_node()
+        self.depart_docinfo_item(node)
 
     def visit_comment(self, node):
         """
@@ -289,6 +273,41 @@ class NodeVisitor:
 
     def depart_comment(self, node):
         self.close_moin_page_node()
+
+    def visit_contact(self, node):
+        self.visit_docinfo_item(node, "contact")
+
+    def depart_contact(self, node):
+        self.depart_docinfo_item(node)
+
+    def visit_date(self, node):
+        self.visit_docinfo_item(node, "date")
+
+    def depart_date(self, node):
+        self.depart_docinfo_item(node)
+
+    def visit_description(self, node):
+        # description of an <option_group> in an <option_list_item>
+        self.open_moin_page_node(moin_page.table_cell())
+
+    def depart_description(self, node):
+        self.close_moin_page_node()
+
+    def visit_docinfo_item(self, node, name):
+        # auxiliary function, called by docinfo items
+        # <address>, <author>, <authors>, <contact>, <copyright>, <date>,
+        # <organization>, <revision>, <status>, and <version>,
+        self.open_moin_page_node(moin_page.table_row())
+        self.open_moin_page_node(moin_page.table_cell())
+        self.open_moin_page_node(moin_page.strong())
+        self.current_node.append(name.capitalize() + ":")  # TODO: i18n
+        self.close_moin_page_node()  # </strong>
+        self.close_moin_page_node()  # </table_cell>
+        self.open_moin_page_node(moin_page.table_cell())
+
+    def depart_docinfo_item(self, node):
+        self.close_moin_page_node()  # </table_cell>
+        self.close_moin_page_node()  # </table_row>
 
     def visit_emphasis(self, node):
         self.open_moin_page_node(moin_page.emphasis(), node)
@@ -352,11 +371,9 @@ class NodeVisitor:
     def visit_field_name(self, node):
         self.open_moin_page_node(moin_page.table_cell(), node)
         self.open_moin_page_node(moin_page.strong())
-        self.open_moin_page_node(f"{node.astext()}:")
-        node.children = []
-        self.close_moin_page_node()
 
     def depart_field_name(self, node):
+        self.current_node.append(":")
         self.close_moin_page_node()
         self.close_moin_page_node()
 
@@ -530,14 +547,31 @@ class NodeVisitor:
     def depart_option_list_item(self, node):
         self.close_moin_page_node()
 
-    def visit_option(self, node):
+    def visit_option_group(self, node):
         self.open_moin_page_node(moin_page.table_cell())
+
+    def depart_option_group(self, node):
+        self.close_moin_page_node()
+
+    def visit_option(self, node):
+        self.open_moin_page_node(moin_page.span(attrib={html.class_: "kbd option"}))
 
     def depart_option(self, node):
         self.close_moin_page_node()
+        if isinstance(node.next_node(descend=False, siblings=True), nodes.option):
+            self.current_node.append(", ")
 
-    visit_description = visit_option
-    depart_description = depart_option
+    def visit_option_argument(self, node):
+        self.current_node.append(node.get("delimiter", " "))
+
+    def depart_option_argument(self, node):
+        pass
+
+    def visit_organization(self, node):
+        self.visit_docinfo_item(node, "organization")
+
+    def depart_organization(self, node):
+        self.depart_docinfo_item(node)
 
     def visit_paragraph(self, node):
         if self.status[-1] == "footnote":
@@ -632,6 +666,12 @@ class NodeVisitor:
     def depart_reference(self, node):
         self.close_moin_page_node()
 
+    def visit_revision(self, node):
+        self.visit_docinfo_item(node, "revision")
+
+    def depart_revision(self, node):
+        self.depart_docinfo_item(node)
+
     def visit_row(self, node):
         self.open_moin_page_node(moin_page.table_row(), node)
 
@@ -643,6 +683,12 @@ class NodeVisitor:
 
     def depart_rubric(self, node):
         self.close_moin_page_node()
+
+    def visit_status(self, node):
+        self.visit_docinfo_item(node, "status")
+
+    def depart_status(self, node):
+        self.depart_docinfo_item(node)
 
     def visit_substitution_definition(self, node):
         """
@@ -811,6 +857,12 @@ class NodeVisitor:
 
     def depart_transition(self, node):
         self.close_moin_page_node()
+
+    def visit_version(self, node):
+        self.visit_docinfo_item(node, "version")
+
+    def depart_version(self, node):
+        self.depart_docinfo_item(node)
 
     def unimplemented_visit(self, node):
         pass

--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -736,7 +736,7 @@ ul#moin-rev-navigation { text-align: center; background-color: var(--bg-zebra); 
 .moin-rst-optionlist,
 .moin-rst-fieldlist { margin-left: 2em; }
 .moin-rst-optionlist td,
-.moin-rst-fieldlist td { border-width: 0; }
+.moin-rst-fieldlist td { border-width: 0; vertical-align: top; }
 .moin-rst-optionlist td:first-child,
 .moin-rst-fieldlist td:first-child { font-weight: bold; }
 


### PR DESCRIPTION
Fix syntax highlight, field lists, option lists, and docinfo.

Add `*~` to .gitignore to ignore editor backup files.