### PR TITLE
Fix: CLI account-create ignores display_name argument

### DIFF
--- a/src/moin/cli/account/create.py
+++ b/src/moin/cli/account/create.py
@@ -39,11 +39,10 @@ def CreateUser(name, display_name, email, password):
     logging.debug("display_name: %s", str(display_name))
     before_wiki()
 
-    # TODO: add display_name to create_user
-    msg = user.create_user(username=name, password=password, email=email)
+    msg = user.create_user(username=name, password=password, email=email, display_name=display_name)
 
     if msg:
         print(msg)
     else:
         u = user.User(auth_username=name)
-        logging.info("User %s %s %s - created.", u.itemid, u.name, u.email)
+        logging.info("User %s %s %s (%s) - created.", u.itemid, u.name, u.email, display_name)


### PR DESCRIPTION
The account-create CLI command accepts a --display-name argument, but it was previously ignored and not passed to the backend user.create_user function. As a result, users created via CLI did not have their display name set.

Changes
Updated 
src/moin/cli/account/create.py
 to pass the display_name argument to user.create_user.
Updated the success logging statement to include the display_name for better verification and observability.
Verification
I verified this manually by running the command:

moin account-create --name TestUser --email test@example.com --password secret --display-name "My Display Name"

I confirmed that the display_name was correctly stored in the user profile metadata on disk and that the success log message included the display name. 