### PR TITLE
Converters: Update conversion of "monospace" inline elements.

### DIFF
--- a/src/moin/converters/_tests/test_creole_in.py
+++ b/src/moin/converters/_tests/test_creole_in.py
@@ -270,12 +270,15 @@ class TestConverter:
         self.do(input, output)
 
     data = [
-        ("{{{nowiki}}}", "<page><body><p><code>nowiki</code></p></body></page>"),
-        ("{{{{nowiki}}}}", "<page><body><p><code>{nowiki}</code></p></body></page>"),
-        ("text: {{{nowiki}}}, text", "<page><body><p>text: <code>nowiki</code>, text</p></body></page>"),
+        ("{{{nowiki}}}", "<page><body><p><literal>nowiki</literal></p></body></page>"),
+        ("{{{{nowiki}}}}", "<page><body><p><literal>{nowiki}</literal></p></body></page>"),
+        ("text: {{{nowiki}}}, text", "<page><body><p>text: <literal>nowiki</literal>, text</p></body></page>"),
         ("{{{\nnowiki\n}}}", "<page><body><blockcode>nowiki</blockcode></body></page>"),
         ("{{{\nnowiki\nno\nwiki\n}}}", "<page><body><blockcode>nowiki\nno\nwiki</blockcode></body></page>"),
-        ("{{{nowiki}}} {{{nowiki}}}", "<page><body><p><code>nowiki</code> <code>nowiki</code></p></body></page>"),
+        (
+            "{{{nowiki}}} {{{nowiki}}}",
+            "<page><body><p><literal>nowiki</literal> <literal>nowiki</literal></p></body></page>",
+        ),
         # XXX: Is <page> correct?
         ("{{{\n#!\nwiki\n}}}", "<page><body><page><body><p>wiki</p></body></page></body></page>"),
         (

--- a/src/moin/converters/_tests/test_docbook_in.py
+++ b/src/moin/converters/_tests/test_docbook_in.py
@@ -406,11 +406,11 @@ class TestConverter(Base):
             # <page><body><div html:class="article"><blockcode>Text</blockcode></div></body></page>
             '/page/body/div[blockcode="Text"]',
         ),
-        # LITERAL --> CODE
+        # LITERAL --> LITERAL
         (
             "<article><para>text<literal>literal</literal></para></article>",
-            # <page><body><div html:class="article"><p>text<code>literal</code></p></div></body></page>
-            '/page/body/div/p[text()="text"][code="literal"]',
+            # <page><body><div html:class="article"><p>text<literal>literal</literal></p></div></body></page>
+            '/page/body/div/p[text()="text"][literal="literal"]',
         ),
         (
             "<article><blockquote><attribution>author</attribution>text</blockquote></article>",
@@ -423,11 +423,17 @@ class TestConverter(Base):
             # <page><body><div html:class="article"><p><code>Text</code></p></article>
             '/page/body/div/p[code="Text"]',
         ),
-        # COMPUTEROUTPUT --> CODE
+        # COMPUTEROUTPUT --> SAMP
         (
             "<article><para><computeroutput>Text</computeroutput></para></article>",
-            # <page><body><div html:class="article"><p><code>Text</code></p></article>
-            '/page/body/div/p[code="Text"]',
+            # <page><body><div html:class="article"><p><samp>Text</samp></p></article>
+            '/page/body/div/p[samp="Text"]',
+        ),
+        # USERINPUT --> KBD
+        (
+            "<article><para><userinput>Ctrl-X</userinput></para></article>",
+            # <page><body><div html:class="article"><p><kbd>Ctrl-X</kbd></p></article>
+            '/page/body/div/p[kbd="Ctrl-X"]',
         ),
         # MARKUP --> CODE
         (

--- a/src/moin/converters/_tests/test_docbook_out.py
+++ b/src/moin/converters/_tests/test_docbook_out.py
@@ -201,11 +201,29 @@ class TestConverter(Base):
             # <article><screen><![CDATA[Text]]></screen></article>
             '/article[screen="<![CDATA[Text]]>"]',
         ),
-        # Code conversion into <literal>
+        # CODE --> CODE
         (
             "<page><body><p><code>Text</code></p></body></page>",
-            # <article><simpara><literal>Text</literal></simpara></article>
-            '/article/simpara[literal="Text"]',
+            # <article><simpara><code>Text</code></simpara></article>
+            '/article/simpara[code="Text"]',
+        ),
+        # KBD --> USERINPUT
+        (
+            "<page><body><p><kbd>Ctrl-X</kbd></p></body></page>",
+            # <article><simpara><userinput>Ctrl-X</userinput></simpara></article>
+            '/article/simpara[userinput="Ctrl-X"]',
+        ),
+        # LITERAL --> LITERAL
+        (
+            "<page><body><p><literal>monospaced</literal></p></body></page>",
+            # <article><simpara><literal>monospaced</literal></simpara></article>
+            '/article/simpara[literal="monospaced"]',
+        ),
+        # SAMP --> COMPUTEROUTPUT
+        (
+            "<page><body><p><samp>Error 42</samp></p></body></page>",
+            # <article><simpara><computeroutput>Error 42</computeroutput></simpara></article>
+            '/article/simpara[computeroutput="Error 42"]',
         ),
         # SPAN --> PHRASE
         (

--- a/src/moin/converters/_tests/test_html_in.py
+++ b/src/moin/converters/_tests/test_html_in.py
@@ -237,11 +237,6 @@ class TestConverter(Base):
             '/page/body/p/emphasis[text()="alternate voice"][@html-tag="i"]',
         ),
         (
-            "<html><p><kbd>Ctrl-X</kbd></p></html>",
-            # <page><body><span html-tag="kbd">Ctrl-X</span></body></page>
-            '/page/body/p/span[text()="Ctrl-X"][@html-tag="kbd"]',
-        ),
-        (
             "<html><p><mark>highlight</mark></p></html>",
             # <page><body><u html-tag="mark">highlight</u></body></page>
             '/page/body/p/u[text()="highlight"][@html-tag="mark"]',
@@ -293,9 +288,14 @@ class TestConverter(Base):
             '/page/body/div[code="Code"]',
         ),
         (
+            "<html><p><kbd>Ctrl-X</kbd></p></html>",
+            # <page><body><kbd>Ctrl-X</kbd></body></page>
+            '/page/body/p[kbd="Ctrl-X"]',
+        ),
+        (
             "<html><div><samp>Code</samp></div></html>",
-            # <page><body><div><code>Code</code></div></body></page>
-            '/page/body/div[code="Code"]',
+            # <page><body><div><samp>Code</samp></div></body></page>
+            '/page/body/div[samp="Code"]',
         ),
         (
             "<html><pre>Code</pre></html>",
@@ -304,8 +304,13 @@ class TestConverter(Base):
         ),
         (
             "<html><p><tt>Code</tt></p></html>",
-            # <page><body><p><code>Code</code></p></body></page>
-            '/page/body/p[code="Code"]',
+            # <page><body><p><literal>Code</literal></p></body></page>
+            '/page/body/p[literal="Code"]',
+        ),
+        (
+            '<html><p><span class="monospaced">Literal</span></p></html>',
+            # <page><body><p><literal>Literal</literal></p></body></page>
+            '/page/body/p[literal="Literal"]',
         ),
     ]
 

