### PR TITLE
Fix method Clock.stop()

### DIFF
--- a/src/moin/utils/clock.py
+++ b/src/moin/utils/clock.py
@@ -48,7 +48,7 @@ class Clock:
 
     def stop(self, timer, comment=""):
         if timer in self.timers:
-            value = time.time() - self.timers[timer].pop()
+            value = time.time() - self.timers[timer].pop(0)
             logging.debug(f"timer {timer}({len(self.timers[timer])}): {value * 1000:.2f}ms {comment}")
             if not self.timers[timer]:
                 del self.timers[timer]


### PR DESCRIPTION
Fix `Clock.stop()` should remove the first element of the timer's entries, not the last one