### PR TITLE
Save/restore HTML tag info for more elements.

### DIFF
--- a/src/moin/converters/_tests/test_html_in.py
+++ b/src/moin/converters/_tests/test_html_in.py
@@ -168,9 +168,9 @@ class TestConverter(Base):
             '/page/body/p/span[text()="Test"][@font-size="120%"]',
         ),
         (
-            "<html><p><small>Test</small></p></html>",
-            # <page><body><p><span font-size="85%">Test</span></p></body></page>
-            '/page/body/p/span[text()="Test"][@font-size="85%"]',
+            '<html><p><span class="moin-small">smaller</span></p></html>',
+            # <page><body><p><span html:class="moin-small">smaller</span></p></body></page>
+            '/page/body/p/span[text()="smaller"][@html:class="moin-small"]',
         ),
         (
             "<html><p><ins>underline</ins></p></html>",
@@ -217,6 +217,11 @@ class TestConverter(Base):
             '/page/body/div[text()="webmaster@example.org"][@html:class="html-address"]',
         ),
         (
+            "<html><p><cite>Hamlet</cite></p></html>",
+            # <page><body><span html:class="html-cite">Hamlet</span></body></page>
+            '/page/body/p/span[text()="Hamlet"][@html:class="html-cite"]',
+        ),
+        (
             "<html><p><dfn>term</dfn></p></html>",
             # <page><body><span html:class="html-dfn">term</span></body></page>
             '/page/body/p/span[text()="term"][@html:class="html-dfn"]',
@@ -225,6 +230,26 @@ class TestConverter(Base):
             "<html><p><kbd>Ctrl-X</kbd></p></html>",
             # <page><body><span html:class="html-kbd">Ctrl-X</span></body></page>
             '/page/body/p/span[text()="Ctrl-X"][@html:class="html-kbd"]',
+        ),
+        (
+            "<html><p><mark>highlight</mark></p></html>",
+            # <page><body><span html:class="html-mark">highlight</span></body></page>
+            '/page/body/p/span[text()="highlight"][@html:class="html-mark"]',
+        ),
+        (
+            "<html><p><q>cogito ergo sum</q></p></html>",
+            # <page><body><span html:class="html-q">cogito ergo sum</span></body></page>
+            '/page/body/p/span[text()="cogito ergo sum"][@html:class="html-q"]',
+        ),
+        (
+            "<html><p><small>fine print</small></p></html>",
+            # <page><body><p><span html:class="html-small">fine print</span></p></body></page>
+            '/page/body/p/span[text()="fine print"][@html:class="html-small"]',
+        ),
+        (
+            "<html><p><var>n</var></p></html>",
+            # <page><body><span html:class="html-var">n</span></body></page>
+            '/page/body/p/span[text()="n"][@html:class="html-var"]',
         ),
     ]
 

--- a/src/moin/converters/_tests/test_html_in_out.py
+++ b/src/moin/converters/_tests/test_html_in_out.py
@@ -96,7 +96,10 @@ class TestConverter(Base):
             '/div/p/u [text()="underline"]',
         ),
         ("<html><p><big>Test</big></p></html>", '/div/p/span[@class="moin-big"][text()="Test"]'),
-        ("<html><p><small>Test</small></p></html>", '/div/p/span[@class="moin-small"][text()="Test"]'),
+        (
+            '<html><p><span class="moin-small">smaller</span></p></html>',
+            '/div/p/span[@class="moin-small"][text()="smaller"]',
+        ),
         (
             "<html><p><ins>underline</ins></p></html>",
             # <div><p><ins>underline</ins></p></div>
@@ -123,8 +126,13 @@ class TestConverter(Base):
         ("<html><p><abbr>etc.</abbr></p></html>", '/div/p[abbr="etc."]'),
         ("<html><p><acronym>AC/DC</acronym></p></html>", '/div/p[abbr="AC/DC"]'),
         ("<html><p><address>webmaster@example.org</address></p></html>", '/div/p[address="webmaster@example.org"]'),
+        ("<html><p><cite>Moin wiki</cite></p></html>", '/div/p[cite="Moin wiki"]'),
         ("<html><p><dfn>term</dfn></p></html>", '/div/p[dfn="term"]'),
         ("<html><p><kbd>Ctrl-X</kbd></p></html>", '/div/p[kbd="Ctrl-X"]'),
+        ("<html><p>see <mark>here</mark></p></html>", '/div/p[text()="see "][mark="here"]'),
+        ("<html><p><q>cogito ergo sum</q></p></html>", '/div/p[q="cogito ergo sum"]'),
+        ("<html><p><small>side remark</small></p></html>", '/div/p[small="side remark"]'),
+        ("<html><p><var>n</var> elements</p></html>", '/div/p[var="n"][text()=" elements"]'),
     ]
 
     @pytest.mark.parametrize("input,xpath", data)

