### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/src/moin/auth/http.py
+++ b/src/moin/auth/http.py
@@ -47,7 +47,7 @@ class HTTPAuthMoin(BaseAuth):
 
         auth = request.authorization
         if auth and auth.username and auth.password is not None:
-            logging.debug(f"http basic auth, received username: {auth.username!r} password: {auth.password!r}")
+            logging.debug(f"http basic auth, received username: {auth.username!r}")
             u = user.User(
                 name=auth.username, password=auth.password, auth_method=self.name, auth_attribs=[], trusted=self.trusted
             )

--- a/src/moin/converters/highlight.py
+++ b/src/moin/converters/highlight.py
@@ -63,7 +63,11 @@ class Converter:
 
     def __init__(self, regex):
         """Treat each word separately and ignore case sensitivity."""
-        self.pattern = re.compile(regex.replace(" ", "|"), re.IGNORECASE)
+        words = [re.escape(word) for word in regex.split()]
+        if not words:
+            self.pattern = re.compile(r"$^")
+            return
+        self.pattern = re.compile("|".join(words), re.IGNORECASE)
 
     def __call__(self, tree: Any) -> Any | None:
         self.recurse(tree)


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `src/moin/auth/http.py:L49`

The HTTP authentication handler logs both username and password at debug level. Even if debug logging is not always enabled, this can expose credentials in log files, log aggregation systems, or crash reports when enabled in production troubleshooting.

## Solution

Never log raw passwords. Remove the password from log messages and, if needed, log only minimal metadata (e.g., username or authentication attempt result). Example: `logging.debug("http basic auth, received username: %r", auth.username)`.

## Changes

- `src/moin/auth/http.py` (modified)
- `src/moin/converters/highlight.py` (modified)