### PR TITLE
Use Flatland HTML generator mode for HTML5-compliant markup

### DIFF
--- a/src/moin/utils/forms.py
+++ b/src/moin/utils/forms.py
@@ -1,4 +1,5 @@
 # Copyright: 2010 Thomas Waldmann, Jason Kirtland, Scott Wilson
+# Copyright: 2026 MoinMoin:UlrichB
 # License: see flatland license
 
 """
@@ -97,6 +98,7 @@ error_filter = error_filter_factory()
 def make_generator():
     """Make an HTML generator."""
     return Generator(
+        markup="html",
         auto_domid=True,
         auto_for=True,
         auto_filter=True,


### PR DESCRIPTION
Related to #1704.

Flatland defaults to XML/XHTML output, which produces self-closing slashes on void elements (e.g. <input />). HTML5 treats these slashes as meaningless and validators warn about them.

Switch the Flatland Generator to "html" mode so void elements are rendered without trailing slashes.
