### PR TITLE
Fix handling of form data in +modify request.

### DIFF
--- a/src/moin/items/__init__.py
+++ b/src/moin/items/__init__.py
@@ -1602,7 +1602,7 @@ class Default(Contentful):
             if data is not None:
 
                 # werkzeug may return form data using type tempfile.SpooledTemporaryFile (issue 1974)
-                if isinstance(data, IOBase):
+                if isinstance(data, IOBase) or hasattr(data, "read"):
                     data = data.read()
 
                 # decode text content we may have received in binary form


### PR DESCRIPTION
Moin supports item data in textual and binary form. This fixes an error introduced in commit d72be050037cb77a6b6b1660053461027e7a8288, that allowed only content in textual form to be persisted in the storage backend.

Moin still may run into trouble when uploading binary content and attempting to preview the uploaded content in the modify form. I will address this in a separate pull request, as it turned out to require more time than initially anticipated to resolve the issues I observed.

Fixes #2064 and #2065 