### PR TITLE
Don't drop attributes in HTML-export of "admonitions".

### DIFF
--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -245,10 +245,9 @@ class Converter:
         """Used by reST and docbook."""
         attrib = {}
         valid_classes = {"attention", "caution", "danger", "error", "hint", "important", "note", "tip", "warning"}
-        cls = elem.get(moin_page.type)
+        cls = elem.attrib.pop(moin_page.type, None)
         if cls in valid_classes:
             attrib[html.class_] = cls
-        elem.attrib = {}
         return self.new_copy(html.div, elem, attrib)
 
     def visit_moinpage_audio(self, elem):


### PR DESCRIPTION
The `<admonition>` element may have attributes like an ID or html:class that should be kept in the HTML output.

Example rST input:
~~~
.. note:: This is just an example.
   :class: orange
   :name: orange-note
~~~