### PR TITLE
Rst fixes

### DIFF
--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -60,7 +60,7 @@ class TestConverter:
         ),
         (
             "Text\n\n~~~~~\n\nTest",
-            '<page><body><p>Text</p><separator xhtml:class="moin-hr3" /><p>Test</p></body></page>',
+            '<page><body><p>Text</p><separator xhtml:class="moin-hr2" /><p>Test</p></body></page>',
         ),
         (".. comment", '<page><body><div class="comment dashed">comment</div></body></page>'),
         ("..\n comment", '<page><body><div class="comment dashed">comment</div></body></page>'),
@@ -495,8 +495,8 @@ text""",
             "<p>topic content</p></div></body></page>",
         ),
         (
-            ".. sidebar:: Sidebar Title\n   :subtitle: Sidebar Subtitle\n\n   sidebar content",
-            '<page><body><div xhtml:class="moin-aside moin-sidebar">'
+            ".. sidebar:: Sidebar Title\n   :subtitle: Sidebar Subtitle\n   :class: float-right\n\n   sidebar content",
+            '<page><body><div xhtml:class="moin-aside moin-sidebar float-right">'
             '<p xhtml:class="moin-title">Sidebar Title</p>'
             '<p xhtml:class="moin-subheading">Sidebar Subtitle</p>'
             "<p>sidebar content</p></div></body></page>",

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -855,9 +855,9 @@ class NodeVisitor:
     def depart_title_reference(self, node):
         pass
 
-    def visit_transition(self, node, default_class="moin-hr3"):
+    def visit_transition(self, node):
         # TODO: add to rst_out
-        attrib = {html.class_: default_class}
+        attrib = {html.class_: "moin-hr2"}
         self.open_moin_page_node(moin_page.separator(attrib=attrib), node)
 
     def depart_transition(self, node):

--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -431,7 +431,7 @@ li > p { margin-top: 0; margin-bottom: 0; }
 .moin-rst-attribution:before { content: "—"; }
 
 /* reST line-blocks */
-.moin-line-block { margin-left: 2em; }
+.moin-line-block > .moin-line-block { margin-left: 2em; }
 .moin-line-blk:empty { min-height: 1em; }
 
 /* HTML <aside> (rST topic and sidebar) */


### PR DESCRIPTION
 Don't drop citation labels.
 (Fast workaround. TODO: Correct conversion of citation elements.)
    
In `visit_sidebar()`, pass node to open_moin_page_node() so that CSS classes
specified in the "sidebar" directive are passed on.
    
Fix CSS rules for "moin-aside" and "moin-line-block".

 Use a narrower horizontal line for "transitions" to better match the section title
 underline in the default theme.
       