--- a/src/moin/converters/_tests/test_html_in_out.py
+++ b/src/moin/converters/_tests/test_html_in_out.py
@@ -148,9 +148,10 @@ class TestConverter(Base):
 
     data = [
         ("<html><div><code>Code</code></div></html>", '/div/div[code="Code"]'),
-        ("<html><div><samp>Code</samp></div></html>", '/div/div[code="Code"]'),
-        ("<html><pre>Code</pre></html>", '/div[pre="Code"]'),
-        ("<html><p><tt>Code</tt></p></html>", '/div/p[code="Code"]'),
+        ("<html><div><kbd>Ctrl-X</kbd></div></html>", '/div/div[kbd="Ctrl-X"]'),
+        ("<html><div><samp>Error 303</samp></div></html>", '/div/div[samp="Error 303"]'),
+        ("<html><pre>Code\n  Block</pre></html>", '/div[pre="Code\n  Block"]'),
+        ("<html><p><tt>Monospace</tt></p></html>", '/div/p/span[@class="monospaced"][text()="Monospace"]'),
     ]
 
     @pytest.mark.parametrize("input,xpath", data)

--- a/src/moin/converters/_tests/test_markdown_in.py
+++ b/src/moin/converters/_tests/test_markdown_in.py
@@ -75,10 +75,14 @@ class TestConverter:
         ('<span class="moin-small">smaller</span>', '<div><p><span html:class="moin-small">smaller</span></p></div>'),
         ("<sub>sub</sub>script", "<div><p><sub>sub</sub>script</p></div>"),
         ("<sup>super</sup>script", "<div><p><sup>super</sup>script</p></div>"),
