### PR TITLE
Fix issues with Moin search

### DIFF
--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -477,6 +477,7 @@ def search():
     terms = []
     trash = request.args.get("trash", "false")
     leading_ns = ""
+
     if ajax:
         query = request.args.get("q")
         history = request.args.get("history") == "true"
@@ -494,7 +495,9 @@ def search():
     else:
         query = search_form["q"].value
         history = bool(request.values.get("history"))
+
     best_match = False
+
     # we test for query in case this is a test run
     if query and query.startswith("\\"):
         best_match = True
@@ -525,7 +528,12 @@ def search():
             qp = flaskg.storage.query_parser(
                 [NAMES, NAMENGRAM, TAGS, SUMMARY, SUMMARYNGRAM, CONTENT, CONTENTNGRAM, COMMENT], idx_name=idx_name
             )
-        q = qp.parse(query)
+        try:
+            q = qp.parse(query)
+        except Exception:
+            flash(_("""QueryError: invalid search term: {search_term}""").format(search_term=query), "error")
+            return render_template("search.html", query=query, medium_search_form=search_form, item_name=item_name)
+
         if trash == "false":
             q = And([q, Not(Term(TRASH, True))])
         if namespaces:
@@ -555,9 +563,13 @@ def search():
             except QueryError:
                 flash(_("""QueryError: invalid search term: {search_term}""").format(search_term=q), "error")
                 return render_template("search.html", query=query, medium_search_form=search_form, item_name=item_name)
+            except re.PatternError:
+                flash(_("""QueryError: invalid regex in search term: {search_term}""").format(search_term=q), "error")
+                return render_template("search.html", query=query, medium_search_form=search_form, item_name=item_name)
             except TermNotFound:
                 flash(_("""TermNotFound: field is not indexed: {search_term}""").format(search_term=q), "error")
                 return render_template("search.html", query=query, medium_search_form=search_form, item_name=item_name)
+
             flaskg.clock.stop("search")
 
             if best_match and results:

--- a/src/moin/converters/highlight.py
+++ b/src/moin/converters/highlight.py
@@ -12,8 +12,6 @@ from typing import Any, TYPE_CHECKING
 
 import re
 
-from flask import request
-
 from moin.utils.mime import type_moin_document
 from moin.utils.tree import html, moin_page
 
@@ -28,9 +26,7 @@ class Converter:
 
     @classmethod
     def _factory(cls, input: Type, output: Type, highlight: str = "", regex: str = "", **kwargs: Any) -> Self | None:
-        if highlight == "highlight":
-            regex = request.args["regex"]
-            return cls(regex)
+        return cls(regex) if highlight == "highlight" else None
 
     def recurse(self, elem):
         new_childs = []
@@ -61,8 +57,8 @@ class Converter:
         if len(new_childs) > len(elem):
             elem[:] = new_childs
 
-    def __init__(self, regex):
-        """Treat each word separately and ignore case sensitivity."""
+    def __init__(self, regex: str) -> None:
+        # Treat each word separately and ignore case sensitivity.
         self.pattern = re.compile(regex.replace(" ", "|"), re.IGNORECASE)
 
     def __call__(self, tree: Any) -> Any | None:

--- a/src/moin/converters/highlight.py
+++ b/src/moin/converters/highlight.py
@@ -28,6 +28,14 @@ class Converter:
     def _factory(cls, input: Type, output: Type, highlight: str = "", regex: str = "", **kwargs: Any) -> Self | None:
         return cls(regex) if highlight == "highlight" else None
 
+    def __init__(self, regex: str) -> None:
+        # Treat each word separately and ignore case sensitivity.
+        self.pattern = re.compile(regex.replace(" ", "|"), re.IGNORECASE)
+
+    def __call__(self, tree: Any) -> Any | None:
+        self.recurse(tree)
+        return tree
+
     def recurse(self, elem):
         new_childs = []
 
@@ -56,14 +64,6 @@ class Converter:
         # Use inline replacement to avoid a complete tree copy
         if len(new_childs) > len(elem):
             elem[:] = new_childs
-
-    def __init__(self, regex: str) -> None:
-        # Treat each word separately and ignore case sensitivity.
-        self.pattern = re.compile(regex.replace(" ", "|"), re.IGNORECASE)
-
-    def __call__(self, tree: Any) -> Any | None:
-        self.recurse(tree)
-        return tree
 
 
 default_registry.register(Converter._factory, type_moin_document, type_moin_document)

--- a/src/moin/converters/highlight.py
+++ b/src/moin/converters/highlight.py
@@ -29,8 +29,12 @@ class Converter:
         return cls(regex) if highlight == "highlight" else None
 
     def __init__(self, regex: str) -> None:
-        # Treat each word separately and ignore case sensitivity.
-        self.pattern = re.compile(regex.replace(" ", "|"), re.IGNORECASE)
+        if match := re.fullmatch('r"([^"]*)"', regex):
+            # extract the real regex from Whoosh regex search term
+            self.pattern = re.compile(match.group(1))
+        else:
+            # treat each word separately and ignore case sensitivity
+            self.pattern = re.compile(regex.replace(" ", "|"), re.IGNORECASE)
 
     def __call__(self, tree: Any) -> Any | None:
         self.recurse(tree)

--- a/src/moin/items/content.py
+++ b/src/moin/items/content.py
@@ -337,7 +337,8 @@ class Content:
         flaskg.clock.stop("conv_link")
 
         if "regex" in request.args:
-            highlight_conv = reg.get(type_moin_document, type_moin_document, highlight="highlight")
+            regex = request.args["regex"]
+            highlight_conv = reg.get(type_moin_document, type_moin_document, highlight="highlight", regex=regex)
             flaskg.clock.start("highlight")
             doc = highlight_conv(doc)
             flaskg.clock.stop("highlight")

--- a/src/moin/templates/search.html
+++ b/src/moin/templates/search.html
@@ -85,6 +85,6 @@
 {% endblock %}
 
 {% block body_scripts %}
-    <script src="{{ url_for('serve.files', name='jquery', filename='jquery.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/search.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
Changes

* jquery script wasn't referenced correctly in template `search.html`
* some bad search terms led to exceptions raised by Whoosh => added exception handling
* when searching Moin using a regular expression (synatx: `r"<regex>"`) and clicking on a search hit the content highlighting did not work correctly

**A known issue not addressed in this PR:**

Some search terms (e.g. `r"[]"`) cause Whoosh to run into an assertion failure

```
  File ".../.venv/lib/python3.14/site-packages/whoosh/analysis/tokenizers.py", line 118, in __call__
	assert isinstance(value, text_type), "%s is not unicode" % repr(value)
		   ~~~~~~~~~~^^^^^^^^^^^^^^^^^^
AssertionError: None is not unicode
```