### PR TITLE
Markdown fixes

### DIFF
--- a/src/moin/converters/_tests/test_markdown_in_out.py
+++ b/src/moin/converters/_tests/test_markdown_in_out.py
@@ -63,6 +63,7 @@ class TestConverter:
         "*emphasis*",
         "    blockcode",
         "`monospace`",
+        "line <br />\nbreak",
         "<abbr>etc.</abbr>",
         "<cite>Winnie-the-Pooh</cite>",
         "<dfn>term</dfn>",
@@ -90,6 +91,7 @@ class TestConverter:
         ("xxx\n\n------\n\n------\n\n------\n", "xxx\n\n----\n\n----\n\n----\n"),
         ("----\n\n------\n\n--------\n", "----\n\n----\n\n----\n"),
         ("<hr>\n\n<hr>\n\n<hr>\n", "----\n\n----\n\n----\n"),
+        ("line  \nbreak", "line<br />\nbreak"),
         # we accept outdated HTML elements but map them to recommended substitute
         ("<acronym>DC</acronym>", "<abbr>DC</abbr>"),  # in HTML5, <acronym> is deprecated in favour of <abbr>
         ("<big>larger</big>\n", '<span class="moin-big">larger</span>'),  # <big> is obsolete

--- a/src/moin/converters/markdown_out.py
+++ b/src/moin/converters/markdown_out.py
@@ -53,7 +53,7 @@ class Markdown:
     samp_close = "`"
     table_marker = "|"
     p = "\n"
-    linebreak = "  "
+    linebreak = "<br />"
     object_open = "{{"
     object_close = "}}"
     definition_list_marker = ":  "


### PR DESCRIPTION
Markdown-out:  
* HTML tag instead of trailing spaces for hard line break.
  We continue to accept the "  " syntax but write the
  alternative syntax using the empty HTML tag `<br />`.
* Reduce redundant code, remove dead code.

Markdown tests: Simplify base tests in Markdown round-trip.