### PR TITLE
Index form: fix wrong label texts generated for content-type filtering

### DIFF
--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -1478,7 +1478,7 @@ def jfu_server(item_name):
 def contenttype_selects_gen():
     for g in content_registry.group_names:
         description = ", ".join([e.display_name for e in content_registry.groups[g]])
-        yield g, None, description
+        yield g, L_(g), description
     yield "Unknown Items", None, "Items of contenttype unknown to MoinMoin"
 
 

--- a/src/moin/templates/forms.html
+++ b/src/moin/templates/forms.html
@@ -149,7 +149,7 @@ See utils.html for more macros.
     {%- for value, label, description in field.member_schema.properties['choice_specs'] %}
         <li>
             {{ raw_input(field, 'checkbox', value=value) }}
-            {{ gen.label(field) }}
+            {{ gen.label(field, value=value, contents=label or value) }}
             {%- if description %}
                 <span class="helper-text">
                     {{ description }}


### PR DESCRIPTION
The form content before the changes in the PR applied:

<img width="1002" height="435" alt="image" src="https://github.com/user-attachments/assets/5d5e0739-f3a5-4a3c-8056-71959fe92700" />

with HTML looking like

<img width="818" height="269" alt="image" src="https://github.com/user-attachments/assets/0313a742-5d69-4ef2-a97c-2260a6346a77" />
