### PR TITLE
CSS: Fix large top/bottom margin of tables

### DIFF
--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -361,7 +361,7 @@ ul.moin-tags li.weight9 { font-size: 280%; }
 .moin-footnotes p { margin: 1em; }
 
 /* moin default table styling */
-table { margin: 1% 0; }
+table { margin: .5em 0; }
 caption { border: 1px solid var(--border); border-bottom: 0;
     background-color: var(--bg-heading); font-size: 1.25em; font-weight: bold; }
 tr > th,


### PR DESCRIPTION
Margin using percentage value depends on the inline size of the containing block. With relatively wide content layout the margins get too too large.

Fixes issue #2225.