### PR TITLE
configure Jinja autoescaping by template type to avoid Markup usage …

### DIFF
--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -6,7 +6,7 @@
 # Copyright: 2010 MoinMoin:DiogenesAugusto
 # Copyright: 2001 Richard Jones <richard@bizarsoftware.com.au>
 # Copyright: 2001 Juergen Hermann <jh@web.de>
-# Copyright: 2023-2025 MoinMoin:UlrichB
+# Copyright: 2023-2026 MoinMoin:UlrichB
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -694,7 +694,7 @@ def show_dom(item):
         status = 404
     else:
         status = 200
-    content = render_template("dom.xml", data_xml=Markup(item.content._render_data_xml()))
+    content = render_template("dom.xml", data_xml=item.content._render_data_xml())
     return Response(content, status, mimetype="text/xml")
 
 

--- a/src/moin/themes/__init__.py
+++ b/src/moin/themes/__init__.py
@@ -1,7 +1,7 @@
 # Copyright: 2003-2010 MoinMoin:ThomasWaldmann
 # Copyright: 2008 MoinMoin:RadomirDopieralski
 # Copyright: 2010 MoinMoin:DiogenesAugusto
-# Copyright: 2023-2024 MoinMoin project
+# Copyright: 2023-2026 MoinMoin project
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -24,6 +24,7 @@ from flask import current_app as app
 from flask import g as flaskg
 from flask import url_for, request, session, flash
 from flask_theme import get_theme, render_theme_template
+from jinja2 import select_autoescape
 
 from babel import Locale
 
@@ -782,3 +783,6 @@ def setup_jinja_env(jinja_env):
     # if Jinja whitespace control options are turned on, it becomes obvious why the default is off
     # app.jinja_env.trim_blocks = True
     # app.jinja_env.lstrip_blocks = True
+
+    # XML templates must not be HTML-autoescaped
+    jinja_env.autoescape = select_autoescape(enabled_extensions=("html", "htm"), disabled_extensions=("xml",))


### PR DESCRIPTION
…for XML

Disable Jinja autoescaping for .xml templates, keep it enabled for HTML.
This allows rendering pre-escaped XML output without using markupsafe.Markup
and avoids Bandit warnings B701/B704.

Related to #1858.