### PR TITLE
Remove compatibility code for ISO8601 timestamps in tests

### DIFF
--- a/src/moin/macros/_tests/test_Date.py
+++ b/src/moin/macros/_tests/test_Date.py
@@ -30,11 +30,8 @@ class TestMacroDateTimeBase:
 
         flaskg.user.valid = True  # show_time creates ISO 8601 dates if user is not logged in
         result = format_date_time(utcfromtimestamp(ts))
-        expected = [
-            "Aug 7, 2023, 5:38:11\u202fAM",
-            "Aug 7, 2023, 5:38:11 AM",
-        ]  # TODO: The second entry can be removed later
-        assert result in expected
+        expected = "Aug 7, 2023, 5:38:11\u202fAM"
+        assert result == expected
 
         with pytest.raises(ValueError):
             # Dates beyond the next 10,000 years can't be predicted.

--- a/src/moin/macros/_tests/test_DateTime.py
+++ b/src/moin/macros/_tests/test_DateTime.py
@@ -30,11 +30,8 @@ def test_Macro():
 
     arguments = ["2023-08-07T11:11:11", "argument2"]
     result = macro_obj.macro("content", arguments, "page_url", "alternative")
-    expected = [
-        "Aug 7, 2023, 11:11:11\u202fAM",
-        "Aug 7, 2023, 11:11:11 AM",
-    ]  # TODO: The second entry can be removed in the future
-    assert result in expected
+    expected = "Aug 7, 2023, 11:11:11\u202fAM"
+    assert result == expected
 
     flaskg.user.valid = False
     result = macro_obj.macro("content", arguments, "page_url", "alternative")

--- a/src/moin/utils/_tests/test_show_time.py
+++ b/src/moin/utils/_tests/test_show_time.py
@@ -67,15 +67,9 @@ class TestShowTime:
         formatted_date = show_time.format_date(utc_dt=0)
         assert formatted_date == "Dec 31, 1969"
         formatted_time = show_time.format_time(utc_dt=0)
-        assert formatted_time in [
-            "5:00:00\u202fPM",
-            "5:00:00 PM",
-        ]  # TODO: The second string can be removed in the future
+        assert formatted_time == "5:00:00\u202fPM"
         formatted_date_time = show_time.format_date_time(utc_dt=0)
-        assert formatted_date_time in [
-            "Dec 31, 1969, 5:00:00\u202fPM",
-            "Dec 31, 1969, 5:00:00 PM",
-        ]  # TODO: Same as above
+        assert formatted_date_time == "Dec 31, 1969, 5:00:00\u202fPM"
 
 
 coverage_modules = ["moin.utils.show_time"]


### PR DESCRIPTION
Related to #1370.
