### PR TITLE
wikiutil.py: handle NotFound exception for invalid url path

### DIFF
--- a/src/moin/_tests/test_wikiutil.py
+++ b/src/moin/_tests/test_wikiutil.py
@@ -145,6 +145,8 @@ def test_file_headers():
         ("+history/users/roland", WikiLinkInfo(True, "frontend.history", "users/roland")),
         # internal global link (not linking to a wiki item)
         ("all", WikiLinkInfo(True, "frontend.global_views", None, True)),
+        # link with invalid path
+        ("invalid_path///", WikiLinkInfo(False)),
         # link without matching moin route
         ("+invalid/help", WikiLinkInfo(False)),
         # external link

--- a/src/moin/wikiutil.py
+++ b/src/moin/wikiutil.py
@@ -18,6 +18,7 @@ import os
 import urllib
 
 from flask import current_app as app
+from werkzeug.exceptions import NotFound
 from werkzeug.routing.exceptions import NoMatch, RoutingException
 
 from moin.constants.misc import URI_SCHEMES
@@ -173,7 +174,7 @@ class WikiLinkAnalyzer:
         try:
             # find moin rule matching link and the corresponding variable mappings
             rule, vars = self.map_adapter.match(link, return_rule=True)
-        except (NoMatch, RoutingException):
+        except (NoMatch, NotFound, RoutingException):
             return WikiLinkInfo(False)
         item_name = vars.get("item_name", None)
         if item_name and item_name.startswith("+"):


### PR DESCRIPTION
fixes a problem raised by Paul B. in the moin-devel mailing list.