### PR TITLE
Exclude xstatic directory from GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Wiki text items must have LF line endings also on Windows
 src/moin/help/** eol=lf
+# exclude xstatic directory from github language stats
+src/moin/xstatic/** linguist-vendored


### PR DESCRIPTION
Related to #2214.

Bring Python back to the top of Moin's language stats.