### PR TITLE
MediaWiki-In Converter: fix handling of media links to local files (images, videos)

### DIFF
--- a/src/moin/converters/_tests/test_mediawiki_in.py
+++ b/src/moin/converters/_tests/test_mediawiki_in.py
@@ -10,12 +10,13 @@ import pytest
 
 from . import serialize, XMLNS_RE
 
-from moin.utils.tree import moin_page, xlink
+from moin.utils.tree import html, moin_page, xinclude, xlink
 from moin.converters.mediawiki_in import Converter
 
 
 class TestConverter:
-    namespaces = {moin_page.namespace: "", xlink.namespace: "xlink"}
+
+    namespaces = {moin_page.namespace: "", html.namespace: "html", xinclude.namespace: "xi", xlink.namespace: "xlink"}
 
     output_re = XMLNS_RE
 
@@ -184,58 +185,59 @@ Apple
     def test_table(self, input, output):
         self.do(input, output)
 
-    data = [
-        ("[[SomeLink]]", '<page><body><p><a xlink:href="wiki.local:SomeLink">SomeLink</a></p></body></page>'),
-        ("[http://external.link]", '<page><body><p><a xlink:href="http://external.link"></a></p></body></page>'),
-        (
-            "[http://external.link alt text]",
-            '<page><body><p><a xlink:href="http://external.link">alt text</a></p></body></page>',
-        ),
-        (
-            "[[SomeLink|Some text]]",
-            '<page><body><p><a xlink:href="wiki.local:SomeLink">Some text</a></p></body></page>',
-        ),
-        (
-            "[[SomeLink|arg1=value|arg2=otherval|Some text]]",
-            '<page><body><p><a xlink:href="wiki.local:SomeLink?arg1=value&amp;arg2=otherval">Some text</a></p></body></page>',
-        ),
-        (
-            "[[File:Test.jpg|test]]",
-            '<page><body><p><object alt="test" xlink:href="wiki.local:Test.jpg?do=get">test</object></p></body></page>',
-        ),
-        (
-            "[[File:MyImage.png]]",
-            '<page><body><p><object alt="MyImage.png" xlink:href="wiki.local:MyImage.png?do=get">MyImage.png</object></p></body></page>',
-        ),
-        (
-            "[[File:MyImage.png|arg=http://google.com|caption]]",
-            '<page><body><p><object alt="caption" xlink:href="wiki.local:MyImage.png?arg=http%253A%252F%252Fgoogle.com&amp;do=get">caption</object></p></body></page>',
-        ),
-        (
-            "[[File:Test.png|do=get|arg1=test|arg2=something else]]",
-            '<page><body><p><object alt="Test.png" xlink:href="wiki.local:Test.png?do=get&amp;arg1=test&amp;arg2=something+else">Test.png</object></p></body></page>',
-        ),
-        # The do=xxx part is just to test if do in args is being updated correctly, it's invalid otherwise
-        (
-            "[[File:Test2.png|do=xxx|caption|arg1=test]]",
-            '<page><body><p><object alt="caption" xlink:href="wiki.local:Test2.png?do=xxx&amp;arg1=test">caption</object></p></body></page>',
-        ),
-        (
-            "[[File:myimg.png|'Graph showing width |= k for 5 < k < 10']]",
-            '<page><body><p><object alt="Graph showing width |= k for 5 &lt; k &lt; 10" xlink:href="wiki.local:myimg.png?do=get">Graph showing width |= k for 5 &lt; k &lt; 10</object></p></body></page>',
-        ),
-        (
-            "[[File:myimg.png|arg1='longish caption value with |= to test'|arg2=other|test stuff]]",
-            '<page><body><p><object alt="test stuff" xlink:href="wiki.local:myimg.png?arg1=longish+caption+value+with+%257C%253D+to+test&amp;arg2=other&amp;do=get">test stuff</object></p></body></page>',
-        ),
-        # Unicode test
-        (
-            "[[File:Test.jpg|\xe8]]",
-            '<page><body><p><object alt="\xe8" xlink:href="wiki.local:Test.jpg?do=get">\xe8</object></p></body></page>',
-        ),
-    ]
-
-    @pytest.mark.parametrize("input,output", data)
+    @pytest.mark.parametrize(
+        "input,output",
+        [
+            ("[[SomeLink]]", '<page><body><p><a xlink:href="wiki.local:SomeLink">SomeLink</a></p></body></page>'),
+            ("[http://external.link]", '<page><body><p><a xlink:href="http://external.link"></a></p></body></page>'),
+            (
+                "[http://external.link alt text]",
+                '<page><body><p><a xlink:href="http://external.link">alt text</a></p></body></page>',
+            ),
+            (
+                "[[SomeLink|Some text]]",
+                '<page><body><p><a xlink:href="wiki.local:SomeLink">Some text</a></p></body></page>',
+            ),
+            (
+                "[[SomeLink|arg1=value|arg2=otherval|Some text]]",
+                '<page><body><p><a xlink:href="wiki.local:SomeLink?arg1=value&amp;arg2=otherval">Some text</a></p></body></page>',
+            ),
+            (
+                "[[File:Test.jpg|test]]",
+                '<page><body><p><xi:include alt="test" xi:href="wiki.local:Test.jpg?do=get">test</xi:include></p></body></page>',
+            ),
+            (
+                "[[File:MyImage.png]]",
+                '<page><body><p><xi:include alt="MyImage.png" xi:href="wiki.local:MyImage.png?do=get">MyImage.png</xi:include></p></body></page>',
+            ),
+            (
+                "[[File:MyImage.png|arg=http://google.com|caption]]",
+                '<page><body><p><xi:include alt="caption" xi:href="wiki.local:MyImage.png?arg=http%253A%252F%252Fgoogle.com&amp;do=get">caption</xi:include></p></body></page>',
+            ),
+            (
+                "[[File:Test.png|do=get|arg1=test|arg2=something else]]",
+                '<page><body><p><xi:include alt="Test.png" xi:href="wiki.local:Test.png?do=get&amp;arg1=test&amp;arg2=something+else">Test.png</xi:include></p></body></page>',
+            ),
+            # The do=xxx part is just to test if do in args is being updated correctly, it's invalid otherwise
+            (
+                "[[File:Test2.png|do=xxx|caption|arg1=test]]",
+                '<page><body><p><xi:include alt="caption" xi:href="wiki.local:Test2.png?do=xxx&amp;arg1=test">caption</xi:include></p></body></page>',
+            ),
+            (
+                "[[File:myimg.png|'Graph showing width |= k for 5 < k < 10']]",
+                '<page><body><p><xi:include alt="Graph showing width |= k for 5 &lt; k &lt; 10" xi:href="wiki.local:myimg.png?do=get">Graph showing width |= k for 5 &lt; k &lt; 10</xi:include></p></body></page>',
+            ),
+            (
+                "[[File:myimg.png|arg1='longish caption value with |= to test'|arg2=other|test stuff]]",
+                '<page><body><p><xi:include alt="test stuff" xi:href="wiki.local:myimg.png?arg1=longish+caption+value+with+%257C%253D+to+test&amp;arg2=other&amp;do=get">test stuff</xi:include></p></body></page>',
+            ),
+            # Unicode test
+            (
+                "[[File:Test.jpg|\xe8]]",
+                '<page><body><p><xi:include alt="\xe8" xi:href="wiki.local:Test.jpg?do=get">\xe8</xi:include></p></body></page>',
+            ),
+        ],
+    )
     def test_links(self, input, output):
         self.do(input, output)
 