--- a/src/moin/converters/_tests/test_markdown_in.py
+++ b/src/moin/converters/_tests/test_markdown_in.py
@@ -72,7 +72,7 @@ class TestConverter:
     data = [
         ("line<br />break", "<div><p>line<line-break />break</p></div>"),
         ("<big>larger</big>", '<div><p><span font-size="120%">larger</span></p></div>'),
-        ("<small>smaller</small>", '<div><p><span font-size="85%">smaller</span></p></div>'),
+        ('<span class="moin-small">smaller</span>', '<div><p><span html:class="moin-small">smaller</span></p></div>'),
         ("<sub>sub</sub>script", '<div><p><span baseline-shift="sub">sub</span>script</p></div>'),
         ("<sup>super</sup>script", '<div><p><span baseline-shift="super">super</span>script</p></div>'),
         ("<em>Emphasis</em>", "<div><p><emphasis>Emphasis</emphasis></p></div>"),
@@ -105,6 +105,7 @@ class TestConverter:
         ),
         ("<dfn>term</dfn>", '<div><p><span html:class="html-dfn">term</span></p></div>'),
         ("<kbd>Ctrl-X</kbd>", '<div><p><span html:class="html-kbd">Ctrl-X</span></p></div>'),
+        ("<small>fine print</small>", '<div><p><span html:class="html-small">fine print</span></p></div>'),
     ]
 
     @pytest.mark.parametrize("input,output", data)

--- a/src/moin/converters/_tests/test_markdown_in_out.py
+++ b/src/moin/converters/_tests/test_markdown_in_out.py
@@ -66,15 +66,19 @@ class TestConverter:
         ("`monospace`\n", "`monospace`\n"),
         ("<abbr>etc.</abbr>", "<abbr>etc.</abbr>"),
         ("<acronym>DC</acronym>", "<abbr>DC</abbr>"),  # in HTML5, <acronym> is deprecated in favour of <abbr>
+        ("<cite>Winnie-the-Pooh</cite>", "<cite>Winnie-the-Pooh</cite>"),
         ("<dfn>term</dfn>", "<dfn>term</dfn>"),
         ("<strike>stroke</strike>\n", "<strike>stroke</strike>\n"),
         # <ins> is changed to <u>
         ("<ins>underline</ins>\n", "<u>underline</u>\n"),
         ("<kbd>Ctrl-X</kbd><", "<kbd>Ctrl-X</kbd><"),
+        ("see <mark>here</mark>", "see <mark>here</mark>"),
+        ("<q>cogito ergo sum</q>", "<q>cogito ergo sum</q>"),
         ("<big>larger</big>\n", "<big>larger</big>\n"),
-        ("<small>smaller</small>\n", "<small>smaller</small>\n"),
+        ("<small>fine print</small>\n", "<small>fine print</small>\n"),
         ("<sup>super</sup>script\n", "<sup>super</sup>script\n"),
         ("<sub>sub</sub>script\n", "<sub>sub</sub>script\n"),
+        ("<var>n</var> times\n", "<var>n</var> times\n"),
         ("<hr>\n\n<hr>\n\n<hr>\n", "----\n\n----\n\n----\n"),
     ]
 

--- a/src/moin/converters/html_in.py
+++ b/src/moin/converters/html_in.py
@@ -83,7 +83,7 @@ class HtmlTags:
 
     # HTML tags that do not have equivalents in the DOM tree
     # We use a <span> element but add information about the original tag.
-    inline_tags = {"abbr", "dfn", "kbd"}
+    inline_tags = {"abbr", "cite", "dfn", "kbd", "mark", "q", "small", "var"}
 
     # HTML tags that are completely ignored by our converter.
     # Deprecated/obsolete tags and tags not suited for wiki content
@@ -117,7 +117,6 @@ class HtmlTags:
         "style",
         "textarea",
         "title",
-        # "var",  # a variable or constant
     }
 
     # standard_attributes are html attributes which are used
@@ -364,15 +363,6 @@ class Converter(HtmlTags):
         key = moin_page("font-size")
         attrib = {}
         attrib[key] = "120%"
-        return self.new_copy(moin_page.span, element, attrib)
-
-    def visit_xhtml_small(self, element):
-        """
-        <small>Text</small> --> <span font-size=85%>Text</span>
-        """
-        key = moin_page("font-size")
-        attrib = {}
-        attrib[key] = "85%"
         return self.new_copy(moin_page.span, element, attrib)
 
     def visit_xhtml_sub(self, element):

--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -169,7 +169,7 @@ class Converter:
     namespaces_visit = {moin_page: "moinpage"}
 
     # Tags which can be directly converted into an HTML element
-    direct_tags = {"abbr", "address", "dfn", "kbd"}
+    direct_tags = {"abbr", "address", "cite", "dfn", "kbd", "mark", "q", "small", "var"}
 
     def __call__(self, element):
         return self.visit(element)

--- a/src/moin/converters/markdown_out.py
+++ b/src/moin/converters/markdown_out.py
@@ -86,7 +86,7 @@ class Converter:
     namespaces = {moin_page.namespace: "moinpage", xinclude: "xinclude"}
 
     # HTML elements represented by a special html:class value.
-    direct_tags = {"abbr", "address", "dfn", "kbd"}
+    direct_tags = {"abbr", "cite", "dfn", "kbd", "mark", "q", "small", "var"}
 
     @classmethod
     def _factory(cls, input, output, **kw):


### PR DESCRIPTION
Add the HTML elements for »text-level semantics« "cite", "mark", "q", "small", and "var" to the tags that are internally represented as `<span class="html-{tagname}">`.

Note:
HTML `<small>` ("side comments such as small print") is semantically different from
`<span class="moin-small">` (`~-smaller-~` font size).

Cf. https://html.spec.whatwg.org/multipage/text-level-semantics.html