### PR TITLE
move Werkzeug debugger docs from serve.rst to development.rst

### DIFF
--- a/docs/admin/serve.rst
+++ b/docs/admin/serve.rst
@@ -38,20 +38,6 @@ Stopping the built-in server
 ----------------------------
 To stop the wiki server, either press Ctrl+C or close the window.
 
-Debugging with the built-in server
-----------------------------------
-Werkzeug has a debugger that may be used to analyze tracebacks. As of version 0.11.0,
-a pin number is written to the log when the server is started::
-
-  INFO werkzeug:87  * Debugger pin code: 123-456-789
-
-The pin code must be entered once per debugging session. If you will never use the
-built-in server for public access, you may disable the pin check by adding::
-
- WERKZEUG_DEBUG_PIN=off
-
-to your OS's environment variables. See Werkzeug docs for more information.
-
 Using the built-in server for production
 ----------------------------------------
 

--- a/docs/devel/development.rst
+++ b/docs/devel/development.rst
@@ -129,14 +129,6 @@ add more tools, exercise tools
     sudo npm install -g sass  # Windows: npm install -g sass
     sass --version  # show version number to prove it works
 
-* sass fixup pending resolution of `issue #2043 <https://github.com/moinwiki/moin/issues/2043>`_,
-  missing xstatic/pkg/bootstrap/data/scss directory
-
-  - point your browser to https://github.com/twbs/bootstrap/tree/v4.5.3/scss (optional, review before downloading)
-  - modify the browser url to https://ssgithub.com/twbs/bootstrap/tree/v4.5.3/scss
-  - click the download button to save a zip file to a convenient location
-  - unzip the file to xstatic/pkg/bootstrap/data creating a scss directory as a sibling to the existing css and js directories
-
 * regenerate CSS files::
 
     ./m css  # Windows: m css
@@ -544,6 +536,22 @@ Note the test startup will be rather slow; be patient.
 .. image:: pycharmC.png
    :alt: pycharm example
    :align: left
+
+Debugging with the Werkzeug debugger
+------------------------------------
+The Werkzeug debugger requires no setup but is less powerful than PyCharm.
+
+.. warning::
+
+  Note that this debugger must only be used in a secure test environment that cannot be
+  accessed by the public!
+
+To use, just start the built-in server with the debug option::
+
+ moin run --debug
+
+See Werkzeug docs for more information.
+
 
 Documentation
 =============

--- a/src/moin/config/wikiconfig.py
+++ b/src/moin/config/wikiconfig.py
@@ -258,8 +258,8 @@ class Config(DefaultConfig):
 MOINCFG = Config  # adding MOINCFG=<path> to OS environment overrides CWD
 # Flask settings - see the flask documentation about their meaning
 SECRET_KEY = "WARNING: set this to a unique string to create secure cookies"
-DEBUG = False  # use True for development only, not for public sites!
-TESTING = False  # built-in server (./m run) ignores TESTING and DEBUG settings
+DEBUG = False  # ignored by the built-in server
+TESTING = False  # if True the built-in server will detect source file changes and restart
 # per https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options
 SESSION_COOKIE_SECURE = False  # flask default is False
 SESSION_COOKIE_HTTPONLY = True  # flask default is True


### PR DESCRIPTION
remove obsolete sass installation workaround
correct DEBUG + TESTING comments in wikiconfig.py