### PR TITLE
Stop centering page in focus theme

### DIFF
--- a/src/moin/themes/focus/static/css/theme.css
+++ b/src/moin/themes/focus/static/css/theme.css
@@ -325,10 +325,6 @@ tr > th { background-color: var(--accent-lighter); }
     .fa.global-history { height: 22pt; width: 22pt; }
 }
 
-@media (min-width: 1000pt) {
-    #moin-page { margin: 0pt auto; }
-}
-
 @media print {
     html, body { max-height: unset; }
     #moin-header, #top-bar, #moin-footer, #moin-flash {


### PR DESCRIPTION
Looks broken when a page has not much content.

This PR solves an issue mentioned in this [comment](https://github.com/moinwiki/moin/issues/1911#issuecomment-3977785731).