### PR TITLE
Less less code duplication in `markdown_in` converter.

### DIFF
--- a/src/moin/converters/_tests/test_markdown_in.py
+++ b/src/moin/converters/_tests/test_markdown_in.py
@@ -70,10 +70,19 @@ class TestConverter:
         self.do(input, output)
 
     data = [
+        ("line<br />break", "<div><p>line<line-break />break</p></div>"),
+        ("<big>larger</big>", '<div><p><span font-size="120%">larger</span></p></div>'),
+        ("<small>smaller</small>", '<div><p><span font-size="85%">smaller</span></p></div>'),
+        ("<sub>sub</sub>script", '<div><p><span baseline-shift="sub">sub</span>script</p></div>'),
+        ("<sup>super</sup>script", '<div><p><span baseline-shift="super">super</span>script</p></div>'),
         ("<em>Emphasis</em>", "<div><p><emphasis>Emphasis</emphasis></p></div>"),
         ("<i>Italic</i>", "<div><p><emphasis>Italic</emphasis></p></div>"),
         ("<u>underline</u>", "<div><p><u>underline</u></p></div>"),
+        ("<ins>inserted</ins>", "<div><p><ins>inserted</ins></p></div>"),
         ("<del>deleted</del>", "<div><p><del>deleted</del></p></div>"),
+        ("<s>no longer accurate</s>", "<div><p><s>no longer accurate</s></p></div>"),
+        # the <strike> tag is deprecated since HTML4.1!
+        ("<strike>obsolete</strike>", "<div><p><s>obsolete</s></p></div>"),
         # TODO: markdown 3.3 outputs `/>\n\n\n\n</p>`, prior versions output `/></p>`. Try test again with versions 3.3+
         # Added similar test to test_markdown_in_out
         # ('<hr>',
@@ -82,6 +91,19 @@ class TestConverter:
 
     @pytest.mark.parametrize("input,output", data)
     def test_html_extension(self, input, output):
+        self.do(input, output)
+
+    data = [
+        ("<abbr>e.g.</abbr>", '<div><p><span html:class="html-abbr">e.g.</span></p></div>'),
+        # <acronym> is deprecated in favour of <abbr> in HTML5!
+        ("<acronym>AC/DC</acronym>", '<div><p><span html:class="html-acronym">AC/DC</span></p></div>'),
+        # <address> is a block-level element!
+        ("<dfn>term</dfn>", '<div><p><span html:class="html-dfn">term</span></p></div>'),
+        ("<kbd>Ctrl-X</kbd>", '<div><p><span html:class="html-kbd">Ctrl-X</span></p></div>'),
+    ]
+
+    @pytest.mark.parametrize("input,output", data)
+    def test_html_inline_tags(self, input, output):
         self.do(input, output)
 
     data = [

--- a/src/moin/converters/html_in.py
+++ b/src/moin/converters/html_in.py
@@ -47,9 +47,9 @@ class NoDupsFlash:
                 pass
 
 
-class Converter:
+class HtmlTags:
     """
-    Convert HTML -> .x.moin.document.
+    Common definitions for HTML and Markdown converters.
     """
 
     # Namespace of our input data
@@ -131,6 +131,30 @@ class Converter:
     # Store the Base URL for all the URL of the document
     base_url = ""
 
+    def new(self, tag, attrib, children):
+        """
+        Return a new element for the DOM Tree
+        """
+        return ET.Element(tag, attrib=attrib, children=children)
+
+    def new_copy(self, tag, element, attrib):
+        """
+        Function to copy one element to the DOM Tree.
+
+        It first converts the child of the element,
+        and the element itself.
+        """
+        attrib_new = self.convert_attributes(element)
+        attrib.update(attrib_new)
+        children = self.do_children(element)
+        return self.new(tag, attrib, children)
+
+
+class Converter(HtmlTags):
+    """
+    Convert HTML -> .x.moin.document.
+    """
+
     @classmethod
     def _factory(cls, input, output, **kw):
         return cls()
@@ -207,24 +231,6 @@ class Converter:
             else:
                 new.append(child)
         return new
-
-    def new(self, tag, attrib, children):
-        """
-        Return a new element for the DOM Tree
-        """
-        return ET.Element(tag, attrib=attrib, children=children)
-
-    def new_copy(self, tag, element, attrib):
-        """
-        Function to copy one element to the DOM Tree.
-
-        It first converts the child of the element,
-        and the element itself.
-        """
-        attrib_new = self.convert_attributes(element)
-        attrib.update(attrib_new)
-        children = self.do_children(element)
-        return self.new(tag, attrib, children)
 
     def new_copy_symmetric(self, element, attrib):
         """


### PR DESCRIPTION
Inherit HTML parsing attributes from `html_in` instead of replicating the code.

Get recent and future fixes for free...