### PR TITLE
Converter fixes

### DIFF
--- a/src/moin/converters/_tests/test_docbook_in.py
+++ b/src/moin/converters/_tests/test_docbook_in.py
@@ -559,6 +559,20 @@ class TestConverter(Base):
         self.do(input, xpath)
 
     data = [
+        # Test misc block-level elements
+        (  # TODO: test also for title and content
+            "<article><sidebar><title>Title</title><para>content</para></sidebar></article>",
+            # '/page/body/div/div[@html-tag="aside"][@html:class="sidebar"][@html:title="Title"]',
+            '/page/body/div/aside[@html:class="sidebar"]',
+        ),
+        # TODO: figures
+    ]
+
+    @pytest.mark.parametrize("input,xpath", data)
+    def test_block_elements(self, input, xpath):
+        self.do(input, xpath)
+
+    data = [
         (
             '<article><para><trademark class="copyright">MoinMoin</trademark></para></article>',
             # <page><body><div html:class="db-article"><p><span html:class="db-trademark">\xa9  MoinMoin</span></p></div></body></page>

--- a/src/moin/converters/_tests/test_html_in.py
+++ b/src/moin/converters/_tests/test_html_in.py
@@ -177,6 +177,11 @@ class TestConverter(Base):
             '/page/body/p/span[text()="smaller"][@html:class="moin-small"]',
         ),
         (
+            "<html><div><p><q>Inline quote</q></p></div></html>",
+            # <page><body><div><p><quote>Inline quote</quote></p></body></page>
+            '/page/body/div/p[quote="Inline quote"]',
+        ),
+        (
             "<html><p><ins>underline</ins></p></html>",
             # <page><body><p><ins>underline</ins></p></body></page>
             '/page/body/p/ins[text()="underline"]',
@@ -202,6 +207,24 @@ class TestConverter(Base):
     def test_inline_elements(self, input, xpath):
         self.do(input, xpath)
 
+    # Many HTML elements have an equivalent Moin DOM tree element
+    data = [
+        (
+            "<html><aside><p>tangentially related</p></aside></html>",
+            # <page><body><aside><p>tangentially related</p></aside></body></page>
+            '/page/body/aside/p[text()="tangentially related"]',
+        ),
+        (
+            "<html><div><blockquote>Block quote</blockquote></div></html>",
+            # <page><body><div><blockquote>Block quote</blockquote></body></page>
+            '/page/body/div[blockquote="Block quote"]',
+        ),
+    ]
+
+    @pytest.mark.parametrize("input,xpath", data)
+    def test_symmetric_elements(self, input, xpath):
+        self.do(input, xpath)
+
     # HTML elements without equivalent Moin DOM tree elements
     # are represented by the "html-tag" attribute:
     data = [
@@ -219,11 +242,6 @@ class TestConverter(Base):
             "<html><address>webmaster@example.org</address></html>",
             # <page><body><div html-tag="address">webmaster@example.org</div></body></page>
             '/page/body/div[text()="webmaster@example.org"][@html-tag="address"]',
-        ),
-        (  # <aside> is a block-level element
-            "<html><aside><p>tangentially related</p></aside></html>",
-            # <page><body><div html-tag="aside"><p>tangentially related</p></div></body></page>
-            '/page/body/div[@html-tag="aside"]/p[text()="tangentially related"]',
         ),
         (
             "<html><p><cite>Hamlet</cite></p></html>",
@@ -335,23 +353,6 @@ class TestConverter(Base):
 
     @pytest.mark.parametrize("input,xpath", data)
     def test_code(self, input, xpath):
-        self.do(input, xpath)
-
-    data = [
-        (
-            "<html><div><p><q>Inline quote</q></p></div></html>",
-            # <page><body><div><p><quote>Inline quote</quote></p></body></page>
-            '/page/body/div/p[quote="Inline quote"]',
-        ),
-        (
-            "<html><div><blockquote>Block quote</blockquote></div></html>",
-            # <page><body><div><blockquote>Block quote</blockquote></body></page>
-            '/page/body/div[blockquote="Block quote"]',
-        ),
-    ]
-
-    @pytest.mark.parametrize("input,xpath", data)
-    def test_quote(self, input, xpath):
         self.do(input, xpath)
 
     data = [

--- a/src/moin/converters/_tests/test_html_in_out.py
+++ b/src/moin/converters/_tests/test_html_in_out.py
@@ -125,7 +125,7 @@ class TestConverter(Base):
         ("<html><p><abbr>etc.</abbr></p></html>", '/div/p[abbr="etc."]'),
         ("<html><p><acronym>AC/DC</acronym></p></html>", '/div/p[abbr="AC/DC"]'),
         ("<html><p><address>webmaster@example.org</address></p></html>", '/div/p[address="webmaster@example.org"]'),
-        ("<html><p><aside>tangentially related</aside></p></html>", '/div/p[aside="tangentially related"]'),
+        ("<html><aside><p>tangentially related</p></aside></html>", '/div/aside[p="tangentially related"]'),
         ("<html><p><cite>Moin wiki</cite></p></html>", '/div/p[cite="Moin wiki"]'),
         ("<html><p><dfn>term</dfn></p></html>", '/div/p[dfn="term"]'),
         ("<html><p><i>alternate voice</i></p></html>", '/div/p[i="alternate voice"]'),

--- a/src/moin/converters/_tests/test_html_out.py
+++ b/src/moin/converters/_tests/test_html_out.py
@@ -107,6 +107,10 @@ class TestConverter(Base):
             "<page:page><page:body><page:div><page:p><page:quote>Quotation</page:quote></page:p></page:div></page:body></page:page>",
             '/div/div/p/q[text()="Quotation"]',
         ),
+        (
+            "<page:page><page:body><page:aside><page:p>tangentially related</page:p></page:aside></page:body></page:page>",
+            '/div/aside[p="tangentially related"]',
+        ),
     ]
 
     @pytest.mark.parametrize("input,xpath", data)

--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -517,14 +517,14 @@ text""",
         # Topics, Sidebars, and Rubrics
         (
             ".. topic:: Topic Title\n   :class: custom\n\n   topic content",
-            '<div html-tag="aside" xhtml:class="custom"><p xhtml:class="moin-title">Topic Title</p><p>topic content</p></div>',
+            '<aside xhtml:class="custom"><p xhtml:class="moin-title">Topic Title</p><p>topic content</p></aside>',
         ),
         (
             ".. sidebar:: Sidebar Title\n   :subtitle: Sidebar Subtitle\n   :class: float-right\n\n   sidebar content",
-            '<div html-tag="aside" xhtml:class="rst-sidebar float-right">'
+            '<aside xhtml:class="sidebar float-right">'
             '<p xhtml:class="moin-title">Sidebar Title</p>'
             '<p xhtml:class="moin-subheading">Sidebar Subtitle</p>'
-            "<p>sidebar content</p></div>",
+            "<p>sidebar content</p></aside>",
         ),
         (
             ".. rubric:: Informal Heading\n  :class: custom",

--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -106,10 +106,13 @@ class TestConverter:
             "</list-item-body></list-item><list-item><list-item-body><p>B</p></list-item-body></list-item></list>"
             "</blockquote>",
         ),
-        ("| line 1\n| line2", "<line-block><line-blk>line 1</line-blk><line-blk>line2</line-blk></line-block>"),
+        (
+            "| line 1\n| line2",
+            "<line-block><line-block-line>line 1</line-block-line><line-block-line>line2</line-block-line></line-block>",
+        ),
         (
             "| line 1\n|  nested line-block",
-            "<line-block><line-blk>line 1</line-blk><line-block><line-blk>nested line-block</line-blk></line-block></line-block>",
+            "<line-block><line-block-line>line 1</line-block-line><line-block><line-block-line>nested line-block</line-block-line></line-block></line-block>",
         ),
     ]
 

--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -250,7 +250,7 @@ class TestConverter:
         (
             "Leading text\n\n:Last Changed: 2001-08-16\n:*Version*: 1\n:Name: Joe Doe",
             "<p>Leading text</p>"
-            '<table xhtml:class="moin-rst-fieldlist"><table-body>'
+            '<table xhtml:class="rst-fieldlist"><table-body>'
             "<table-row><table-cell><strong>Last Changed:</strong></table-cell>"
             "<table-cell><p>2001-08-16</p></table-cell></table-row>"
             "<table-row><table-cell><strong><emphasis>Version</emphasis>:</strong></table-cell>"
@@ -263,7 +263,7 @@ class TestConverter:
         # bibliographic data (visible meta-data)
         (
             ":Date: 2001-08-16\n:Author: Joe Doe\n:Version:  $Revision: 1.17 $\n",
-            '<table xhtml:class="moin-rst-fieldlist"><table-body>'
+            '<table xhtml:class="rst-fieldlist"><table-body>'
             "<table-row><table-cell><strong>Date:</strong></table-cell><table-cell>2001-08-16</table-cell></table-row>"
             "<table-row><table-cell><strong>Author:</strong></table-cell><table-cell>Joe Doe</table-cell></table-row>"
             "<table-row><table-cell><strong>Version:</strong></table-cell><table-cell>1.17</table-cell></table-row>"
@@ -271,7 +271,7 @@ class TestConverter:
         ),
         (
             ":Authors: Pat, Patagon\n:Copyright: © 2026 Pat\n:Address: 100 Acre Wood\n:Test: custom field",
-            '<table xhtml:class="moin-rst-fieldlist"><table-body>'
+            '<table xhtml:class="rst-fieldlist"><table-body>'
             "<table-row><table-cell><strong>Authors:</strong></table-cell>"
             "<table-cell><p>Pat</p><p>Patagon</p></table-cell></table-row>"
             "<table-row><table-cell><strong>Copyright:</strong></table-cell><table-cell>© 2026 Pat</table-cell></table-row>"
@@ -286,7 +286,7 @@ class TestConverter:
             "--print arg  Output just arg.\n"
             "-f FILE, --file=FILE  These two options are synonyms;\n"
             "                      both have arguments.\n",
-            '<table xhtml:class="moin-rst-optionlist"><table-body>'
+            '<table xhtml:class="rst-optionlist"><table-body>'
             '<table-row><table-cell><span xhtml:class="kbd option">-a</span></table-cell>'
             "<table-cell><p>Output all.</p></table-cell></table-row>"
             '<table-row><table-cell><span xhtml:class="kbd option">--print arg</span></table-cell>'

--- a/src/moin/converters/_tests/test_rst_out.py
+++ b/src/moin/converters/_tests/test_rst_out.py
@@ -63,7 +63,7 @@ class TestConverter(Base):
             "\n..\n comment\n",
         ),
         (
-            "<page><body><line-block><line-blk>Lend us a couple of bob till Thursday.</line-blk></line-block></body></page>",
+            "<page><body><line-block><line-block-line>Lend us a couple of bob till Thursday.</line-block-line></line-block></body></page>",
             "\n| Lend us a couple of bob till Thursday.\n",
         ),
     ]

--- a/src/moin/converters/docbook_in.py
+++ b/src/moin/converters/docbook_in.py
@@ -336,7 +336,6 @@ class Converter:
         "screenshoot",
         "set",
         "setindex",
-        "sidebar",
         "simplesect",
         "subtitle",
         "synopsis",
@@ -1062,6 +1061,13 @@ class Converter:
             else:
                 new.append(child)
         return ET.Element(moin_page.list, attrib={}, children=new)
+
+    def visit_docbook_sidebar(self, element, depth):
+        """
+        <sidebar> --> <aside html:class="sidebar">
+        """
+        attrib = {html.class_: "sidebar"}
+        return self.new_copy(moin_page("aside"), element, depth, attrib=attrib)
 
     def visit_docbook_simplelist(self, element, depth):
         """

--- a/src/moin/converters/docbook_in.py
+++ b/src/moin/converters/docbook_in.py
@@ -329,7 +329,7 @@ class Converter:
         "dedication",
         "epigraph",
         "example",
-        "figure",
+        "figure",  # TODO there is a moinpage.figure!
         "equation",
         "part",
         "partintro",

--- a/src/moin/converters/html_in.py
+++ b/src/moin/converters/html_in.py
@@ -48,6 +48,7 @@ class HtmlTags:
 
     # HTML tags which can be converted directly to the moin_page namespace
     symmetric_tags: Final = {
+        "aside",
         "blockquote",
         "code",
         "del",
@@ -93,7 +94,6 @@ class HtmlTags:
     indirect_tags: Final = {
         "abbr": moin_page.span,  # abbreviation
         "address": moin_page.div,  # contact info
-        "aside": moin_page.div,  # content that is tangentially related to the main content
         "cite": moin_page.emphasis,  # title of a creative work
         "dfn": moin_page.emphasis,  # defining instance of a term
         "i": moin_page.emphasis,  # alternate voice

--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -241,6 +241,9 @@ class Converter:
             attrib[html.class_] = cls
         return self.new_copy(html.div, elem, attrib)
 
+    def visit_moinpage_aside(self, elem):
+        return self.new_copy(html.aside, elem)
+
     def visit_moinpage_audio(self, elem):
         href = elem.get(xlink.href, None)
         attrib = {html.src: href} if href else {}

--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -348,8 +348,8 @@ class Converter:
         # TODO: attributes?
         return html.br()
 
-    def visit_moinpage_line_blk(self, elem):
-        return self.new_copy(html.div, elem, attrib={html.class_: "moin-line-blk"})
+    def visit_moinpage_line_block_line(self, elem):
+        return self.new_copy(html.div, elem, attrib={html.class_: "moin-line-block-line"})
 
     def visit_moinpage_line_block(self, elem):
         """

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -782,8 +782,8 @@ class NodeVisitor:
 
     def visit_sidebar(self, node):
         # analogous to the DocBook <sidebar> and HTML <aside> element
-        attrib = {moin_page("html-tag"): "aside", html.class_: "rst-sidebar"}
-        self.open_moin_page_node(moin_page.div(attrib=attrib), node)
+        attrib = {html.class_: "sidebar"}
+        self.open_moin_page_node(moin_page.aside(attrib=attrib), node)
 
     def depart_sidebar(self, node):
         self.close_moin_page_node()
@@ -916,8 +916,7 @@ class NodeVisitor:
     def visit_topic(self, node):
         # content outside the flow of the main content of the document
         # analogous to the HTML <aside> element
-        attrib = {moin_page("html-tag"): "aside"}
-        self.open_moin_page_node(moin_page.div(attrib=attrib), node)
+        self.open_moin_page_node(moin_page.aside(), node)
 
     def depart_topic(self, node):
         self.close_moin_page_node()

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -234,7 +234,7 @@ class NodeVisitor:
         self.close_moin_page_node()
 
     def visit_attribution(self, node):
-        attrib = {html.class_: "moin-rst-attribution"}
+        attrib = {html.class_: "rst-attribution"}
         self.open_moin_page_node(moin_page.p(attrib=attrib), node)
 
     def depart_attribution(self, node):
@@ -266,7 +266,7 @@ class NodeVisitor:
         self.close_moin_page_node()
 
     def visit_docinfo(self, node):
-        self.open_moin_page_node(moin_page.table(attrib={html.class_: "moin-rst-fieldlist"}), node)
+        self.open_moin_page_node(moin_page.table(attrib={html.class_: "rst-fieldlist"}), node)
         self.open_moin_page_node(moin_page.table_body())
 
     def depart_docinfo(self, node):
@@ -399,7 +399,7 @@ class NodeVisitor:
         self.close_moin_page_node()
 
     def visit_field_list(self, node):
-        attrib = {html.class_: "moin-rst-fieldlist"}
+        attrib = {html.class_: "rst-fieldlist"}
         self.open_moin_page_node(moin_page.table(attrib=attrib), node)
         self.open_moin_page_node(moin_page.table_body())
 
@@ -540,7 +540,7 @@ class NodeVisitor:
         if self.status[-1] == "footnote":
             self.footnote_lable = node.astext()
             raise nodes.SkipNode
-        attrib = {html.class_: "moin-rst-label float-left"}
+        attrib = {html.class_: "rst-label float-left"}
         self.open_moin_page_node(moin_page.div(attrib=attrib), node)
         self.current_node.append("[")
 
@@ -549,7 +549,7 @@ class NodeVisitor:
         self.close_moin_page_node()
 
     def visit_line(self, node):
-        """| first line of a line_block"""
+        """| line of a line_block"""
         self.open_moin_page_node(moin_page.line_blk())
 
     def depart_line(self, node):
@@ -605,7 +605,7 @@ class NodeVisitor:
         self.close_moin_page_node()
 
     def visit_option_list(self, node):
-        attrib = {html.class_: "moin-rst-optionlist"}
+        attrib = {html.class_: "rst-optionlist"}
         self.open_moin_page_node(moin_page.table(attrib=attrib), node)
         self.open_moin_page_node(moin_page.table_body())
 

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -550,7 +550,7 @@ class NodeVisitor:
 
     def visit_line(self, node):
         """| line of a line_block"""
-        self.open_moin_page_node(moin_page.line_blk())
+        self.open_moin_page_node(moin_page.line_block_line())
 
     def depart_line(self, node):
         self.close_moin_page_node()

--- a/src/moin/converters/rst_out.py
+++ b/src/moin/converters/rst_out.py
@@ -516,7 +516,7 @@ class Converter:
             ret[0] = ret[0].replace("image", "include")
         return "\n".join(ret) + "\n"
 
-    def open_moinpage_line_blk(self, elem):
+    def open_moinpage_line_block_line(self, elem):
         out = self.open_children(elem)
         if out.startswith("\n"):
             out = out[1:]

--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -417,9 +417,9 @@ li > p { margin-top: 0; margin-bottom: 0; }
 .rst-attribution { font-style: italic; }
 .rst-attribution:before { content: "—"; }
 
-/* rST line-blocks */
+/* moinpage elements for rST line-blocks */
 .moin-line-block > .moin-line-block { margin-left: 2em; }
-.moin-line-blk:empty { min-height: 1em; }
+.moin-line-block-line:empty { min-height: 1em; }
 
 /* rST topic and rST/DocBook sidebar */
 aside { margin-left: 2em; } /* content outside of the document's main text */

--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -414,8 +414,8 @@ blockquote { padding-left: 2em; font-size: .92em; }
 blockquote blockquote { font-size: 1em; }
 ul blockquote { padding-left: 0; font-size: 1em; }
 li > p { margin-top: 0; margin-bottom: 0; }
-.moin-rst-attribution { font-style: italic; }
-.moin-rst-attribution:before { content: "—"; }
+.rst-attribution { font-style: italic; }
+.rst-attribution:before { content: "—"; }
 
 /* rST line-blocks */
 .moin-line-block > .moin-line-block { margin-left: 2em; }
@@ -723,12 +723,12 @@ ul#moin-rev-navigation { text-align: center; background-color: var(--bg-zebra); 
 
 /* reST field lists and option lists*/
 
-.moin-rst-optionlist,
-.moin-rst-fieldlist { margin-left: 2em; }
-.moin-rst-optionlist td,
-.moin-rst-fieldlist td { border-width: 0; vertical-align: top; }
-.moin-rst-optionlist td:first-child,
-.moin-rst-fieldlist td:first-child { font-weight: bold; }
+.rst-optionlist,
+.rst-fieldlist { margin-left: 2em; }
+.rst-optionlist td,
+.rst-fieldlist td { border-width: 0; vertical-align: top; }
+.rst-optionlist td:first-child,
+.rst-fieldlist td:first-child { font-weight: bold; }
 
 /* MonthCalendar macro */
 

--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -423,7 +423,7 @@ li > p { margin-top: 0; margin-bottom: 0; }
 
 /* rST topic and rST/DocBook sidebar */
 aside { margin-left: 2em; } /* content outside of the document's main text */
-aside.rst-sidebar, div.db-sidebar {
+aside.sidebar {
     color: var(--primary); border: var(--border-style);
     margin: 10px 30px; padding: 8px; }
 


### PR DESCRIPTION
Simplify html.class names for rST-specific elements.

Rename element "line-blk" to "line-block-line".

 Use native element `<aside>` for HTML `<aside>`, DocBook `<sidebar>`,
 and rST "sidebar" and "topic".

Closes #2092.