### PR TITLE
CSS: Fix styling of preformatted blocks and inline code.

### DIFF
--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -145,9 +145,8 @@ div.warning > p { margin-top: 8px; padding-left: 4em; }
 .gray { background-color: var(--bg-user-gray); }
 .grey { background-color: var(--bg-user-gray); }
 .lightgray { background-color: lightgray; }
-.code { border: 1px solid var(--border-code); background-color: var(--bg-code);
-    padding: 7px 10px; clear: both; margin: .75em 0; white-space: pre-wrap; word-wrap: break-word; word-break: break-all; border-radius: 4px;
-    font-family: Menlo, Monaco, Consolas, "Courier New", monospace; }
+/* .code -- see "preformatted blocks and inline code" below */
+.code.wrap, pre.wrap, code.wrap { white-space: pre-wrap; overflow-wrap: break-word; word-break: break-all; }
 .solid { border: 2px solid var(--border-code); padding: 2px; clear: both; }
 .dashed { border: 2px dashed var(--border-code); padding: 2px; clear: both; }
 .dotted {  border: 2px dotted var(--border-code); padding: 2px; clear: both; }
@@ -498,10 +497,12 @@ a.moin-button:active { color: var(--primary); text-decoration: none; }
 .moin-button:disabled:hover { box-shadow: none; }
 .moin-button-less { border: 0; background: inherit; color: var(--link); }
 
-/* pre */
-pre { border: 1px solid var(--border-code); background-color: var(--bg-code);
-    padding: 7px 10px; clear: both; margin: .75em 0; white-space: pre-wrap; word-wrap: break-word; word-break: break-all; border-radius: 4px;
+/* preformatted blocks and inline code */
+.code, pre, code { background-color: var(--bg-code);
+    border: 1px solid var(--border-code); border-radius: 4px;
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace; }
+div.code, pre { clear: both; padding: 7px 10px; margin: .75em 0; }
+span.code, code { white-space: pre-wrap; overflow-wrap: anywhere; }
 
 /* table of contents (div.toc is for markdown parser) */
 div.moin-table-of-contents,


### PR DESCRIPTION
1. Long lines in preformatted blocks and code are wrapped *anyw here* (similar to console output in an X-terminal). This results in hard to read code blocks and broken "ASCII-art"; especially if the text area is narrow, e.g., in side-by-side examples.

-> Don't wrap long lines in pre-formatted text blocks by default.
   Authors can use the new "userstyle" `wrap` to get wrapping in pre-formatted
   blocks (e.g. for an IRC chat log).

2. *Inline* elements with class "code" ares styled with settings suited for code blocks, with padding that interferes with neighbouring text lines.

-> Use no padding, when the `code` "userstyle" class is applied
   to inline elements.

Fixes #2071.

Attention: 
  this fix changes the styling of `<pre>` elements to "preformatted" (i.e. no line wrapping, only start a new line when there is a newline character in the source).

IMV, this is the correct default for code and preformatted blocks.
If there are objections, I can prepare an alternative PR with a `nowrap` "userstyle".

