### PR TITLE
rST in: Support custom "text-level semantics" roles based on "literal".

### DIFF
--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -61,7 +61,8 @@ class TestConverter:
         (".. role:: u\n\n:u:`annoted` text", "<p><u>annoted</u> text</p>"),
         # custom roles with matching HTML element
         (".. role:: dfn\n\n:dfn:`term`", '<p><span xhtml:class="html-dfn">term</span></p>'),
-        (".. role:: kbd\n\nEnter :kbd:`Ctrl-X`", '<p>Enter <span xhtml:class="html-kbd">Ctrl-X</span></p>'),
+        (".. role:: kbd(literal)\n\nEnter :kbd:`Ctrl-X`", '<p>Enter <span xhtml:class="html-kbd">Ctrl-X</span></p>'),
+        (".. role:: samp(literal)\n\n:samp:`Error 303`", '<p><span xhtml:class="html-samp">Error 303</span></p>'),
         (  # custom role derived from "code" with syntax highlight
             '.. role:: python(code)\n   :language: python\n\nInline code like :python:`print(3*"Hurra!")`.',
             '<p>Inline code like <code xhtml:class="code python">'

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -500,13 +500,13 @@ class NodeVisitor:
         moin_node = moin_page.span()
         # some class values indicate a matching HTML element (except when used for syntax highlight):
         if not (isinstance(node.parent, (nodes.literal_block, nodes.literal)) and "code" in node.parent.get("classes")):
-            for tag in classes:
+            for i, tag in enumerate(classes):
                 if tag in HtmlTags.symmetric_tags:
                     moin_node = getattr(moin_page, tag)()
                     classes.remove(tag)
                     break
                 if tag in HtmlTags.inline_tags:
-                    classes[classes.index(tag)] = "html-" + tag
+                    classes[i] = "html-" + tag
         self.open_moin_page_node(moin_node, node)
 
     def depart_inline(self, node):
@@ -548,7 +548,16 @@ class NodeVisitor:
         self.close_moin_page_node()
 
     def visit_literal(self, node):
-        self.open_moin_page_node(moin_page.code(), node)
+        # some class values indicate a matching HTML element:
+        classes = node["classes"]
+        for i, tag in enumerate(classes):
+            if tag in ("kbd", "samp"):
+                classes[i] = "html-" + tag
+                moin_node = moin_page.span()
+                break
+        else:
+            moin_node = moin_page.code()
+        self.open_moin_page_node(moin_node, node)
 
     def depart_literal(self, node):
         self.close_moin_page_node()


### PR DESCRIPTION
The "Standard Include File" `html-roles.txt` defines a set of roles matching HTML for "text-level semantics".  The "kbd" and "samp" roles are based on "literal" (for "graceful degradation"). Convert them to internal representation as `<span class="html-{tagname}">` to ensure the `<kbd>` and `<samp>` tags are used.

See the rST help page (localhost:5000/help-en/rst#Additional_Text_Roles) for a usage example.