+        ("<code>Code</code>", "<div><p><code>Code</code></p></div>"),
         ("<em>Emphasis</em>", "<div><p><emphasis>Emphasis</emphasis></p></div>"),
         ("<i>alternate voice</i>", '<div><p><emphasis html-tag="i">alternate voice</emphasis></p></div>'),
         ("<u>underline</u>", "<div><p><u>underline</u></p></div>"),
         ("<ins>inserted</ins>", "<div><p><ins>inserted</ins></p></div>"),
+        ("<kbd>Ctrl-X</kbd>", "<div><p><kbd>Ctrl-X</kbd></p></div>"),
+        ("<samp>Error 33</samp>", "<div><p><samp>Error 33</samp></p></div>"),
+        ("<tt>literal</tt>", "<div><p><literal>literal</literal></p></div>"),
         ("<del>deleted</del>", "<div><p><del>deleted</del></p></div>"),
         ("<s>no longer accurate</s>", "<div><p><s>no longer accurate</s></p></div>"),
         # the <strike> tag is deprecated since HTML4.1!
@@ -105,7 +109,6 @@ class TestConverter:
             '<div><div><div html-tag="address">webmaster@example.org</div>\n</div></div>',
         ),
         ("<dfn>term</dfn>", '<div><p><emphasis html-tag="dfn">term</emphasis></p></div>'),
-        ("<kbd>Ctrl-X</kbd>", '<div><p><span html-tag="kbd">Ctrl-X</span></p></div>'),
         ("<small>fine print</small>", '<div><p><span html-tag="small">fine print</span></p></div>'),
     ]
 

--- a/src/moin/converters/_tests/test_markdown_in_out.py
+++ b/src/moin/converters/_tests/test_markdown_in_out.py
@@ -69,15 +69,16 @@ class TestConverter:
         "<dfn>term</dfn>",
         "<ins>inserted</ins>",
         "<del>deleted</del>",
-        "<u>annotated</u>",
-        "<s>no longer accurate</s>",
         "<kbd>Ctrl-X</kbd><",
         "see <mark>here</mark>",
         "<q>cogito ergo sum</q>",
+        "<s>no longer accurate</s>",
+        "<samp>Error 33</samp>",
         "<small>fine print</small>",
         '<span class="red" id="dwarf">star</span>',
         "<sup>super</sup>script",
         "<sub>sub</sub>script",
+        "<u>annotated</u>",
         "<var>n</var> times",
     ]
 
@@ -92,10 +93,12 @@ class TestConverter:
         ("----\n\n------\n\n--------\n", "----\n\n----\n\n----\n"),
         ("<hr>\n\n<hr>\n\n<hr>\n", "----\n\n----\n\n----\n"),
         ("line  \nbreak", "line<br />\nbreak"),
+        ("<code>Code</code>", "`Code`"),
         # we accept outdated HTML elements but map them to recommended substitute
         ("<acronym>DC</acronym>", "<abbr>DC</abbr>"),  # in HTML5, <acronym> is deprecated in favour of <abbr>
         ("<big>larger</big>\n", '<span class="moin-big">larger</span>'),  # <big> is obsolete
-        ("<strike>stroke</strike>\n", "<s>stroke</s>\n"),  # <strike> is obsolete since HTML 4.1
+        ("<strike>stroke</strike>\n", "<s>stroke</s>"),  # <strike> is obsolete since HTML 4.1
+        ("<tt>literal</tt>", '<span class="monospaced">literal</span>'),
     )
 
     @pytest.mark.parametrize("input,output", data)