--- a/src/moin/converters/image_in.py
+++ b/src/moin/converters/image_in.py
@@ -42,7 +42,7 @@ class Converter:
 
     def __call__(self, rev: Revision, contenttype: str | None = None, arguments: Arguments | None = None) -> None:
         item_name = rev.item.name
-        query_keys = {"do": "get", "rev": rev.revid}
+        query_keys = {"do": ["get"], "rev": [rev.revid]}
         attrib = {}
         if arguments:
             query = arguments.keyword.get(xinclude.href)
@@ -51,7 +51,7 @@ class Converter:
                 query_keys.update(parse_qs(query.query))
             attrib = arguments.keyword
 
-        query = urlencode(query_keys, encoding=CHARSET)
+        query = urlencode(query_keys, doseq=True, encoding=CHARSET)
 
         attrib.update(
             {

--- a/src/moin/converters/mediawiki_in.py
+++ b/src/moin/converters/mediawiki_in.py
@@ -28,7 +28,7 @@ from moin import log
 from moin.constants.contenttypes import CHARSET
 from moin.constants.misc import URI_SCHEMES
 from moin.utils.iri import Iri
-from moin.utils.tree import moin_page, xlink
+from moin.utils.tree import moin_page, xinclude, xlink
 from moin.utils.mime import Type, type_moin_document
 
 from . import default_registry
@@ -676,6 +676,7 @@ class Converter(ConverterMacro):
             target = Iri(scheme="wiki.local", path=path, query=query, fragment=fragment)
             text = link_item
         else:
+            # local file link?
             if link_url and len(link_url.split(":")) > 0 and link_url.split(":")[0] == "File":
                 object_item = ":".join(link_url.split(":")[1:])
                 args = parsed_args.keyword
@@ -692,10 +693,9 @@ class Converter(ConverterMacro):
 
                 if not link_text:
                     link_text = text
-                attrib = {xlink.href: target}
-                attrib[moin_page.alt] = link_text
 
-                element = moin_page.object(attrib)
+                element = xinclude.include({xinclude.href: target, moin_page.alt: link_text})
+
                 stack.push(element)
                 if link_text:
                     self.preprocessor.push()
@@ -705,6 +705,7 @@ class Converter(ConverterMacro):
                     stack.top_append(text)
                 stack.pop()
                 return
+
             target = Iri(scheme="wiki.local", path=link_url)
             text = link_url
         if external_link_url:

--- a/src/moin/help/help-en/mediawiki.meta
+++ b/src/moin/help/help-en/mediawiki.meta
@@ -12,14 +12,15 @@
   ],
   "itemid": "cb68b5889e344c1994d6c22fd365db04",
   "itemlinks": [
-    "Home",
+    "Home"
+  ],
+  "itemtransclusions": [
     "help-common/audio.mp3",
     "help-common/cat.jpg",
     "help-common/logo.png",
     "help-common/logo.svg",
     "help-common/video.mp4"
   ],
-  "itemtransclusions": [],
   "itemtype": "default",
   "mtime": 1681742400,
   "name": [


### PR DESCRIPTION
Display linked (local) media files using img/video tag.

Fixes a bug in the Image converter causing bad query parameters.