### PR TITLE
HTML in: Fix conversion of "acronym" and "address" elements.

### DIFF
--- a/src/moin/converters/_tests/test_html_in.py
+++ b/src/moin/converters/_tests/test_html_in.py
@@ -198,36 +198,38 @@ class TestConverter(Base):
     def test_span(self, input, xpath):
         self.do(input, xpath)
 
+    # HTML elements without equivalent Moin DOM tree elements
+    # are represented via a "html-{tagname}" `class` attribute:
     data = [
         (
-            "<html><p><abbr>Text</abbr></p></html>",
-            # <page><body><span html:class="html-abbr">Text</span></body></page>
-            '/page/body/p/span[text()="Text"][@html:class="html-abbr"]',
+            "<html><p><abbr>e.g.</abbr></p></html>",
+            # <page><body><span html:class="html-abbr">e.g.</span></body></page>
+            '/page/body/p/span[text()="e.g."][@html:class="html-abbr"]',
+        ),
+        (  # in HTML5, <acronym> is deprecated in favour of <abbr>
+            "<html><p><acronym>AC/DC</acronym></p></html>",
+            # <page><body><span html:class="html-abbr">AC/DC</span></body></page>
+            '/page/body/p/span[text()="AC/DC"][@html:class="html-abbr"]',
+        ),
+        (  # address is a block-level element, use <div ...>
+            "<html><address>100 Acre Wood</address></html>",
+            # <page><body><div html:class="html-address">100 Acre Wood</div></body></page>
+            '/page/body/div[text()="100 Acre Wood"][@html:class="html-address"]',
         ),
         (
-            "<html><p><acronym>Text</acronym></p></html>",
-            # <page><body><span html:class="html-acronym">Text</span></body></page>
-            '/page/body/p/span[text()="Text"][@html:class="html-acronym"]',
+            "<html><p><dfn>term</dfn></p></html>",
+            # <page><body><span html:class="html-dfn">term</span></body></page>
+            '/page/body/p/span[text()="term"][@html:class="html-dfn"]',
         ),
         (
-            "<html><p><address>Text</address></p></html>",
-            # <page><body><span html:class="html-address">Text</span></body></page>
-            '/page/body/p/span[text()="Text"][@html:class="html-address"]',
-        ),
-        (
-            "<html><p><dfn>Text</dfn></p></html>",
-            # <page><body><span html:class="html-dfn">Text</span></body></page>
-            '/page/body/p/span[text()="Text"][@html:class="html-dfn"]',
-        ),
-        (
-            "<html><p><kbd>Text</kbd></p></html>",
-            # <page><body><span html:class="html-kbd">Text</span></body></page>
-            '/page/body/p/span[text()="Text"][@html:class="html-kbd"]',
+            "<html><p><kbd>Ctrl-X</kbd></p></html>",
+            # <page><body><span html:class="html-kbd">Ctrl-X</span></body></page>
+            '/page/body/p/span[text()="Ctrl-X"][@html:class="html-kbd"]',
         ),
     ]
 
     @pytest.mark.parametrize("input,xpath", data)
-    def test_span_html_element(self, input, xpath):
+    def test_other_html_elements(self, input, xpath):
         self.do(input, xpath)
 
     data = [

--- a/src/moin/converters/_tests/test_html_in_out.py
+++ b/src/moin/converters/_tests/test_html_in_out.py
@@ -121,8 +121,8 @@ class TestConverter(Base):
 
     data = [
         ("<html><p><abbr>Text</abbr></p></html>", '/div/p/span[@class="html-abbr"][text()="Text"]'),
-        ("<html><p><acronym>Text</acronym></p></html>", '/div/p/span[@class="html-acronym"][text()="Text"]'),
-        ("<html><p><address>Text</address></p></html>", '/div/p/span[@class="html-address"][text()="Text"]'),
+        ("<html><p><acronym>AC/DC</acronym></p></html>", '/div/p/span[@class="html-abbr"][text()="AC/DC"]'),
+        ("<html><address>100 Acre Wood</address></html>", '/div/div[@class="html-address"][text()="100 Acre Wood"]'),
         ("<html><p><dfn>Text</dfn></p></html>", '/div/p/span[@class="html-dfn"][text()="Text"]'),
         ("<html><p><kbd>Text</kbd></p></html>", '/div/p/span[@class="html-kbd"][text()="Text"]'),
     ]

--- a/src/moin/converters/_tests/test_markdown_in.py
+++ b/src/moin/converters/_tests/test_markdown_in.py
@@ -94,16 +94,21 @@ class TestConverter:
         self.do(input, output)
 
     data = [
+        # TODO: there are too many <div> wrappers!
         ("<abbr>e.g.</abbr>", '<div><p><span html:class="html-abbr">e.g.</span></p></div>'),
-        # <acronym> is deprecated in favour of <abbr> in HTML5!
-        ("<acronym>AC/DC</acronym>", '<div><p><span html:class="html-acronym">AC/DC</span></p></div>'),
-        # <address> is a block-level element!
+        # <acronym> is deprecated in favour of <abbr> in HTML5
+        ("<acronym>AC/DC</acronym>", '<div><p><span html:class="html-abbr">AC/DC</span></p></div>'),
+        # <address> is a block-level element
+        (
+            "<address>100 Acre Wood</address>",
+            '<div><div><div html:class="html-address">100 Acre Wood</div>\n</div></div>',
+        ),
         ("<dfn>term</dfn>", '<div><p><span html:class="html-dfn">term</span></p></div>'),
         ("<kbd>Ctrl-X</kbd>", '<div><p><span html:class="html-kbd">Ctrl-X</span></p></div>'),
     ]
 
     @pytest.mark.parametrize("input,output", data)
-    def test_html_inline_tags(self, input, output):
+    def test_other_html_elements(self, input, output):
         self.do(input, output)
 
     data = [

--- a/src/moin/converters/html_in.py
+++ b/src/moin/converters/html_in.py
@@ -83,8 +83,7 @@ class HtmlTags:
 
     # HTML tags that do not have equivalents in the DOM tree
     # We use a <span> element but add information about the original tag.
-    inline_tags = {"abbr", "acronym", "address", "dfn", "kbd"}
-    # TODO: Use a <div> element for <address> (it is a "body element").
+    inline_tags = {"abbr", "dfn", "kbd"}
 
     # HTML tags that are completely ignored by our converter.
     # Deprecated/obsolete tags and tags not suited for wiki content
@@ -342,6 +341,15 @@ class Converter(HtmlTags):
         attrib[key] = heading_level
         ret = self.new_copy(moin_page.h, element, attrib)
         return ret
+
+    def visit_xhtml_acronym(self, element):
+        # in HTML5, <acronym> is deprecated in favour of <abbr>
+        attrib = {html.class_: "html-abbr"}
+        return self.new_copy(moin_page.span, element, attrib)
+
+    def visit_xhtml_address(self, element):
+        attrib = {html.class_: "html-address"}
+        return self.new_copy(moin_page.div, element, attrib)
 
     def visit_xhtml_br(self, element):
         """


### PR DESCRIPTION
The `<acronym>` element is deprecated in favour of `<abbr>` in HTML5. Store as `<span html:class="abbr">`.

The `<address>` element is a block-level element.
Store as `<div ...>`.

Also changes HTML parsing in the Markdown in converter.