### PR TITLE
CSS: Limit .moin-transclusion children max-width so large images, videos, etc. don't break out of layout

### DIFF
--- a/docs/user/moinwiki.rst
+++ b/docs/user/moinwiki.rst
@@ -254,6 +254,8 @@ else is ignored) to be added as attributes in the HTML, however
 one can, add anything to the query URL using ``&``, like ``&w``
 in the example above.
 
+Transcluded images and videos are resized to fit within layout by default. If you wish to see full-sized file, follow the resource link which can be provided by wiki editor on page or found in Transclusion tab.
+
 Most browsers will display a large blank space when a web page using
 an https protocol is transcluded into a page using http protocol.
 Transcluding a png image using an https protocol into an http protocol

--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -226,7 +226,7 @@ a.moin-nonexistent object {  background: var(--bg-disabled);  border: 3px dashed
 /* end of transclusion positioning */
 
 /* transclusion wrapper overlays */
-.moin-transclusion { max-width: 100%; }
+.moin-transclusion > * { max-width: 100%; }
 .moin-item-wrapper { position: relative; display: inline-block; }
 div.moin-item-wrapper { /* force bottom border of transcluded headings to extend across entire page */ width: 100%; }
 div.moin-item-wrapper,


### PR DESCRIPTION
# Pull request description

This pull requests adds `max-width: 100%` property to all children of `.moin-transclusion` class in `static/common.css`.
It limits images, video, etc. width to layout size (parent div) in case `width` attribute is higher.

Updates corresponding docs.

Fixes #1909.

## Tested markdown

- [x] MoinMoin
- [x] WikiCreole
- [ ] MediaWiki
- [ ] ReST
- [x] Markdown
- [ ] HTML
- [ ] DocBook

## Tested styles
- [x] Basic
- [x] Focus
- [x] Modernized
- [x] Topside
- [ ] Topside CMS

# Additional notes
Due to lack of experience with the project not all markdown types were tested successfully, so I kindly ask more experienced participants to double-check before merging changes into master branch