### PR TITLE
Command maint-validate-metadata: correct missing 'itemtype' entry in item metadata

### DIFF
--- a/src/moin/cli/maint/modify_item.py
+++ b/src/moin/cli/maint/modify_item.py
@@ -268,14 +268,16 @@ class RevData:
     rev_id: str
     rev_number: int
     mtime: int
-    parent_id: str = None
+    parent_id: str | None = None
     issues: list[str] = field(default_factory=list)
 
 
-def ValidateMetadata(backends=None, all_backends=False, verbose=False, fix=False):
+def ValidateMetadata(
+    backend_names: str | None = None, all_backends: bool = False, verbose: bool = False, fix: bool = False
+) -> set[str]:
     flaskg.add_lineno_attr = False
-    backends = get_backends(backends, all_backends)
-    bad_revids = set()
+    backends = get_backends(backend_names, all_backends)
+    bad_revids: set[str] = set()
     for backend in backends:
         revs: dict[str, list[RevData]] = defaultdict(list)
         for meta, data, issues in correcting_rev_iter(backend):
@@ -287,9 +289,11 @@ def ValidateMetadata(backends=None, all_backends=False, verbose=False, fix=False
                 for issue in issues:
                     print(issue)
             _fix_if_bad(bad, meta, data, bad_revids, fix, backend)
+
         # Skipping checks for userprofiles, as revision numbers and parentids are not used here
         if backend == current_app.cfg.backend_mapping[NAMESPACE_USERPROFILES]:
             continue
+
         # fix bad parentid references and repeated or missing revision numbers
         for item_id, rev_datum in revs.items():
             rev_datum.sort(key=lambda r: (r.rev_number, r.mtime))
@@ -310,6 +314,7 @@ def ValidateMetadata(backends=None, all_backends=False, verbose=False, fix=False
                         rev_data.rev_number = prev_rev_data.rev_number + 1
                         rev_data.issues.append("revision_number_error")
                 prev_rev_data = rev_data
+
             for rev_data in [r for r in rev_datum if r.issues]:
                 bad = True
                 meta, data = backend.retrieve(rev_data.rev_id)
@@ -336,6 +341,7 @@ def ValidateMetadata(backends=None, all_backends=False, verbose=False, fix=False
                         pass
                 meta[REV_NUMBER] = rev_data.rev_number
                 _fix_if_bad(bad, meta, data, bad_revids, fix, backend)
+
     print(f'{len(bad_revids)} items with invalid metadata found{" and fixed" if fix else ""}')
     return bad_revids
 

--- a/src/moin/storage/middleware/serialization.py
+++ b/src/moin/storage/middleware/serialization.py
@@ -21,7 +21,8 @@ import json
 from werkzeug.wsgi import LimitedStream
 
 from moin.constants.keys import NAME, ITEMTYPE, SIZE, NAMESPACE, REVID, ITEMID, REV_NUMBER, HASH_ALGORITHM
-from moin.constants.itemtypes import ITEMTYPE_DEFAULT
+from moin.constants.itemtypes import ITEMTYPE_DEFAULT, ITEMTYPE_USERPROFILE
+from moin.constants.namespaces import NAMESPACE_USERPROFILES
 from moin.storage.backends.stores import Backend
 from moin.storage.backends._util import TrackingFileWrapper
 
@@ -72,13 +73,23 @@ def correcting_rev_iter(backend: Backend):
         issues: list of strings describing issues that were corrected
     """
     for revid in backend:
-        issues = []
+
+        issues: list[str] = []
+
         if isinstance(revid, tuple):
             # router middleware gives tuples and wants both values for retrieve:
             meta, data = backend.retrieve(*revid)
         else:
             # lower level backends have simple revids
             meta, data = backend.retrieve(revid)
+
+        if ITEMTYPE not in meta:
+            itemtype = ITEMTYPE_DEFAULT
+            if meta.get(NAMESPACE) == NAMESPACE_USERPROFILES:
+                itemtype = ITEMTYPE_USERPROFILE
+            issues.append(f"{ITEMTYPE}_error {get_rev_str(meta)}: missing itemtype ({itemtype})")
+            meta[ITEMTYPE] = itemtype
+
         tfw = TrackingFileWrapper(data)
         while tfw.read(64 * 1024):
             pass
@@ -92,6 +103,7 @@ def correcting_rev_iter(backend: Backend):
             )
             meta[HASH_ALGORITHM] = real_hash
         data.seek(0)
+
         yield meta, data, issues
 
 

--- a/src/moin/storage/middleware/serialization.py
+++ b/src/moin/storage/middleware/serialization.py
@@ -83,6 +83,10 @@ def correcting_rev_iter(backend: Backend):
             # lower level backends have simple revids
             meta, data = backend.retrieve(revid)
 
+        if REV_NUMBER not in meta:
+            issues.append(f"{REV_NUMBER}_error {get_rev_str(meta)}: missing revision number")
+            meta[REV_NUMBER] = -1
+
         if ITEMTYPE not in meta:
             itemtype = ITEMTYPE_DEFAULT
             if meta.get(NAMESPACE) == NAMESPACE_USERPROFILES:


### PR DESCRIPTION
```
(.venv) [roland@reckoner moin-test]$ moin maint-validate-metadata -b userprofiles -v -f
 * Tip: There are .env files present. Install python-dotenv to use them.
itemtype_error name: userprofiles/roland item: 8411d4c17c0a405fae0d7253cd2e15ad rev_number: 1 rev_id: e8190c02cb2a4b149c08fc9e061f3bfb: missing itemtype (userprofile)
1 items with invalid metadata found and fixed
```

Fixes issue #2228