### PR TITLE
Fix markdown parser crash on emphasized text inside HTML tags

### DIFF
--- a/src/moin/converters/_tests/test_markdown_in.py
+++ b/src/moin/converters/_tests/test_markdown_in.py
@@ -241,6 +241,27 @@ class TestConverter:
         """Test embedded markup in markdown"""
         self.do(input, output)
 
+    data = [
+        # Original issue #1838: emphasis inside <del> in a list item
+        (
+            "* <del>Deleted list item with _emphasized text_</del>",
+            '<list item-label-generate="unordered"><list-item><list-item-body>'
+            "<del>Deleted list item with <emphasis>emphasized text</emphasis></del>"
+            "</list-item-body></list-item></list>",
+        ),
+        # <ins> with emphasis
+        ("<ins>Inserted with _emphasis_</ins>", "<p><ins>Inserted with <emphasis>emphasis</emphasis></ins></p>"),
+        # <kbd> with strong
+        ("<kbd>Press **Ctrl+C**</kbd>", "<p><kbd>Press <strong>Ctrl+C</strong></kbd></p>"),
+        # <del> without markdown (should still work - regression check)
+        ("<del>deleted</del>", "<div><p><del>deleted</del></p></div>"),
+    ]
+
+    @pytest.mark.parametrize("input,output", data)
+    def test_html_with_markdown_emphasis(self, input, output):
+        """Test HTML tags containing markdown inline markup (issue #1838)"""
+        self.do(input, output)
+
     def serialize_strip(self, elem, **options):
         result = serialize(elem, namespaces=self.namespaces, **options)
         return self.output_re.sub("", result)


### PR DESCRIPTION
## Summary
- Fixes #1838: `IndexError: pop from empty list` when markdown like `* <del>Deleted list item with _emphasized text_</del>` is rendered
- Adds a reassembly step that detects HTML tags split by markdown's inline pattern processor and wraps the fragments + intervening elements into proper DOM nodes before `convert_embedded_markup` processes them
- Adds test cases for `<del>`, `<ins>`, and `<kbd>` with inline markdown emphasis/strong, plus a regression test for non-split HTML tags

## Test plan
- [x] All 63 markdown_in tests pass (including 4 new tests)
- [x] All 71 markdown roundtrip tests pass
- [x] All 1132 converter tests pass with 0 regressions