--- a/src/moin/converters/_tests/test_mediawiki_in.py
+++ b/src/moin/converters/_tests/test_mediawiki_in.py
@@ -33,7 +33,7 @@ class TestConverter:
         ),
         (
             "<nowiki>no ''markup''</nowiki>\n\n<code>no ''markup''</code>\n\n<tt>no ''markup''</tt>",
-            "<page><body><p><code>no ''markup''</code></p><p><code>no ''markup''</code></p><p><code>no ''markup''</code></p></body></page>",
+            "<page><body><p><literal>no ''markup''</literal></p><p><code>no ''markup''</code></p><p><literal>no ''markup''</literal></p></body></page>",
         ),
         (
             "<pre>no ''markup'' block</pre>",

--- a/src/moin/converters/_tests/test_moinwiki_in.py
+++ b/src/moin/converters/_tests/test_moinwiki_in.py
@@ -434,18 +434,18 @@ class TestConverter:
         self.do(input, output)
 
     data = [
-        ("{{{nowiki}}}", "<page><body><p><samp>nowiki</samp></p></body></page>"),
-        ("`nowiki`", "<page><body><p><code>nowiki</code></p></body></page>"),
-        ("{{{{nowiki}}}}", "<page><body><p><samp>{nowiki}</samp></p></body></page>"),
-        ("text: {{{nowiki}}}, text", "<page><body><p>text: <samp>nowiki</samp>, text</p></body></page>"),
+        ("{{{nowiki}}}", "<page><body><p><code>nowiki</code></p></body></page>"),
+        ("`nowiki`", "<page><body><p><literal>nowiki</literal></p></body></page>"),
+        ("{{{{nowiki}}}}", "<page><body><p><code>{nowiki}</code></p></body></page>"),
+        ("text: {{{nowiki}}}, text", "<page><body><p>text: <code>nowiki</code>, text</p></body></page>"),
         ("{{{\nnowiki\n}}}", "<page><body><nowiki>3<nowiki-args></nowiki-args>nowiki</nowiki></body></page>"),
         (
             "{{{\nnowiki\nno\nwiki\n}}}",
             "<page><body><nowiki>3<nowiki-args></nowiki-args>nowiki\nno\nwiki</nowiki></body></page>",
         ),
-        ("{{{nowiki}}} {{{nowiki}}}", "<page><body><p><samp>nowiki</samp> <samp>nowiki</samp></p></body></page>"),
-        ("{{{}}}", "<page><body><p><samp></samp></p></body></page>"),
-        ("``", "<page><body><p><code></code></p></body></page>"),
+        ("{{{nowiki}}} {{{nowiki}}}", "<page><body><p><code>nowiki</code> <code>nowiki</code></p></body></page>"),
+        ("{{{}}}", "<page><body><p><code></code></p></body></page>"),
+        ("``", "<page><body><p><literal></literal></p></body></page>"),
         # XXX: Is <page> correct?
         ("{{{#!\ntest\n}}}", "<page><body><nowiki>3<nowiki-args>#!</nowiki-args>test</nowiki></body></page>"),
         (

--- a/src/moin/converters/_tests/test_moinwiki_out.py
+++ b/src/moin/converters/_tests/test_moinwiki_out.py
@@ -52,7 +52,8 @@ class TestConverter(Base):
         ("<page:strong>strong</page:strong>", "'''strong'''"),
         ("<page:emphasis>emphasis</page:emphasis>", "''emphasis''"),
         ("<page:blockcode>blockcode</page:blockcode>", "{{{\nblockcode\n}}}\n"),
-        ("<page:code>monospace</page:code>", "`monospace`"),
+        ("<page:code>code</page:code>", "{{{code}}}"),
+        ("<page:literal>monospace</page:literal>", "`monospace`"),
         ("<page:del>stroke</page:del>", "--(stroke)--"),
         ("<page:ins>underline</page:ins>", "__underline__"),
         ('<page:span html:class="moin-big">larger</page:span>', "~+larger+~"),
@@ -206,7 +207,7 @@ class TestConverter(Base):
         ),
         (
             '<page:page><page:body><page:page><page:body page:class="red solid"><page:p>This is wiki markup in a <page:strong>div</page:strong> with <page:ins>css</page:ins> <page:code>class="red solid"</page:code>.</page:p></page:body></page:page></page:body></page:page>',
-            "{{{#!wiki red/solid\nThis is wiki markup in a '''div''' with __css__ `class=\"red solid\"`.\n}}}\n",
+            "{{{{#!wiki red/solid\nThis is wiki markup in a '''div''' with __css__ {{{class=\"red solid\"}}}.\n}}}}\n",
         ),
         (
             '<page:page><page:body><page:part page:content-type="x-moin/format;name=creole"><page:arguments><page:argument page:name="style">st: er</page:argument><page:argument page:name="class">par: arg para: arga</page:argument></page:arguments><page:body>... **bold** ...</page:body></page:part></page:body></page:page>',

--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -28,7 +28,7 @@ class TestConverter:
         ("paragraph 1\n\nparagraph\n2", "<p>paragraph 1</p><p>paragraph\n2</p>"),
         ("**Text**", "<p><strong>Text</strong></p>"),
         ("*Text*", "<p><emphasis>Text</emphasis></p>"),
-        ("``Text``", "<p><code>Text</code></p>"),
+        ("``literal``", "<p><literal>literal</literal></p>"),
         ("a _`Link`", '<p>a <span id="link">Link</span></p>'),
         ("thematic\n\n~~~~~\n\nbreak", '<p>thematic</p><separator xhtml:class="moin-hr2" /><p>break</p>'),
         (".. comment", '<div class="comment dashed">comment</div>'),
@@ -44,8 +44,8 @@ class TestConverter:
         # standard roles:
         (":abbreviation:`abbr.`", '<p><span html-tag="abbr">abbr.</span></p>'),
         (":ac:`DC`", '<p><span html-tag="abbr">DC</span></p>'),
-        (r":code:`y = exp(x)`", r'<p><code xhtml:class="code">y = exp(x)</code></p>'),
-        (r":literal:`% \ `", "<p><code>% </code></p>"),
+        (r":code:`y = exp(x)`", r"<p><code>y = exp(x)</code></p>"),
+        (r":literal:`% \ `", "<p><literal>% </literal></p>"),
         (r":math:`\sin(x)`", r"<p>\sin(x)</p>"),  # TODO: properly support mathematical content
         (":RFC:`1234`", '<p><a xlink:href="https://tools.ietf.org/html/rfc1234.html">RFC 1234</a></p>'),
         (":PEP:`01`", '<p><a xlink:href="https://peps.python.org/pep-0001">PEP 01</a></p>'),
@@ -62,11 +62,11 @@ class TestConverter:
         (".. role:: q\n\n:q:`inline quote`", "<p><quote>inline quote</quote></p>"),
         # custom roles with matching HTML element
         (".. role:: dfn\n\n:dfn:`term`", '<p><emphasis html-tag="dfn">term</emphasis></p>'),
-        (".. role:: kbd(literal)\n\nEnter :kbd:`Ctrl-X`", '<p>Enter <span html-tag="kbd">Ctrl-X</span></p>'),
-        (".. role:: samp(literal)\n\n:samp:`Error 303`", '<p><span html-tag="samp">Error 303</span></p>'),
+        (".. role:: kbd(literal)\n\nEnter :kbd:`Ctrl-X`", "<p>Enter <kbd>Ctrl-X</kbd></p>"),
+        (".. role:: samp(literal)\n\n:samp:`Error 303`", "<p><samp>Error 303</samp></p>"),
         (  # custom role derived from "code" with syntax highlight
             '.. role:: python(code)\n   :language: python\n\nInline code like :python:`print(3*"Hurra!")`.',
-            '<p>Inline code like <code xhtml:class="code python">'
+            '<p>Inline code like <code xhtml:class="python">'
             '<span xhtml:class="nb">print</span><span xhtml:class="p">(</span>'
             '<span xhtml:class="mi">3</span><span xhtml:class="o">*</span>'
             '<span xhtml:class="s2">"Hurra!"</span><span xhtml:class="p">)</span>'

--- a/src/moin/converters/creole_in.py
+++ b/src/moin/converters/creole_in.py
@@ -416,7 +416,7 @@ class Converter(ConverterMacro):
     """
 
     def inline_nowiki_repl(self, stack, nowiki, nowiki_text):
-        stack.top_append(moin_page.code(children=(nowiki_text,)))
+        stack.top_append(moin_page.literal(children=(nowiki_text,)))
 
     inline_object = r"""
         (?P<object>

--- a/src/moin/converters/docbook_in.py
+++ b/src/moin/converters/docbook_in.py
@@ -310,7 +310,6 @@ class Converter:
         "termdef",
         "type",
         "uri",
-        "userinput",
         "wordasword",
         "varname",
         "anchor",
@@ -379,12 +378,12 @@ class Converter:
     # DocBook tags which can be convert directly to a DOM Tree element
     simple_tags: Final = {
         "code": moin_page.code,
-        "computeroutput": moin_page.code,
+        "computeroutput": moin_page.samp,
         "glossdef": moin_page("list-item-body"),
         "glossentry": moin_page("list-item"),
         "glosslist": moin_page("list"),
         "glossterm": moin_page("list-item-label"),
-        "literal": moin_page.code,
+        "literal": moin_page.literal,
         "markup": moin_page.code,
         "para": moin_page.p,
         "phrase": moin_page.span,
@@ -401,6 +400,7 @@ class Converter:
         "tfoot": moin_page("table-footer"),
         "tbody": moin_page("table-body"),
         "tr": moin_page("table-row"),
+        "userinput": moin_page.kbd,
         "variablelist": moin_page("list"),
         "varlistentry": moin_page("list-item"),
     }

--- a/src/moin/converters/docbook_out.py
+++ b/src/moin/converters/docbook_out.py
@@ -43,11 +43,14 @@ class Converter:
     # DOM tree elements that can be easily converted into a DocBook
     # element, without attributes.
     simple_tags = {
-        "code": docbook.literal,
+        "code": docbook.code,
         "emphasis": docbook.emphasis,
+        "kbd": docbook.userinput,
         "list-item": docbook.varlistentry,
         "list-item-label": docbook.term,
+        "literal": docbook.literal,
         "quote": docbook.quote,
+        "samp": docbook.computeroutput,
         "sub": docbook.subscript,
         "sup": docbook.superscript,
     }

--- a/src/moin/converters/html_in.py
+++ b/src/moin/converters/html_in.py
@@ -65,7 +65,21 @@ class HtmlTags:
     html_namespace: Final = {html.namespace: "xhtml"}
 
     # HTML tags which can be converted directly to the moin_page namespace
-    symmetric_tags: Final = {"blockquote", "code", "del", "div", "ins", "p", "s", "span", "strong", "sub", "sup", "u"}
+    symmetric_tags: Final = {
+        "blockquote",
+        "code",
+        "del",
+        "div",
+        "ins",
+        "kbd",
+        "p",
+        "s",
+        "samp",
+        "strong",
+        "sub",
+        "sup",
+        "u",
+    }
 
     # HTML tags that define a list; except dl, which is a little bit different
     list_tags: Final = {"ul", "dir", "ol"}
@@ -80,8 +94,7 @@ class HtmlTags:
         "br": moin_page.line_break,
         # Code and Blockcode
         "pre": moin_page.blockcode,
-        "tt": moin_page.code,  # deprecated
-        "samp": moin_page.code,  # computer output sample
+        "tt": moin_page.literal,  # deprecated, output as <span class="monospaced">
         # Lists
         "dt": moin_page.list_item_label,
         "dd": moin_page.list_item_body,
@@ -102,7 +115,6 @@ class HtmlTags:
         "cite": moin_page.emphasis,  # title of a creative work
         "dfn": moin_page.emphasis,  # defining instance of a term
         "i": moin_page.emphasis,  # alternate voice
-        "kbd": moin_page.span,  # user input;  TODO: use moin_page.code?
         "mark": moin_page.u,  # marked or highlighted for reference purposes
         "small": moin_page.span,  # side comment (small print)
         "var": moin_page.emphasis,  # variable
@@ -590,6 +602,13 @@ class Converter(HtmlTags):
         """
         list_item_body = ET.Element(moin_page.list_item_body, attrib={}, children=self.do_children(element))
         return ET.Element(moin_page.list_item, attrib={}, children=[list_item_body])
+
+    def visit_xhtml_span(self, element):
+        element_type = moin_page.span
+        html_class = element.get(html.class_, "")
+        if "monospaced" in html_class:
+            element_type = moin_page.literal
+        return self.new_copy(element_type, element, attrib={})
 
     def visit_xhtml_table(self, element):
         attrib = self.convert_attributes(element)

--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -343,6 +343,9 @@ class Converter:
     def visit_moinpage_ins(self, elem):
         return self.new_copy(html.ins, elem)
 
+    def visit_moinpage_kbd(self, elem):
+        return self.new_copy(html.kbd, elem)
+
     def visit_moinpage_line_break(self, elem):
         # TODO: attributes?
         return html.br()
@@ -428,6 +431,11 @@ class Converter:
                 elif item.tag.name == "list-item-body":
                     ret.append(self.new_copy(html.dd, item))
         return ret
+
+    def visit_moinpage_literal(self, elem):
+        """Inline literal text (user input, computer output, etc.)."""
+        attrib = {html.class_: "monospaced"}
+        return self.new_copy(html.span, elem, attrib)
 
     def eval_object_type(self, mimetype, href):
         """

--- a/src/moin/converters/mediawiki_in.py
+++ b/src/moin/converters/mediawiki_in.py
@@ -7,6 +7,12 @@
 
 """
 MoinMoin - MediaWiki input converter.
+
+Mediawiki syntax is documented at
+https://www.mediawiki.org/wiki/Help:Formatting
+
+Supported HTML tags are listed at
+https://www.mediawiki.org/wiki/Help:HTML_in_wikitext
 """
 
 from __future__ import annotations
@@ -760,13 +766,13 @@ class Converter(ConverterMacro):
 
         if nowiki_text is not None:
             text = nowiki_text
-            stack.top_append(moin_page.code(children=[text]))
+            stack.top_append(moin_page.literal(children=[text]))
         elif nowiki_text_code is not None:
             text = nowiki_text_code
             stack.top_append(moin_page.code(children=[text]))
         elif nowiki_text_tt is not None:
             text = nowiki_text_tt
-            stack.top_append(moin_page.code(children=[text]))
+            stack.top_append(moin_page.literal(children=[text]))
         # Remove empty backtick nowiki samples
         elif nowiki_text_pre:
             # TODO: pre_args parsing

--- a/src/moin/converters/moinwiki_in.py
+++ b/src/moin/converters/moinwiki_in.py
@@ -841,10 +841,10 @@ class Converter(ConverterMacro):
 
     def inline_nowiki_repl(self, stack, nowiki, nowiki_text=None, nowiki_text_backtick=None):
         if nowiki_text is not None:
-            return stack.top_append(moin_page.samp(children=[nowiki_text]))
+            return stack.top_append(moin_page.code(children=[nowiki_text]))
         # we must pass empty strings for moinwiki in > out conversions (@``DATE@ must not be converted to @DATE@)
         elif nowiki_text_backtick is not None:
-            return stack.top_append(moin_page.code(children=[nowiki_text_backtick]))
+            return stack.top_append(moin_page.literal(children=[nowiki_text_backtick]))
 
     inline_object = r"""
         (?P<object>

--- a/src/moin/converters/moinwiki_out.py
+++ b/src/moin/converters/moinwiki_out.py
@@ -48,12 +48,12 @@ class Moinwiki:
     a_close = "]]"
     verbatim_open = "{"  # * 3
     verbatim_close = "}"  # * 3
-    monospace = "`"
+    literal = "`"
     strong = "'''"
     emphasis = "''"
     underline = "__"
-    samp_open = "{{{"  # 3 brackets is only option for inline
-    samp_close = "}}}"
+    code_open = "{{{"  # 3 brackets is only option for inline
+    code_close = "}}}"
     stroke_open = "--("
     stroke_close = ")--"
     table_marker = "||"
@@ -260,10 +260,8 @@ class Converter:
         return "\n\n" + "\n".join(indented) + "\n\n"
 
     def open_moinpage_code(self, elem):
-        ret = Moinwiki.monospace
-        ret += "".join(elem.itertext())
-        ret += Moinwiki.monospace
-        return ret
+        # text {{{more text}}} end
+        return f'{Moinwiki.code_open}{"".join(elem.itertext())}{Moinwiki.code_close}'
 
     def open_moinpage_div(self, elem):
         childrens_output = self.open_children(elem)
@@ -287,6 +285,10 @@ class Converter:
         ret += "".join(elem.itertext())
         ret += f" {Moinwiki.h * level}\n"
         return "\n" + ret
+
+    def open_moinpage_kbd(self, elem):
+        # there is no specific markup for user input (<kbd>)
+        self.open_moinpage_literal()
 
     def open_moinpage_line_break(self, elem):
         return Moinwiki.linebreak
@@ -335,6 +337,10 @@ class Converter:
             ret = "\n"
         ret += " " * (len("".join(self.list_item_labels[:-1])) + len(self.list_item_labels[:-1])) + self.list_item_label
         return ret + self.open_children(elem)
+
+    def open_moinpage_literal(self, elem):
+        # Inline text that is some literal value. Typically set in monospace
+        return f'{Moinwiki.literal}{"".join(elem.itertext())}{Moinwiki.literal}'
 
     def open_moinpage_note(self, elem):
         class_ = elem.get(moin_page.note_class, "")
@@ -540,11 +546,8 @@ class Converter:
         return ret
 
     def open_moinpage_samp(self, elem):
-        # text {{{more text}}} end
-        ret = Moinwiki.samp_open
-        ret += "".join(elem.itertext())
-        ret += Moinwiki.samp_close
-        return ret
+        # there is no specific markup for computer output (<samp>)
+        self.open_moinpage_literal()
 
     def open_moinpage_separator(self, elem, hr_class_prefix="moin-hr"):
         hr_ending = "\n"

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -503,12 +503,11 @@ class NodeVisitor:
 
     def visit_inline(self, node):
         # <inline> element class values that indicate specific HTML tags
-        symmetric_tags = {"del", "ins", "s", "samp", "u"}
+        symmetric_tags = {"del", "ins", "kbd", "s", "samp", "u"}
         indirect_tags = {
             "b": moin_page.strong,
             "dfn": moin_page.emphasis,
             "i": moin_page.emphasis,
-            "kbd": moin_page.code,
             "mark": moin_page.u,
             "small": moin_page.span,
             "var": moin_page.emphasis,
@@ -575,13 +574,13 @@ class NodeVisitor:
         # some class values indicate a matching HTML element:
         classes = node["classes"]
         for tag in classes:
-            if tag in ("kbd", "samp"):
+            if tag in ("code", "kbd", "samp"):
                 classes.remove(tag)
-                moin_node = moin_page.span(attrib={moin_page("html-tag"): tag})
+                moin_node_type = getattr(moin_page, tag)
                 break
         else:
-            moin_node = moin_page.code()
-        self.open_moin_page_node(moin_node, node)
+            moin_node_type = moin_page.literal
+        self.open_moin_page_node(moin_node_type(), node)
 
     def depart_literal(self, node):
         self.close_moin_page_node()

--- a/src/moin/converters/rst_out.py
+++ b/src/moin/converters/rst_out.py
@@ -226,7 +226,7 @@ class ReST:
 
     a_separator = "|"
     verbatim = "::"
-    monospace = "``"
+    literal = "``"
     strong = "**"
     emphasis = "*"
     p = "\n"
@@ -429,7 +429,7 @@ class Converter:
         )
 
     def open_moinpage_code(self, elem):
-        ret = "{}{}{}".format(ReST.monospace, "".join(elem.itertext()), ReST.monospace)
+        ret = "{}{}{}".format(ReST.literal, "".join(elem.itertext()), ReST.literal)
         return ret
 
     def open_moinpage_div(self, elem):


### PR DESCRIPTION
Use 4 internal element types for "monospace"-styled inline elements. (Add "literal" and "kbd" to the already existing "code" and "samp".)

~~~
=========  =========  =============  ============  ================
           generic    source code    user input    computer output
=========  =========  =============  ============  ================
DocBook    <literal>  <code>         <userinput>   <computeroutput>

HTML       <tt>¹      <code>         <kbd>         <samp>

MediaWiki  <tt>¹      <code>         <kbd>         <samp>

Markdown   <tt>¹      ` … `          <kbd>         <samp>

MoinWiki   ` … `      {{{ … }}}      n/a           n/a

rST        `` … ``    ``:code:`…```  ``:kbd:`…```  ``:samp:`…```

Creole     {{{ … }}}  n/a            n/a           n/a
=========  =========  =============  ============  ================

¹ The HTML tag <tt> is deprecated.
  Moin recognizes <tt> but writes <span class="monospaced">.
  A rule in ``common.css`` sets the content in a monospaced font.
~~~
Attention: changed/fixed semantics

`<moinpage:code>`: "generic mono" -> "source code" (as in HTML and DocBook)

MoinWiki Markup `{{{something}}}`: "computer output" --> "source code".