### PR TITLE
Web UI: make +index work better when JavaScript is not available

### DIFF
--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, Iterable
 from io import BytesIO
 
+import json
 import pytest
 
 from flask import url_for
@@ -30,8 +31,7 @@ def client_request(
     if user is not None:
         set_user_in_client_session(client, user)
     print(f"client request: {method} {url}")
-    response = client.open(url, method=method, **kwargs)
-    return response
+    return client.open(url, method=method, **kwargs)
 
 
 @pytest.mark.usefixtures("_req_ctx")
@@ -44,19 +44,19 @@ class TestFrontend:
         status: str = "200 OK",
         data: Iterable[str] = ("<html>", "</html>"),
         content_types: Iterable[str] = ("text/html; charset=utf-8",),
-        viewopts: dict[str, Any] | None = None,
+        viewargs: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
         user: user.User | None = None,
     ) -> TestResponse:
 
-        if viewopts is None:
-            viewopts = {}
+        if viewargs is None:
+            viewargs = {}
         if params is None:
             params = {}
 
         with current_app.test_client() as client:
 
-            request_url = url_for(viewname, **viewopts)
+            request_url = url_for(viewname, **viewargs)
 
             response = client_request(client, "HEAD", request_url, user=user, data=params)
             assert response.status == status
@@ -79,19 +79,19 @@ class TestFrontend:
         content_types: Iterable[str] = ("text/html; charset=utf-8",),
         data: Iterable[str] = ("<html>", "</html>"),
         form: dict[str, Any] | None = None,
-        viewopts: dict[str, Any] | None = None,
+        viewargs: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
         user: user.User | None = None,
     ) -> TestResponse:
 
         if params is None:
             params = {}
-        if viewopts is None:
-            viewopts = {}
+        if viewargs is None:
+            viewargs = {}
         if form is None:
             form = {}
 
-        request_url = url_for(viewname, **viewopts)
+        request_url = url_for(viewname, **viewargs)
         print("POST %s" % request_url)
 
         with current_app.test_client() as client:
@@ -103,46 +103,82 @@ class TestFrontend:
                 assert item in rv_data
             return response
 
+    def post_xhr_request(
+        self,
+        viewname: str,
+        *,
+        status: str = "302 FOUND",
+        data: dict[str, Any] | None = None,
+        viewargs: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+        user: user.User | None = None,
+        expected: dict[str, Any] = {},
+    ) -> TestResponse:
+
+        if params is None:
+            params = {}
+        if viewargs is None:
+            viewargs = {}
+
+        request_url = url_for(viewname, **viewargs)
+        print("POST %s" % request_url)
+
+        with current_app.test_client() as client:
+            response = client_request(
+                client,
+                "POST",
+                request_url,
+                user=user,
+                query_string=params,
+                data=json.dumps(data),
+                content_type="application/json; charset=utf-8",
+            )
+            assert response.status == status
+            assert response.headers["Content-Type"] == "application/json"
+            assert response.is_json
+            rv_data = response.json
+            assert isinstance(rv_data, dict)
+            for key, val in expected.items():
+                assert key in rv_data
+                assert val == rv_data[key]
+            return response
+
     def test_ajaxdelete_item_name_route(self):
-        self._test_view_post(
+        self.post_xhr_request(
             "frontend.ajaxdelete",
             status="200 OK",
-            content_types=["application/json"],
-            data=["{", "}"],
-            form=dict(comment="Test", itemnames='["DoesntExist"]'),
-            viewopts=dict(item_name="DoesntExist"),
+            viewargs=dict(item_name="DoesntExist"),
+            data=dict(itemnames='["DoesntExist"]', comment="Test"),
+            expected={"itemnames": []},
         )
 
     def test_ajaxdelete_no_item_name_route(self):
-        self._test_view_post(
+        self.post_xhr_request(
             "frontend.ajaxdelete",
             status="200 OK",
-            content_types=["application/json"],
-            data=["{", "}"],
-            form=dict(comment="Test", itemnames='["DoesntExist"]'),
+            data=dict(itemnames='["DoesntExist"]', comment="Test"),
+            expected={"itemnames": []},
         )
 
     def test_ajaxdestroy_item_name_route(self):
-        self._test_view_post(
+        self.post_xhr_request(
             "frontend.ajaxdestroy",
             status="200 OK",
-            content_types=["application/json"],
-            data=["{", "}"],
-            form=dict(comment="Test", itemnames='["DoesntExist"]'),
-            viewopts=dict(item_name="DoesntExist"),
+            viewargs=dict(item_name="DoesntExist"),
+            data=dict(itemnames='["DoesntExist"]', comment="Test"),
+            expected={"itemnames": []},
         )
 
     def test_ajaxdestroy_no_item_name_route(self):
-        self._test_view_post(
+        self.post_xhr_request(
             "frontend.ajaxdestroy",
             status="200 OK",
-            content_types=["application/json"],
-            data=["{", "}"],
-            form=dict(comment="Test", itemnames='["DoesntExist"]'),
+            data=dict(comment="Test", itemnames='["DoesntExist"]'),
+            expected={"itemnames": []},
         )
 
     def test_ajaxmodify(self):
-        self._test_view_post("frontend.ajaxmodify", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view_post("frontend.ajaxmodify", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_jfu_server(self):
         self._test_view_post(
@@ -157,49 +193,49 @@ class TestFrontend:
                     content_type="text/plain; charset=utf-8",
                 )
             ),
-            viewopts=dict(item_name="WillBeCreated"),
+            viewargs=dict(item_name="WillBeCreated"),
         )
 
     def test_show_item(self):
-        self._test_view("frontend.show_item", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.show_item", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_show_dom(self):
         self._test_view(
             "frontend.show_dom",
             status="404 NOT FOUND",
             data=["<?xml", ">"],
-            viewopts=dict(item_name="DoesntExist"),
+            viewargs=dict(item_name="DoesntExist"),
             content_types=["text/xml; charset=utf-8"],
         )
 
     def test_indexable(self):
-        self._test_view("frontend.indexable", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.indexable", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_highlight_item(self):
-        self._test_view("frontend.highlight_item", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.highlight_item", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_show_item_meta(self):
-        self._test_view("frontend.show_item_meta", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.show_item_meta", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_content_item(self):
-        self._test_view("frontend.content_item", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.content_item", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_get_item(self):
-        self._test_view("frontend.get_item", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.get_item", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_download_item(self):
-        self._test_view("frontend.download_item", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.download_item", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_convert_item(self):
         self._test_view(
             "frontend.convert_item",
             status="404 NOT FOUND",
-            viewopts=dict(item_name="DoesntExist"),
+            viewargs=dict(item_name="DoesntExist"),
             params=dict(contenttype="text/plain"),
         )
 
     def test_modify_item(self):
-        self._test_view("frontend.modify_item", status="200 OK", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.modify_item", status="200 OK", viewargs=dict(item_name="DoesntExist"))
 
     def test_modify_item_show_preview(self):
 
@@ -211,42 +247,42 @@ class TestFrontend:
         self._test_view_post(
             "frontend.modify_item",
             status="200 OK",
-            viewopts=dict(item_name="quokka"),
+            viewargs=dict(item_name="quokka"),
             params={"itemtype": "default", "contenttype": "text/x.moin.wiki;charset=utf-8", "template": ""},
             form=make_modify_form_data("quokka", content=content, preview="Preview"),
             user=test_user,
         )
 
     def test_rename_item(self):
-        self._test_view("frontend.rename_item", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.rename_item", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_delete_item(self):
-        self._test_view("frontend.delete_item", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.delete_item", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_index(self):
-        self._test_view("frontend.index", status="200 OK", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.index", status="200 OK", viewargs=dict(item_name="DoesntExist"))
 
     def test_forwardrefs(self):
-        self._test_view("frontend.forwardrefs", status="200 OK", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.forwardrefs", status="200 OK", viewargs=dict(item_name="DoesntExist"))
 
     def test_backrefs(self):
-        self._test_view("frontend.backrefs", status="200 OK", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.backrefs", status="200 OK", viewargs=dict(item_name="DoesntExist"))
 
     def test_history(self):
-        self._test_view("frontend.history", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.history", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_diff(self):
         # TODO: Add another test with valid rev1 and rev2 URL args and an existing item.
-        self._test_view("frontend.diff", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.diff", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_similar_names(self):
-        self._test_view("frontend.similar_names", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.similar_names", viewargs=dict(item_name="DoesntExist"))
 
     def test_sitemap(self):
-        self._test_view("frontend.sitemap", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.sitemap", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_tagged_items(self):
-        self._test_view("frontend.tagged_items", status="200 OK", viewopts=dict(tag="DoesntExist"))
+        self._test_view("frontend.tagged_items", status="200 OK", viewargs=dict(tag="DoesntExist"))
 
     def test_root(self):
         self._test_view("frontend.index")
@@ -259,11 +295,11 @@ class TestFrontend:
 
     def test_revert_item(self):
         self._test_view(
-            "frontend.revert_item", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist", rev="000000")
+            "frontend.revert_item", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist", rev="000000")
         )
 
     def test_mychanges(self):
-        self._test_view("frontend.mychanges", viewopts=dict(userid="000000"))
+        self._test_view("frontend.mychanges", viewargs=dict(userid="000000"))
 
     def test_global_history(self):
         self._test_view("frontend.global_history")
@@ -278,12 +314,12 @@ class TestFrontend:
         self._test_view(
             "frontend.quicklink_item",
             status="302 FOUND",
-            viewopts=dict(item_name="DoesntExist"),
+            viewargs=dict(item_name="DoesntExist"),
             data=["<!doctype html"],
         )
 
     def test_subscribe_item(self):
-        self._test_view("frontend.subscribe_item", status="404 NOT FOUND", viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.subscribe_item", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
     def test_register(self):
         self._test_view("frontend.register")
@@ -330,7 +366,7 @@ class TestFrontend:
 
     def test_diffraw(self):
         # TODO: Add another test with valid rev1 and rev2 URL args and an existing item.
-        self._test_view("frontend.diffraw", status="404 NOT FOUND", data=[], viewopts=dict(item_name="DoesntExist"))
+        self._test_view("frontend.diffraw", status="404 NOT FOUND", data=[], viewargs=dict(item_name="DoesntExist"))
 
     def test_global_tags(self):
         self._test_view("frontend.global_tags")

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -29,11 +29,14 @@ import threading
 import urllib.request
 import urllib.parse
 import urllib.error
+
+from ast import literal_eval
 from io import BytesIO
 from datetime import datetime
 from datetime import timezone
 from collections import namedtuple
 from functools import wraps, partial
+from itertools import chain
 
 from werkzeug.exceptions import BadRequest
 from werkzeug.utils import secure_filename
@@ -56,9 +59,16 @@ from whoosh.query.qcore import QueryError, TermNotFound
 from whoosh.analysis import StandardAnalyzer
 
 from moin import current_app, flaskg, log
-from moin.i18n import _, L_
-from moin.themes import render_template, contenttype_to_class, get_editor_info
+from moin.constants.contenttypes import *  # noqa
+from moin.constants.forms import WIDGET_HIDDEN
+from moin.constants.itemtypes import ITEMTYPE_DEFAULT, ITEMTYPE_NONEXISTENT
+from moin.constants.keys import *  # noqa
+from moin.constants.misc import FLASH_REPEAT
+from moin.constants.namespaces import *  # noqa
+from moin.constants.rights import SUPERUSER
+from moin.converters import default_registry as reg
 from moin.forms import (
+    Boolean,
     OptionalText,
     RequiredText,
     YourEmail,
@@ -78,9 +88,11 @@ from moin.forms import (
     validate_name,
     NameNotValidError,
 )
+from moin.i18n import _, L_
 from moin.items import (
     BaseChangeForm,
     Item,
+    ItemDeletionResult,
     NonExistent,
     NameNotUniqueError,
     MissingParentError,
@@ -89,12 +101,13 @@ from moin.items import (
     find_matches,
 )
 from moin.items.content import content_registry, conv_serialize
-from moin.constants.keys import *  # noqa
-from moin.constants.namespaces import *  # noqa
-from moin.constants.itemtypes import ITEMTYPE_DEFAULT, ITEMTYPE_NONEXISTENT
-from moin.constants.contenttypes import *  # noqa
-from moin.constants.rights import SUPERUSER
-from moin.constants.misc import FLASH_REPEAT
+from moin.search import SearchForm
+from moin.search.analyzers import item_name_analyzer
+from moin.security.csp import add_csp_headers
+from moin.signalling import item_displayed, item_modified
+from moin.storage.middleware.exceptions import AccessDenied
+from moin.storage.middleware.validation import validate_data
+from moin.themes import render_template, contenttype_to_class, get_editor_info
 from moin.user import create_user, normalize_username, search_users, User
 from moin.utils import crypto, rev_navigation, close_file, show_time, utcfromtimestamp
 from moin.utils.crypto import make_uuid, hash_hexdigest
@@ -103,13 +116,6 @@ from moin.utils.markup import safe_markup
 from moin.utils.mime import Type, type_moin_document
 from moin.utils.names import CompositeName, gen_fqnames, split_fqname
 from moin.utils.tree import html, docbook
-from moin.search import SearchForm
-from moin.search.analyzers import item_name_analyzer
-from moin.security.csp import add_csp_headers
-from moin.signalling import item_displayed, item_modified
-from moin.storage.middleware.exceptions import AccessDenied
-from moin.converters import default_registry as reg
-from moin.storage.middleware.validation import validate_data
 import moin.utils.mimetype as mime_type
 
 if TYPE_CHECKING:
@@ -1163,31 +1169,10 @@ def delete_item(item_name):
     return ret
 
 
-@frontend.route("/+ajaxdelete/<itemname:item_name>", methods=["POST"])
-@frontend.route("/+ajaxdelete", defaults=dict(item_name=""), methods=["POST"])
-def ajaxdelete(item_name):
-    return ajaxdestroy(item_name, req="delete")
+def _delete_items(itemnames: list[str], comment: str, do_subitems: bool, do_destroy: bool) -> ItemDeletionResult:
 
+    result = ItemDeletionResult()
 
-@frontend.route("/+ajaxdestroy/<itemname:item_name>", methods=["POST"])
-@frontend.route("/+ajaxdestroy", defaults=dict(item_name=""), methods=["POST"])
-def ajaxdestroy(item_name, req="destroy"):
-    """
-    Handles both ajax delete and ajax destroy.
-
-    Incoming item_name not currently used, contains parent name of items to be deleted/destroyed or ''.
-
-    Json response object includes these lists:
-        - itemnames: list of item names and subnames successfully deleted/destroyed in url format
-        - messages: formatted success/fail message for each item processed
-    """
-    args = request.values.to_dict()
-    comment = args.get("comment")
-    itemnames = args.get("itemnames")
-    do_subitems = True if args.get("do_subitems") == "true" else False
-    itemnames = json.loads(itemnames)
-    response = {"itemnames": [], "messages": []}
-    messages = []
     for itemname_url in itemnames:
         itemname = urllib.parse.unquote(itemname_url)  # itemname is url quoted str
         try:
@@ -1195,47 +1180,197 @@ def ajaxdestroy(item_name, req="destroy"):
             if isinstance(item, NonExistent):
                 # we should not try to destroy a nonexistent item,
                 # user probably checked a subitem and checked do subitems
-                response["messages"].append(
-                    _("Item '{bad_name}' does not exist or you do not have permission to access it.").format(
-                        bad_name=item.name
-                    )
+                message = _("Item '{bad_name}' does not exist or you do not have permission to access it.").format(
+                    bad_name=item.name
                 )
+                result.messages.append(message)
                 continue
-            subitem_names = []
-            if req == "destroy":
+
+            if do_destroy:
+                subitem_names: list[str] = []
                 if do_subitems:
                     subitems = item.get_subitem_revs()
                     # if subitem has alias of unselected sibling or ancester, it will be included
-                    subitem_names = [x.meta.revision.names for x in subitems]
-                messages, subitem_names = item.destroy(
-                    comment=comment, destroy_item=True, subitem_names=subitem_names, ajax=True
-                )
+                    subitem_names += chain.from_iterable([x.meta.revision.names for x in subitems])
+                result += item.destroy(comment=comment, destroy_item=True, subitem_names=subitem_names)
                 log_destroy_action(item, subitem_names, comment)
+                result.itemnames += subitem_names
             else:
                 try:
-                    messages, subitem_names = item.delete(comment, do_subitems=do_subitems, ajax=True)
+                    result += item.delete(comment, do_subitems=do_subitems)
                 except AccessDenied:
                     # some deletes may have succeeded, one failed, there may be unprocessed items
                     msg = _("Access denied for a subitem of {bad_name}, check History for status.").format(
                         bad_name=itemname
                     )
-                    response["messages"].append(msg)
-            response["messages"] += messages
-            response["itemnames"] += subitem_names + itemnames
+                    result.messages.append(msg)
+            result.itemnames += itemnames
+            close_file(item.rev.data)
         except AccessDenied:
-            response["messages"].append(_("Access denied processing '{bad_name}'.").format(bad_name=itemname))
-    return jsonify(response)
+            result.messages.append(_("Access denied processing '{bad_name}'.").format(bad_name=itemname))
+
+    return result
 
 
-@frontend.route("/+ajaxmodify/<itemname:item_name>", methods=["POST"])
+@frontend.route("/+ajaxdelete", defaults=dict(item_name=""), methods=["POST"])
+@frontend.route("/+ajaxdelete/<itemname:item_name>", methods=["POST"])
+def ajaxdelete(item_name: str) -> Response:
+    """
+    Handles an ajax delete request.
+
+    Incoming item_name not currently used, contains parent name of items to be deleted/destroyed or ''.
+
+    JSON response object includes these lists:
+        - itemnames: list of item names and subnames successfully deleted/destroyed in url format
+        - messages: formatted success/fail message for each item processed
+    """
+    assert request.is_json
+    data = request.json
+    itemnames = data["itemnames"]
+    comment = data["comment"]
+    do_subitems = data.get("do_subitems", False)
+    result = _delete_items(itemnames, comment, do_subitems, do_destroy=False)
+    return jsonify(result.as_dict())
+
+
+@frontend.route("/+ajaxdestroy", defaults=dict(item_name=""), methods=["POST"])
+@frontend.route("/+ajaxdestroy/<itemname:item_name>", methods=["POST"])
+def ajaxdestroy(item_name: str) -> Response:
+    """
+    Handles an ajax destroy request.
+
+    Incoming item_name not currently used, contains parent name of items to be deleted/destroyed or ''.
+
+    JSON response object includes these lists:
+        - itemnames: list of item names and subnames successfully deleted/destroyed in url format
+        - messages: formatted success/fail message for each item processed
+    """
+    assert request.is_json
+    data = request.json
+    itemnames = data["itemnames"]
+    comment = data["comment"]
+    do_subitems = data.get("do_subitems", False)
+    result = _delete_items(itemnames, comment, do_subitems, do_destroy=True)
+    return jsonify(result.as_dict())
+
+
+def _create_item_from_file_upload(item_name, data_file):
+    message = ""
+    base_file_name = os.path.basename(data_file.filename)
+    file_name = secure_filename(base_file_name)
+    if file_name != base_file_name:
+        message = _("File Successfully uploaded and renamed from {bad_name} to {good_name}. ").format(
+            bad_name=base_file_name, good_name=file_name
+        )
+    subitem_name = file_name
+    item_name = f"{item_name}/{subitem_name}" if item_name else subitem_name
+    mt = mime_type.MimeType(filename=file_name)
+    contenttype = mt.content_type(charset="utf-8")
+    small_meta = {CONTENTTYPE: contenttype}
+
+    details = dict(file=item_name, name=subitem_name, message=message, contenttype=contenttype_to_class(contenttype))
+
+    valid = validate_data(small_meta, data_file.stream)
+    if not valid:
+        message = _(
+            "UnicodeDecodeError, upload failed, not a text file, nothing saved: '{file_name}'. "
+            "Try changing the name."
+        ).format(file_name=file_name)
+        details["message"] = message
+        return None, details
+
+    with jfu_server_lock:
+        try:
+            item = Item.create(item_name)
+            if not isinstance(item, NonExistent):
+                message += _("File Successfully uploaded, existing file overwritten: '{file_name}'.").format(
+                    file_name=file_name
+                )
+            revid, size = item.modify({"itemtype": ITEMTYPE_DEFAULT}, data_file.stream, contenttype_guessed=contenttype)
+        except AccessDenied:
+            # return 200 status with error message
+            message = _("Permission denied, upload failed: '{file_name}'.").format(file_name=file_name)
+            details["message"] = message
+            return None, details
+
+    item_modified.send(current_app, fqname=item.fqname, action=ACTION_SAVE, new_meta=item.meta)
+
+    message = _("File Successfully uploaded: '{item_name}'.").format(item_name=item_name)
+    details["message"] = message
+    details["revid"] = revid
+    details["size"] = str(size)
+
+    return item, details
+
+
 @frontend.route("/+ajaxmodify", methods=["POST"], defaults=dict(item_name=""))
+@frontend.route("/+ajaxmodify/<path:item_name>", methods=["POST"])
 def ajaxmodify(item_name):
-    newitem = request.values.get("newitem")
-    if not newitem:
-        abort(404, item_name)
+    new_name = request.values.get("new_name")
+    if not new_name:
+        abort(404, new_name)
     if item_name:
-        newitem = item_name + "/" + newitem
-    return redirect(url_for_item(newitem))
+        new_name = f"{item_name}/{new_name}"
+    return redirect(url_for_item(new_name))
+
+
+def _get_subitems(item_names: list[str], action_auth: str):
+
+    all_alias_names: set[str] = set()
+    all_subitem_names: set[str] = set()
+    all_selected_names: set[str] = set()
+    all_rejected_names: set[str] = set()
+
+    for item_name in item_names:
+        item_name = urllib.parse.unquote(item_name)
+        try:
+            item = Item.create(item_name, rev_id=CURRENT)
+        except AccessDenied:
+            abort(403)  # should never happen
+
+        if isinstance(item, NonExistent):
+            # user deletes item with alias, then tries to delete same item with other alias
+            all_rejected_names.add(item_name)
+            continue
+
+        fqname = item.fqname
+        if action_auth == "destroy":
+            if not flaskg.user.may.destroy(fqname):
+                # user can read this item, but not destroy
+                all_rejected_names.add(item_name)
+                continue
+        else:
+            if not flaskg.user.may.write(fqname):
+                # user can read this item, but not delete
+                all_rejected_names.add(item_name)
+                continue
+
+        alias_names = []
+        subitems = list(item.get_subitem_revs())
+
+        # TODO: add check for delete/destroy auth, add to rejected names,
+        # subitems may have alias names pointing to sibling or parent of user selected items
+
+        if fqname.namespace:
+            namespace_prefix = f"{fqname.namespace}/"  # used to build fullname for aliases and subitems
+        else:
+            namespace_prefix = ""
+
+        subitem_names = [f"{namespace_prefix}{y}" for x in subitems for y in x.meta[NAME]]
+
+        if not [item.name] == item.names:
+            alias_names = [f"{namespace_prefix}{x}" for x in item.names if not x == item.name]
+
+        all_alias_names.update(alias_names)
+        all_subitem_names.update(subitem_names)
+        all_selected_names.add(item_name)
+
+    return {
+        "subitem_names": sorted(list(all_subitem_names)),
+        "alias_names": list(all_alias_names),
+        "selected_names": list(all_selected_names),
+        "rejected_names": list(all_rejected_names),
+    }
 
 
 @frontend.route("/+ajaxsubitems", methods=["POST"])
@@ -1249,60 +1384,14 @@ def ajaxsubitems():
     """
     item_names = request.values.getlist("item_names[]")
     action_auth = request.values.get("action_auth")
-    all_alias_names = []
-    all_subitem_names = []
-    all_selected_names = []
-    all_rejected_names = []
-    for item_name in item_names:
-        item_name = urllib.parse.unquote(item_name)
-        try:
-            item = Item.create(item_name, rev_id=CURRENT)
-        except AccessDenied:
-            abort(403)  # should never happen
-        if isinstance(item, NonExistent):
-            # user deletes item with alias, then tries to delete same item with other alias
-            all_rejected_names.append(item_name)
-            continue
-        fqname = item.fqname
-        if action_auth == "destroy":
-            if not flaskg.user.may.destroy(fqname):
-                # user can read this item, but not destroy
-                all_rejected_names.append(item_name)
-                continue
-        else:
-            if not flaskg.user.may.write(fqname):
-                # user can read this item, but not delete
-                all_rejected_names.append(item_name)
-                continue
-        alias_names = []
-        subitems = list(item.get_subitem_revs())
-        # TODO: add check for delete/destroy auth, add to rejected names,
-        # subitems may have alias names pointing to sibling or parent of user selected items
-
-        if fqname.namespace:
-            namespace_prefix = f"{fqname.namespace}/"  # used to build fullname for aliases and subitems
-        else:
-            namespace_prefix = ""
-
-        subitem_names = [f"{namespace_prefix}{y}" for x in subitems for y in x.meta[NAME]]
-
-        if not [item.name] == item.names:
-            alias_names = [f"{namespace_prefix}{x}" for x in item.names if not x == item.name]
-        all_alias_names += alias_names
-        all_subitem_names += subitem_names
-        all_selected_names.append(item_name)
-    all_subitem_names = set(all_subitem_names)
-    response = {
-        "subitem_names": list(all_subitem_names),
-        "alias_names": all_alias_names,
-        "selected_names": all_selected_names,
-        "rejected_names": all_rejected_names,
-    }
-    return jsonify(response)
+    result = _get_subitems(item_names, action_auth)
+    return jsonify(result)
 
 
 def log_destroy_action(item, subitem_names, comment, revision=None):
-    """Document the destruction of an item or item revision."""
+    """
+    Document the destruction of an item or item revision.
+    """
     destroy_info = [
         ("An item has been destroyed", ""),
         ("  Names", item.meta[NAME]),
@@ -1353,17 +1442,22 @@ def destroy_item(item_name, rev):
     else:
         _rev = rev
         destroy_item = False
+
     try:
         item = Item.create(item_name, rev_id=_rev)
     except AccessDenied:
         abort(403)
+
     fqname = item.fqname
     if not flaskg.user.may.destroy(fqname):
         abort(403)
+
     if isinstance(item, NonExistent):
         abort(404, fqname.fullname)
+
     item_may = get_item_permissions(fqname, item)
     item_is_deleted = flash_if_item_deleted(item_name, rev, item)
+
     subitem_names = []
     alias_names = []
     if rev is None and item_is_deleted:
@@ -1388,13 +1482,16 @@ def destroy_item(item_name, rev):
             if not do_subitems:
                 subitem_names = []
             try:
-                item.destroy(comment=comment, destroy_item=destroy_item, subitem_names=subitem_names)
+                result = item.destroy(comment=comment, destroy_item=destroy_item, subitem_names=subitem_names)
+                for message in result.messages:
+                    flash(message, "info")
             except AccessDenied:
                 abort(403)
             log_destroy_action(item, subitem_names, comment, revision=rev)
             # show user item is deleted by showing "item does not exist, create it?" page
             return redirect(url_for_item(item_name))
-    ret = render_template(
+
+    response = render_template(
         "destroy.html",
         item=item,
         item_name=item_name if item.meta[NAME] else item.meta[NAME_OLD][0],
@@ -1407,9 +1504,26 @@ def destroy_item(item_name, rev):
         item_is_deleted=item_is_deleted,
         may=item_may,
     )
+
     close_file(item.meta.revision.data)
     close_file(item.rev.data)
-    return ret
+
+    return response
+
+
+def _upload_file(item_name: str) -> tuple[Item | None, dict[str, str]]:
+
+    file_storage = request.files.get("file_storage")
+
+    try:
+        item, details = _create_item_from_file_upload(item_name, file_storage)
+    except Exception as err:
+        item = None
+        details = {"message": str(err)}
+    finally:
+        file_storage.close()
+
+    return item, details
 
 
 @frontend.route("/+jfu-server/<itemname:item_name>", methods=["POST"])
@@ -1418,83 +1532,12 @@ def jfu_server(item_name):
     """
     jquery-file-upload server component, returns a json response
     """
-    msg = ""
-    data_file = request.files.get("file_storage")
-    base_file_name = os.path.basename(data_file.filename)
-    file_name = secure_filename(base_file_name)
-    if not file_name == base_file_name:
-        msg = _("File Successfully uploaded and renamed from {bad_name} to {good_name}. ").format(
-            bad_name=base_file_name, good_name=file_name
-        )
-    subitem_name = file_name
-    data = data_file.stream
-    mt = mime_type.MimeType(filename=file_name)
-    contenttype = mt.content_type(charset="utf-8")
-    small_meta = {CONTENTTYPE: contenttype}
-    valid = validate_data(small_meta, data)
-    if not valid:
-        msg = _(
-            "UnicodeDecodeError, upload failed, not a text file, nothing saved: '{file_name}'. "
-            "Try changing the name."
-        ).format(file_name=file_name)
-        ret = make_response(
-            jsonify(
-                file=item_name,
-                name=subitem_name,
-                message=msg,
-                css_class="jfu-failed",
-                contenttype=contenttype_to_class(contenttype),
-            ),
-            200,
-        )
-        return ret
-
-    if item_name:
-        subitem_prefix = item_name + "/"
+    item, details = _upload_file(item_name)
+    if item is None:
+        details.update(css_class="jfu-failed")
     else:
-        subitem_prefix = ""
-    item_name = subitem_prefix + subitem_name
-    jfu_server_lock.acquire()
-    try:
-        item = Item.create(item_name)
-        if not isinstance(item, NonExistent):
-            msg += _("File Successfully uploaded, existing file overwritten: '{file_name}'.").format(
-                file_name=file_name
-            )
-        revid, size = item.modify({"itemtype": ITEMTYPE_DEFAULT}, data, contenttype_guessed=contenttype)
-        jfu_server_lock.release()
-    except AccessDenied:
-        # return 200 status with error message
-        jfu_server_lock.release()
-        msg = _("Permission denied, upload failed: '{file_name}'.").format(file_name=file_name)
-        ret = make_response(
-            jsonify(
-                file=item_name,
-                name=subitem_name,
-                message=msg,
-                css_class="jfu-failed",
-                contenttype=contenttype_to_class(contenttype),
-            ),
-            200,
-        )
-        return ret
-
-    data_file.close()
-    item_modified.send(current_app, fqname=item.fqname, action=ACTION_SAVE, new_meta=item.meta)
-    if not msg:
-        msg = _("File Successfully uploaded: '{item_name}'.").format(item_name=item_name)
-    ret = make_response(
-        jsonify(
-            file=item_name,
-            name=subitem_name,
-            size=size,
-            url=url_for(".show_item", item_name=item_name),
-            contenttype=contenttype_to_class(contenttype),
-            message=msg,
-        ),
-        200,
-    )
-    return ret
+        details.update(url=url_for(".show_item", item_name=item.fqname))
+    return make_response(jsonify(**details), 200)
 
 
 def contenttype_selects_gen():
@@ -1509,16 +1552,97 @@ ContenttypeGroup = MultiSelect.of(Enum.out_of(contenttype_selects_gen())).using(
 
 class IndexForm(Form):
     contenttype = ContenttypeGroup
+    show_create_item = Boolean.with_properties(widget=WIDGET_HIDDEN).using(default=False)
+    show_namespace_list = Boolean.with_properties(widget=WIDGET_HIDDEN).using(default=False)
+    show_content_filter = Boolean.with_properties(widget=WIDGET_HIDDEN).using(default=False)
     submit_label = L_("Apply Filter")
 
 
-@frontend.route("/+index/", defaults=dict(item_name=""), methods=["GET", "POST"])
-@frontend.route("/+index/<itemname:item_name>", methods=["GET", "POST"])
-def index(item_name):
+@frontend.route("/+index", defaults=dict(item_name=""), methods=["GET", "POST"])
+@frontend.route("/+index/<path:item_name>", methods=["GET", "POST"])
+def index(item_name: str):
     """
     Generate data for various index reports: global, sub-item, starts with character,
     or namespace. Identify missing items causing orphan sub-items.
     """
+
+    form = IndexForm.from_flat(list(request.args.items(multi=True)) + list(request.form.items(multi=True)))
+
+    action = request.args.get("action")
+
+    selected_names = []
+    alias_names = []
+    rejected_names = []
+    subitem_names = []
+
+    if request.method == "POST":
+
+        if action == "cancel" or action == "close":
+            redirect_target = urllib.parse.urlparse(request.referrer)._replace(query="").geturl()
+            return redirect(redirect_target)
+
+        elif action == "download-file":
+            item_names = request.form.getlist("itemname")
+            if len(item_names) == 1:
+                fqname = split_fqname(item_names[0])
+                item = Item.create(item_names[0], rev_id=CURRENT)
+                if item is not None and item.itemtype != ITEMTYPE_NONEXISTENT:
+                    return item.content.do_get(force_attachment=True)
+                else:
+                    flash("Item not found.", "info")
+            else:
+                flash("Only a single file can be downloaded", "info")
+
+            redirect_target = urllib.parse.urlparse(request.referrer)._replace(query="").geturl()
+            return redirect(redirect_target)
+
+        elif action == "upload-file":
+            uploaded_item, details = _upload_file(item_name)
+            flash(details.get("message", "Upload finished"), "info")
+            redirect_target = urllib.parse.urlparse(request.referrer)._replace(query="").geturl()
+            return redirect(redirect_target)
+
+        elif action == "delete" or action == "destroy":
+            item_names = request.form.getlist("itemname")
+            result = _get_subitems(item_names, action)
+            selected_names = result["selected_names"]
+            alias_names = result["alias_names"]
+            rejected_names = result["rejected_names"]
+            subitem_names = result["subitem_names"]
+
+        elif action == "submit-deletion":
+            item_names = literal_eval(request.form.get("selected-names"))
+            comment = request.form.get("comment")
+            do_subitems = request.form.get("do_subitems", type=bool)
+            do_destroy = request.form.get("delete-action") == "destroy"
+            result = _delete_items(item_names, comment, do_subitems, do_destroy)
+            for message in result.messages:
+                flash(message, "info")
+            redirect_target = urllib.parse.urlparse(request.referrer)._replace(query="").geturl()
+            return redirect(redirect_target)
+
+        elif action == "create-new-item":
+            new_name = request.values.get("new_name")
+            if not new_name:
+                abort(404, new_name)
+            if item_name:
+                new_name = f"{item_name}/{new_name}"
+            return redirect(url_for_item(new_name))
+
+        elif action == "toggle-create-item":
+            form["show_create_item"] = not form["show_create_item"]
+            form["show_namespace_list"] = False
+            form["show_content_filter"] = False
+
+        elif action == "toggle-namespace-display":
+            form["show_create_item"] = False
+            form["show_namespace_list"] = not form["show_namespace_list"]
+            form["show_content_filter"] = False
+
+        elif action == "toggle-content-filter":
+            form["show_create_item"] = False
+            form["show_namespace_list"] = False
+            form["show_content_filter"] = not form["show_content_filter"]
 
     def name_initial(files, uppercase=False, lowercase=False):
         """
@@ -1539,15 +1663,14 @@ def index(item_name):
         item = Item.create(item_name)  # when item_name='', it gives toplevel index
     except AccessDenied:
         abort(403)
+
     item_may = get_item_permissions(item_name, item)
 
-    # request.args is a MultiDict instance, which degenerates into a normal
-    # single-valued dict on most occasions (making the first value the *only*
-    # value for a specific key) unless explicitly told to expose multiple
-    # values, e.g. calling items with multi=True. See Werkzeug documentation for
-    # more.
+    # request.args is a MultiDict instance, which degenerates into a normal single-valued dict on most
+    # occasions (making the first value the *only* value for a specific key) unless explicitly told to
+    # expose multiple values, e.g. calling items with multi=True.
+    # See the Werkzeug documentation for more.
 
-    form = IndexForm.from_flat(request.args.items(multi=True))
     selected_groups = form["contenttype"].value
     startswith = request.values.get("startswith")
     dirs, files = item.get_index(startswith, selected_groups, short=True)
@@ -1603,6 +1726,10 @@ def index(item_name):
         item_names=item_names,
         item_name=item_name,
         fqname=fqname,
+        selected_names=selected_names,
+        alias_names=alias_names,
+        rejected_names=rejected_names,
+        subitem_names=subitem_names,
         files=files,
         dirs=dirs,
         dirs_fullname=dirs_fullname,
@@ -1610,6 +1737,7 @@ def index(item_name):
         initials=initials,
         startswith=startswith,
         form=form,
+        action=action,
         item=item,
         title=title,
         NAMESPACE_USERPROFILES=NAMESPACE_USERPROFILES,

--- a/src/moin/items/__init__.py
+++ b/src/moin/items/__init__.py
@@ -25,6 +25,7 @@ import difflib
 import json
 import re
 
+from dataclasses import asdict, dataclass, field
 from io import BytesIO, IOBase
 from time import time, strftime
 from operator import attrgetter
@@ -115,11 +116,26 @@ if TYPE_CHECKING:
 
 logging = log.getLogger(__name__)
 
-
 PreviewDiffItem: TypeAlias = tuple[int, Markup, int, Markup]
 
 COLS = 80
 ROWS_META = 10
+
+
+@dataclass
+class ItemDeletionResult:
+
+    messages: list[str] = field(default_factory=list)
+    itemnames: list[str] = field(default_factory=list)
+
+    def __iadd__(self, other: ItemDeletionResult) -> ItemDeletionResult:
+        assert other is not self
+        self.itemnames += other.itemnames
+        self.messages += other.messages
+        return self
+
+    def as_dict(self) -> dict[str, list[str]]:
+        return asdict(self)
 
 
 def find_matches(fq_name, s_re=None, e_re=None):
@@ -851,41 +867,26 @@ class Item:
         return meta
 
     def _rename(
-        self,
-        names: list[str],
-        comment: str,
-        action: str,
-        delete: bool = False,
-        do_subitems: bool = True,
-        ajax: bool = False,
-    ) -> tuple[list[str], list[str]]:
+        self, names: list[str], comment: str, action: str, delete: bool = False, do_subitems: bool = True
+    ) -> ItemDeletionResult:
         """
         Process Delete and Rename actions.
 
         Delete removes all alias names, and at users option (do_subitems=True) all subitems of all aliases.
         Rename changes subitem names only when the parent name is removed/changed.
         """
-        messages: list[str] = []
-        subitem_names: list[str] = []
+        assert self.content
+        result = ItemDeletionResult()
         self._save(self.meta, self.content.data, names=names, action=action, comment=comment, delete=delete)
         old_name = self.names if len(self.names) > 1 else self.names[0]
         new_name = names if len(names) > 1 else names[0]
         if delete:
-            if ajax:
-                messages.append(L_('The item "{name}" was deleted.').format(name=old_name))
-            else:
-                flash(L_('The item "{name}" was deleted.').format(name=old_name), "info")
+            result.messages.append(L_('The item "{name}" was deleted.').format(name=old_name))
         else:
             # rename
-            if ajax:
-                messages.append(
-                    L_('The item "{name}" was renamed to "{new_name}".').format(name=old_name, new_name=new_name)
-                )
-            else:
-                flash(
-                    L_('The item "{name}" was renamed to "{new_name}".').format(name=old_name, new_name=new_name),
-                    "info",
-                )
+            result.messages.append(
+                L_('The item "{name}" was renamed to "{new_name}".').format(name=old_name, new_name=new_name)
+            )
         removed_names = set(self.meta[NAME]) - set(names)
         removed_names = tuple(x + "/" for x in removed_names)
         if removed_names or delete:
@@ -900,12 +901,9 @@ class Item:
                     item._save(
                         item.meta, item.content.data, names=child_newname, action=action, comment=comment, delete=delete
                     )
-                    if ajax:
-                        messages.append(L_('The subitem "{name}" was deleted.').format(name=old_name))
-                    else:
-                        flash(L_('The item "{name}" was deleted.').format(name=old_name), "info")
+                    result.messages.append(L_('The subitem "{name}" was deleted.').format(name=old_name))
                     close_file(item.rev.data)
-                    subitem_names += [x.fullname for x in child.meta.revision.fqnames]
+                    result.itemnames += [x.fullname for x in child.meta.revision.fqnames]
                 else:  # rename
                     working_name = child.meta[NAME][:]
                     for child_oldname in child.meta[NAME]:
@@ -925,14 +923,13 @@ class Item:
                                     delete=delete,
                                 )
                                 new_name = working_name if len(working_name) > 1 else working_name[0]
-                                flash(
+                                result.messages.append(
                                     L_('The item "{name}" was renamed to "{new_name}".').format(
                                         name=old_name, new_name=new_name
-                                    ),
-                                    "info",
+                                    )
                                 )
                                 close_file(item.rev.data)
-        return messages, subitem_names
+        return result
 
     def rename(self, names: str | list[str], comment: str = "") -> None:
         """
@@ -955,24 +952,22 @@ class Item:
                 _verify_parents(self, name, self.fqname.namespace, old_name=self.fqname.value)
         self._rename(names, comment, action=ACTION_RENAME)
 
-    def delete(self, comment: str = "", do_subitems: bool = True, ajax: bool = False) -> tuple[list[str], list[str]]:
+    def delete(self, comment: str = "", do_subitems: bool = True) -> ItemDeletionResult:
         """
         delete this item
         """
         item_modified.send(current_app, fqname=self.fqname, action=ACTION_TRASH, data=self.rev.data, meta=self.meta)
-        ret = self._rename(self.names, comment, action=ACTION_TRASH, delete=True, do_subitems=do_subitems, ajax=ajax)
-        return ret
+        return self._rename(self.names, comment, action=ACTION_TRASH, delete=True, do_subitems=do_subitems)
 
     def revert(self, comment: str = "") -> tuple[str, int] | None:
+        assert self.content
         meta = dict(self.meta)
         meta[TRASH] = False
         if not self.meta[NAME]:
             meta[NAME] = meta[NAME_OLD]
         return self._save(meta, self.content.data, names=meta[NAME], action=ACTION_REVERT, comment=comment)
 
-    def destroy(
-        self, comment: str = "", destroy_item: bool = False, subitem_names: list = [], ajax: bool = False
-    ) -> tuple[list[str], list[str]]:
+    def destroy(self, comment: str = "", destroy_item: bool = False, subitem_names: list = []) -> ItemDeletionResult:
         """
         If destroy_item is false destroy current revision; else destroy current item and
         any items passed in subitem_names.
@@ -981,8 +976,8 @@ class Item:
 
         Return a list of messages and a list of destroyed names and alias names.
         """
-        messages = []
-        destroyed_names = self.names
+        result = ItemDeletionResult()
+        result.itemnames += self.names
         action = DESTROY_ALL if destroy_item else DESTROY_REV
         item_modified.send(current_app, fqname=self.fqname, action=action, data=self.rev.data, meta=self.meta)
         close_file(self.rev.data)
@@ -993,10 +988,7 @@ class Item:
         if destroy_item:
             # destroy complete item with all revisions, metadata, etc.
             self.rev.item.destroy_all_revisions()
-            if ajax:
-                messages.append(L_('The item "{name}" was destroyed.').format(name=old_name))
-            else:
-                flash(L_('The item "{name}" was destroyed.').format(name=old_name), "info")
+            result.messages.append(L_('The item "{name}" was destroyed.').format(name=old_name))
             # destroy all subitems
             for subitem_name in subitem_names:
                 first_name = subitem_name[0] if isinstance(subitem_name, list) else subitem_name
@@ -1005,35 +997,21 @@ class Item:
                 old_name = subitem_name if len(subitem_name) > 1 else subitem_name[0]
                 if flaskg.user.may.destroy(item.fqname):
                     item.rev.item.destroy_all_revisions()
-                    if ajax:
-                        messages.append(L_('The subitem "{name}" was destroyed.').format(name=old_name))
-                    else:
-                        flash(L_('The item "{name}" was destroyed.').format(name=old_name), "info")
-                    destroyed_names += item.names
+                    result.messages.append(L_('The subitem "{name}" was destroyed.').format(name=old_name))
+                    result.itemnames += item.names
                 else:
-                    if ajax:
-                        messages.append(
-                            L_('Error: The subitem "{name}" was not destroyed, permission denied.').format(
-                                name=old_name
-                            )
-                        )
-                    else:
-                        flash(
-                            L_('Error: The subitem "{name}" was not destroyed, permission denied.').format(
-                                name=old_name
-                            ),
-                            "info",
-                        )
+                    result.messages.append(
+                        L_('Error: The subitem "{name}" was not destroyed, permission denied.').format(name=old_name)
+                    )
         else:
             # just destroy this revision
             self.rev.item.destroy_revision(self.rev.revid)
-            flash(
+            result.messages.append(
                 L_('Rev Number {rev_number} of the item "{name}" was destroyed.').format(
                     rev_number=self.meta[REV_NUMBER], name=old_name
-                ),
-                "info",
+                )
             )
-        return messages, destroyed_names
+        return result
 
     def modify(
         self,

--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -473,7 +473,7 @@ a.moin-button:visited,
 a.moin-button:hover,
 a.moin-button:active { color: var(--primary); text-decoration: none; }
 .moin-button { background: var(--bg-button); border: 1px solid var(--border-button);
-    border-radius: 6px; cursor: pointer; font-size: 0.75em; font-weight: bold; padding: 4px 15px; margin: .3em; display: inline-block; }
+    border-radius: 6px; cursor: pointer; font-size: 0.75em; font-weight: bold; padding: 4px 15px; margin: .3em; }
 .moin-button.moin-button-disabled { background: var(--bg-disabled); }
 .moin-button:hover,
 .moin-button:focus { box-shadow: 2px 2px 1px var(--border-button-hover); outline: none; }
@@ -518,31 +518,29 @@ span.db-inlinemediaobject span.db-caption { display: none; } /* inline captions 
 .moin-index-menu li { display: inline-block; }
 .moin-select-allitem { display: inline-block; cursor: default; text-align: left; }
 .moin-download-link { display: none; }
-.moin-contenttype-selection { margin: .5em 0; display: none; }
-.moin-contenttype-selection div { cursor: pointer; margin: 0 0 .5em; padding: .5em 1.2em .5em .5em; height: 1em; text-align: center; }
 
-.moin-contenttype-selection form { z-index: 2;  background: var(--bg-primary);
-    border: 3px solid var(--border); padding: .2em; border-radius: 7px; }
+.moin-contenttype-selection { background: var(--bg-primary); border: 3px solid var(--border); border-radius: 7px; padding: 1em; }
+.moin-contenttype-selection div { padding: 0 0 .5em 0; height: 1em; text-align: center; }
+.moin-contenttype-selection form { z-index: 2; padding: .2em; }
 .moin-contenttype-selection ul li { list-style-type: none; }
-.moin-contenttype-selection ul li label { display: inline; vertical-align: middle; font-size: 1.25em; }
+.moin-contenttype-selection ul li label { display: inline; vertical-align: middle; font-size: 1em; }
 .moin-contenttype-selection ul li .helper-text { margin-left: 1em; font-size: .85em; color: var(--muted); }
 .moin-contenttype-selection form input[type="submit"] { font-size: .9em; }
-.moin-filter-toggle { margin: .5em 2em; font-size: 90%; }
+.moin-filter-toggle { margin: .5em 2em; }
 .moin-index-path { margin-left: .5em; margin-top: 2em; font-size: 1.33em; }
 .moin-path-separator { font-size: 120%; color: var(--primary); }
 .moin-index-separator { clear: both; border-top: 3px solid var(--border);
     width: 99%; margin-left: .5%; margin-bottom: 1.5em; display: none; }
 
-.moin-namespace-selection { background: var(--bg-primary); border-radius: 7px;
-    border: 3px solid var(--border); padding: .2em; display: none; }
+.moin-namespace-selection { background: var(--bg-primary); border: 3px solid var(--border); border-radius: 7px; padding: .2em 1em; }
 .moin-namespace-selection ul li { list-style-type: none; font-size: 1.25em; }
+
+.moin-newitem-selection { background: var(--bg-primary); border: 3px solid var(--border); border-radius: 7px; padding: 1em; }
 .moin-newitem-toggle,
 .moin-ns-toggle,
 .moin-ct-toggle { color: var(--primary); }
 #moin-newitem { width: 50%; }
 .moin-new-item { margin-left: 1em; }
-.moin-newitem-selection { background: var(--bg-primary); border-radius: 7px;
-    border: 3px solid var(--border); padding: .2em; display: none; }
 #moin-initials { width: 90%; margin: 1em auto; text-align: center; }
 #moin-initials a { display: inline-block; margin: 2px 1px; padding: 4px 5px; }
 #moin-initials a.selected { background: var(--bg-inverse); border-radius: 5px;
@@ -554,7 +552,7 @@ span.db-inlinemediaobject span.db-caption { display: none; } /* inline captions 
 p.moin-selected-groups { font-size: 1.25em; font-weight: bold; }
 li.moin-selected-groups { font-size: 1em; font-weight: bold; }
 
-#popup { padding: 0; width: 80%; position: absolute; top: 10em; left: 10%; display: none; z-index: 10;
+#popup { padding: 0; width: 80%; position: absolute; top: 10em; left: 10%; z-index: 10;
     border: 3px solid var(--border-popup); }
 .popup-header { background: var(--bg-popup-header); color: var(--inverse);
     font-size: 1.25em; padding: 10px; margin: 0; font-weight: bold; }
@@ -574,7 +572,6 @@ li.moin-selected-groups { font-size: 1em; font-weight: bold; }
    background-position: right bottom; transition:all 1s ease; padding: 1em; }
 .jfu-file.jfu-failed { background: linear-gradient(to right, var(--jfu-failed) 100%, transparent 100%); }
 .jfu-bar { margin-top: 1em; font-weight: bold; background: var(--jfu-progress); width: 0%; }
-#jfu-fileupload { margin-left: 1em; }
 
 /* Forms - User Settings, rename, delete, destroy, register, diff... */
 

--- a/src/moin/static/js/index_action.js
+++ b/src/moin/static/js/index_action.js
@@ -8,13 +8,15 @@
 /*global $:true, _:true */
 
 // This anonymous function is executed once after a global index page loads.
-$("document").ready(function () {
+$(function () {
+
     "use strict";
 
-    var POPUP_FADE_TIME = 200, // fade in, fade out times for selected popups
-        IFRAME_REMOVE_DELAY = 3000, // life expectancy of iframe used for file downloads
-        // delete and destroy process started and completed messages
-        ACTION_LOADING = {'delete': _("Deleting.."),
+    // life expectancy of iframe used for file downloads
+    const IFRAME_REMOVE_DELAY = 3000;
+
+    // delete and destroy process started and completed messages
+    var ACTION_LOADING = {'delete': _("Deleting.."),
                           'destroy': _("Destroying..")},
         ACTION_DONE = {'delete': _("Items deleted: "),
                        'destroy': _("Items destroyed: ")},
@@ -46,6 +48,7 @@ $("document").ready(function () {
             dataType: "json",
             data: {item_names: checked_names, action_auth: action},
             success: (function(response) {
+                $('input[name="selected-names"]').val(JSON.stringify(response.selected_names));
                 if (response.rejected_names.length) {
                     $('p.popup-rejected-names > span').text(response.rejected_names.join(', '));
                     $('p.popup-rejected-names').removeClass("hidden");
@@ -65,10 +68,9 @@ $("document").ready(function () {
     }
 
     // called by click handlers Delete item, and Destroy item within Actions dropdown menu
-    function showpop(action) {
+    function show_popup(action) {
+        $('input[name="delete-action"]').val(action);
         // hide Actions popup and show Comment popup
-        $(".popup-container").css("display", "none");
-        $("#popup-for-action").css("display", "block");
         $(".popup-comment").val("");
         $(".popup-action").val(action);
         if (action === "delete") {
@@ -77,15 +79,14 @@ $("document").ready(function () {
             $(".popup-header > span").html(POPUP_DESTROY_HEADER);
         }
         get_subitem_names(action);
-        $("#popup").fadeIn();
+        $("#popup").removeClass("hidden");
         $(".popup-comment").focus();
         $("#lightbox").css("display", "block");
     }
 
     // called by click handlers within "Create new item" and "Please provide comment" popups
-    function hidepop() {
-        // hide popup
-        $("#popup").css("display", "none");
+    function hide_popup() {
+        $("#popup").addClass("hidden");
         $("#lightbox").css("display", "none");
     }
 
@@ -99,42 +100,39 @@ $("document").ready(function () {
     }
 
     // executed via the "provide comment" popup triggered by an Actions Delete or Destroy selection
-    function do_action(comment, action) {
-        var links = [],
-            itemnames,
-            actionTrigger,
-            url;
-        // create an array of selected item names
-        $("input.moin-item:checked").each(function () {
-            var itemname = $(this).attr("value");
-            links.push(itemname);
-        });
+    function do_action(itemnames, comment, action) {
+        $("#popup").addClass("hidden");
         // remove any flash messages, display "deleting..." or "destroying..." flash msg while process is in progress
-        $("#popup").css("display", "none");
         // note the parent of .moin-flash messages is #moin-flash; moin-flash is used as both id and class
         $(".moin-flash").remove();
         MoinMoin.prototype.moinFlashMessage(MoinMoin.prototype.MOINFLASHINFO, ACTION_LOADING[action]);
         // create a transaction to delete or destroy selected items
-        itemnames = JSON.stringify(links);
-        actionTrigger = "moin-" + action + "-trigger";
-        url = $("#" + actionTrigger).attr("data-actionurl");
+        const actionTrigger = `moin-${action}-trigger`;
+        const url = $("#" + actionTrigger).attr("data-actionurl");
         // outgoing itemnames is an array of checked item names; comment is from text field of popup,
         // do_subitems is state of checkbox - true if subitems are to be processed
-        $.post(url, {
+        const data = {
+            action: action,
             itemnames: itemnames,
             comment: comment,
-            do_subitems: $("#moin-do-subitems").is(":checked") ? "true" : "false"
-        }, function (data) {
+            do_subitems: $('input[name="moin-do-subitems"]').is(":checked")
+        };
+        $.ajax({
+            type: "POST",
+            url: url,
+            contentType: "application/json; charset=utf-8",
+            data: JSON.stringify(data),
+            dataType: "json",
+        }).done(function (data) {
             // incoming itemnames is list of item names (including alias names) successfully deleted/destroyed
-            var itemnames = data.itemnames,
-                idx;
+            const itemnames = data.itemnames;
             // display success/fail flash messages created by server for each selected item and subitem
-            for (idx = 0; idx < data.messages.length; idx += 1) {
+            for (let idx = 0; idx < data.messages.length; idx += 1) {
                 MoinMoin.prototype.moinFlashMessage(MoinMoin.prototype.MOINFLASHINFO, data.messages[idx]);
             }
             // remove index rows for all deleted/destroyed items; including alias names (items with alias names have multiple rows)
             $.each(itemnames, function (itemindex, itemname) {
-                var isLastElement = itemindex == itemnames.length -1;
+                const isLastElement = itemindex == itemnames.length - 1;
                 $('input[value="' + itemname + '"]').parent().parent().parent().remove();
                 if (isLastElement) {
                     MoinMoin.prototype.moinFlashMessage(MoinMoin.prototype.MOINFLASHINFO, _("Action complete."));
@@ -144,11 +142,14 @@ $("document").ready(function () {
                     $('#moin-flash').find('p').first().remove();
                 }
             });
-        }, "json");
+        });
     }
 
+    // hide the upload button (used when javascript is disabled)
+    $("#upload-file-btn").addClass("hidden");
+
     // add click handler to "Select All" tab to select/deselect all items
-    $(".moin-select-toggle").change(function () {
+    $(".moin-select-toggle").on("change", function () {
         if ($(this).find("input").prop("checked")) {
             $(".moin-select-item > input.moin-item").each(function () {
                 $(this).prop('checked', true);
@@ -161,12 +162,14 @@ $("document").ready(function () {
     });
 
     // add click handler to Cancel buttons and red "X" on Delete, Destroy popups
-    $(".popup-cancel").click(function () {
-        hidepop();
+    $('button[name="popup-cancel"], button[name="popup-close"]').on("click", function () {
+        hide_popup();
+        return false;
     });
 
     // add click handler to "Download" button of Actions dropdown
-    $("#moin-download-trigger").click(function () {
+    $("#moin-download-trigger").on("click", function (event) {
+        event.preventDefault();
         if (!($(".moin-item:checked").length)) {
             $(".moin-flash").remove();
             MoinMoin.prototype.moinFlashMessage(MoinMoin.prototype.MOINFLASHWARNING, _("Download failed, no items were selected."));
@@ -180,36 +183,36 @@ $("document").ready(function () {
     });
 
     // add click handler to "Delete" and "Destroy" buttons of Actions dropdown
-    $(".moin-action-tab").click(function () {
-        var action = this.innerText;
+    $(".moin-action-tab").on("click", function (event) {
+        event.preventDefault();
+        const action = this.getAttribute("data-action");
         // Show error msg if nothing selected, else show comment popup. Hide actions dropdown.
         if (!($(".moin-item:checked").length)) {
             $(".moin-flash").remove();
             MoinMoin.prototype.moinFlashMessage(MoinMoin.prototype.MOINFLASHWARNING, action + ' failed, no items were selected.');
         } else {
-            if (this.id === "moin-delete-trigger") {
-                showpop("delete");
-            } else {
-                showpop("destroy");
-            }
+            show_popup(action);
         }
+        return false;
     });
 
     // add click handler to "Submit" button on "Please provide comment..." popup
-    $("#popup-form").submit(function (event) {
+    $('button[name="popup-submit"]').on("click", function (event) {
         event.preventDefault();
         // process delete or destroy action
-        var comment = $(".popup-comment").val(),
-            action = $(".popup-action").val();
-        comment = comment.trim();
-        do_action(comment, action);
-        hidepop();
+        const itemnames = JSON.parse($('input[name="selected-names"]').val());
+        const comment = $('input[name="moin-comment"]').val().trim();
+        const action = $('input[name="delete-action"]').val();
+        do_action(itemnames, comment, action);
+        hide_popup();
+        return false;
     });
 
     // add click handler to "Toggle" button on "Filter by content type" dropdown
-    $(".moin-filter-toggle").click(function () {
+    $(".moin-filter-toggle").on("click", function (event) {
+        event.preventDefault();
         // reverse checked/unchecked for each content type
-        $(".moin-contenttype-selection form").find("input[type='checkbox']").each(function () {
+        $(".moin-contenttype-selection").find("input[type='checkbox']").each(function () {
             $(this).prop('checked', !$(this).is(':checked'));
         });
         return false;
@@ -217,31 +220,37 @@ $("document").ready(function () {
 
     // Filter, Namespace, New Item buttons have similar actions, show last clicked action, hide others
     // add click handler to toggle button for content type "Filter" dropdown
-    $(".moin-ct-toggle").click(function () {
+    $(".moin-ct-toggle").on("click", function (event) {
+        event.preventDefault();
         // show/hide content type selection
-        $(".moin-contenttype-selection").toggle();
-        $(".moin-namespace-selection").css("display", "none");
-        $(".moin-newitem-selection").css("display", "none");
+        $(".moin-contenttype-selection").toggleClass("hidden");
+        $(".moin-namespace-selection").addClass("hidden");
+        $(".moin-newitem-selection").addClass("hidden");
+        return false;
     });
 
     // add click handler to toggle button on "Namespace" dropdown
-    $(".moin-ns-toggle").click(function () {
+    $(".moin-ns-toggle").on("click", function (event) {
+        event.preventDefault();
         // show/hide namespace selection
-        $(".moin-namespace-selection").toggle();
-        $(".moin-contenttype-selection").css("display", "none");
-        $(".moin-newitem-selection").css("display", "none");
+        $(".moin-namespace-selection").toggleClass("hidden");
+        $(".moin-contenttype-selection").addClass("hidden");
+        $(".moin-newitem-selection").addClass("hidden");
+        return false;
     });
 
     // add click handler to toggle button on "New Item" dropdown
-    $(".moin-newitem-toggle").click(function () {
+    $(".moin-newitem-toggle").on("click", function (event) {
+        event.preventDefault();
         // show/hide new item selection
-        $(".moin-newitem-selection").toggle();
-        $(".moin-contenttype-selection").css("display", "none");
-        $(".moin-namespace-selection").css("display", "none");
+        $(".moin-newitem-selection").toggleClass("hidden");
+        $(".moin-contenttype-selection").addClass("hidden");
+        $(".moin-namespace-selection").addClass("hidden");
+        return false;
     });
 
     // add click handlers to all items shown on global index page
-    $(".moin-select-item").click(function () {
+    $(".moin-select-item").on("click", function () {
         // toggle selection classes
         $(this > "input[type='checkbox']").prop('checked', !$(this > "input[type='checkbox']").is(':checked'));
         if ($(this).parent().hasClass("selected-item")) {
@@ -256,5 +265,4 @@ $("document").ready(function () {
 
     // add item count to upper left of table
     $(".moin-num-rows").text($('.moin-index tbody tr').length);
-
-    });
+});

--- a/src/moin/static/js/jfu.js
+++ b/src/moin/static/js/jfu.js
@@ -18,6 +18,9 @@ $(function () {
     "use strict";
     $('#jfu-fileupload').fileupload({
         dataType: 'json',
+        start: function (e) {
+            $("#jfu-progress").removeClass("hidden");
+        },
         add: function(e, data) {
             // show file upload progress bar and overall progress bar after user selects files
             data.context = $('<p class="jfu-file"></p>')

--- a/src/moin/templates/forms.html
+++ b/src/moin/templates/forms.html
@@ -184,10 +184,12 @@ See utils.html for more macros.
     </dd>
 {%- endmacro %}
 
- {% macro render_file_uploader(submit_url) %} {# pages that use this macro must also use file_uploader_scripts macro below #}
+{# pages that use this macro must also use file_uploader_scripts macro below #}
+{% macro render_file_uploader(submit_url, form_name) %}
     <div id="jfu-file_upload">
-        <input id="jfu-fileupload" type="file" name="file_storage" data-url={{ submit_url }}>
-        <div id="jfu-progress">
+        <input id="jfu-fileupload" type="file" name="file_storage" data-url={{ submit_url }} form="{{ form_name }}">
+        <button class="moin-button" id="upload-file-btn" form="{{ form_name }}">{{ _("Upload") }}</button>
+        <div id="jfu-progress" class="hidden">
             <p class="jfu-bar"></p>
          </div>
      </div>

--- a/src/moin/templates/index.html
+++ b/src/moin/templates/index.html
@@ -18,15 +18,17 @@ initially hidden by CSS, and displayed when the user clicks a button.
     {{ itemviews }}
 {% endblock %}
 
-{# Each item entry is formatted by the following macro. The entry includes
+{#
+Each item entry is formatted by the following macro. The entry includes
 a checkbox, an invisible link used by js for download, a link to the item
 (CSS places a content type icon before the link), a link to display subitems
-(if the item has subitems), size, number revisions, editor and modified time. #}
+(if the item has subitems), size, number revisions, editor and modified time.
+#}
 {% macro render_file_entry(e) %}
     <tr>
         <td class="moin-index-icons">
             <span class="moin-select-item">
-                <input class="moin-item" type="checkbox" name="{{ e.fullname }}" value="{{ e.fullname }}"/>
+                <input class="moin-item" type="checkbox" name="itemname" value="{{ e.fullname }}"/>
                 {% set mimetype = "application/x.moin.download" %}
                 {# invisible link below is used by js to download item #}
                 <a href="{{ url_for('.download_item', item_name=e.fullname, mimetype=mimetype) }}" class="moin-download-link">
@@ -98,52 +100,76 @@ a checkbox, an invisible link used by js for download, a link to the item
         </div>
     {% endif %}
 
-    <div class="moin-index-menu">
-        {% if not (dirs or files) %}
+    {{ gen.form.open(form, method="post", action=url_for('frontend.index', item_name=item_name), enctype="multipart/form-data") }}
+
+        <input type="hidden" name="show_content_filter" value="{{ form['show_content_filter'] }}" />
+        <input type="hidden" name="show_namespace_list" value="{{ form['show_namespace_list'] }}" />
+        <input type="hidden" name="show_create_item" value="{{ form['show_create_item'] }}" />
+
+        <div class="moin-index-menu">
+            {% if not (dirs or files) %}
             <p>
                 <i class="fa fa-minus-circle fa-lg"></i>
                 {{ _("There are no items or read permission is denied for all.") }}
             </p>
-        {% else %}
+            {% else %}
             {# display the row of action buttons: Select All, Download, Delete, Destroy, Filter, Namespace, New Item #}
             <span class="moin-select-toggle moin-button" title="{{ _('Toggle item selections') }}">
-               <input type="checkbox" id="moin-select-all"/>
-               <label for="moin-select-all">{{ _("Select All") }}</label>
+                <input type="checkbox" id="moin-select-all"/>
+                <label for="moin-select-all">{{ _("Select All") }}</label>
             </span>
-            <span class="moin-button" id="moin-download-trigger" title="{{ _('Download selected items') }}">
-               <i class="fa fa-download fa-lg"></i>
-               {{ _("Download") }}
-            </span>
-            <span class="moin-action-tab moin-button" id="moin-delete-trigger" title="{{ _('Delete selected items') }}"
-               data-actionurl="{{ url_for('frontend.ajaxdelete', item_name=item_name) }}">
-               <i class="fa fa-minus-circle fa-lg"></i>
-               {{ _("Delete") }}
-            </span>
-            <span class="moin-action-tab moin-button" id="moin-destroy-trigger" title="{{ _('Destroy selected items') }}"
-               data-actionurl="{{ url_for('frontend.ajaxdestroy', item_name=item_name) }}">
-               <i class="fa fa-times-circle fa-lg"></i>
-               {{ _("Destroy") }}
-            </span>
-        {% endif %}
-        {% if dirs or files or form.contenttype %}
+            <button type="submit" formaction="{{ url_for('frontend.index', item_name=item_name, action='download-file') }}" id="moin-download-trigger" class="moin-button">
+                <span title="{{ _('Download selected items') }}">
+                    <i class="fa fa-download fa-lg"></i>
+                    {{ _("Download") }}
+                </span>
+            </button>
+            <button type="submit" id="moin-delete-trigger" class="moin-action-tab moin-button"
+                formaction="{{ url_for('frontend.index', item_name=item_name, action='delete') }}"
+                data-actionurl="{{ url_for('frontend.ajaxdelete', item_name=item_name) }}"
+                data-action="delete"
+            >
+                <span title="{{ _('Delete selected items') }}">
+                    <i class="fa fa-minus-circle fa-lg"></i>
+                    {{ _("Delete") }}
+                </span>
+            </button>
+            <button type="submit" id="moin-destroy-trigger" class="moin-action-tab moin-button"
+                formaction="{{ url_for('frontend.index', item_name=item_name, action='destroy') }}"
+                data-actionurl="{{ url_for('frontend.ajaxdestroy', item_name=item_name) }}"
+                data-action="destroy"
+            >
+                <span title="{{ _('Destroy selected items') }}">
+                    <i class="fa fa-times-circle fa-lg"></i>
+                    {{ _("Destroy") }}
+                </span>
+            </button>
+            {% endif %}
+            {% if dirs or files or form.contenttype %}
             {# prior filter action on contenttype may have resulted in no dirs or files #}
-            <span class="moin-ct-toggle moin-button" title="{{ _('Filter items by content type') }}">
-                <i class="fa fa-filter"></i>
-                {{ _("Filter") }}
-            </span>
-        {% endif %}
-        {# these action buttons have a purpose even when there are no items. #}
-        <span class="moin-ns-toggle moin-button" title="{{ _('Change namespace') }}">
-            <i class="fa fa-list-alt"></i>
-            {{ _("Namespace") }}
-        </span>
-        <span class="moin-newitem-toggle moin-button" id="moin-create-new-item" title="{{ _('Open create item dialog') }}" >
-           <i class="fa-solid fa-file-lines"></i>
-           {{ _("New Item") }}
-        </span>
-    </div>
+            <button type="submit" formaction="{{ url_for('frontend.index', item_name=item_name, action='toggle-content-filter') }}" class="moin-ct-toggle moin-button">
+                <span title="{{ _('Filter items by content type') }}">
+                    <i class="fa fa-filter"></i>
+                    {{ _("Filter") }}
+                </span>
+            </button>
+            {% endif %}
+            {# these action buttons have a purpose even when there are no items. #}
+            <button type="submit" formaction="{{ url_for('frontend.index', item_name=item_name, action='toggle-namespace-display') }}" class="moin-ns-toggle moin-button">
+                <span title="{{ _('Change namespace') }}">
+                    <i class="fa fa-list-alt"></i>
+                    {{ _("Namespace") }}
+                </span>
+            </button>
+            <button type="submit" formaction="{{ url_for('frontend.index', item_name=item_name, action='toggle-create-item') }}" class="moin-newitem-toggle moin-button">
+                <span title="{{ _('Open create item dialog') }}" >
+                    <i class="fa-solid fa-file-lines"></i>
+                    {{ _("New Item") }}
+                </span>
+            </button>
+        </div>
 
-    {% if selected_groups %}
+        {% if selected_groups %}
         <div>
             <p class="moin-selected-groups">{{ _("Filter is on for these selected groups:") }}</p>
             <ul>
@@ -152,27 +178,26 @@ a checkbox, an invisible link used by js for download, a link to the item
                 {%- endfor %}
             </ul>
         </div>
-    {% endif %}
+        {% endif %}
 
-    {# Hidden namespace selection content that is revealed by javascript if user clicks namespace button above. #}
-    <div class="moin-namespace-selection">
-        <p> {{ _("Click home icon to view namespace home page or click name to view namespace index.") }} </p>
-        <ul class="moin-namespaces">
-            <li><i class="fa fa-home"></i> <a href="{{ url_for('frontend.index', item_name='all') }}">{{ _("all") }}</a></li>
-            {% for namespace, root in theme_supp.get_namespaces() -%}
-                {% set index = '%s/%s' % ('+index', root.namespace) %}
-                <li>
-                    <a href="{{ url_for('frontend.show_item', item_name=root) }}"><i class="fa fa-home"></i></a>
-                    <a href="{{ url_for('frontend.show_item', item_name=index) }}">{{ namespace }}</a>
-                </li>
-            {%- endfor %}
-        </ul>
-    </div>
+        {# Hidden namespace selection content that is revealed by javascript if user clicks namespace button above. #}
+        <div class="moin-namespace-selection {% if not form['show_namespace_list'] %}hidden{% endif %}">
+            <p> {{ _("Click home icon to view namespace home page or click name to view namespace index.") }} </p>
+            <ul class="moin-namespaces">
+                <li><i class="fa fa-home"></i> <a href="{{ url_for('frontend.index', item_name='all') }}">{{ _("all") }}</a></li>
+                {% for namespace, root in theme_supp.get_namespaces() -%}
+                    {% set index = '%s/%s' % ('+index', root.namespace) %}
+                    <li>
+                        <a href="{{ url_for('frontend.show_item', item_name=root) }}"><i class="fa fa-home"></i></a>
+                        <a href="{{ url_for('frontend.show_item', item_name=index) }}">{{ namespace }}</a>
+                    </li>
+                {%- endfor %}
+            </ul>
+        </div>
 
-    {# Hidden filter content that is revealed if user clicks filter button above. #}
-    <div class="moin-contenttype-selection">
-        {% set unknown_items_label = _("items having unknown mime types") %}
-        {{ gen.form.open(form, method="get", action=url_for('frontend.index', item_name=item_name)) }}
+        {# Hidden filter content that is revealed if user clicks filter button above. #}
+        <div class="moin-contenttype-selection {% if not form['show_content_filter'] %}hidden{% endif %}">
+            {% set unknown_items_label = _("items having unknown mime types") %}
             <a href="#" class="moin-filter-toggle moin-button">
                 <i class="fa fa-refresh"></i>
                 {{ _("Toggle") }}
@@ -181,129 +206,130 @@ a checkbox, an invisible link used by js for download, a link to the item
                 {{ forms.render(form['contenttype']) }}
             </ul>
             {{ forms.render_submit(form) }}
-        {{ gen.form.close() }}
-    </div>
-
-    {# Hidden New Item content that is revealed if user clicks New Item button above. #}
-    <div class="moin-newitem-selection">
-        <br/>
-        <form class="moin-new-item" action={{ url_for('.ajaxmodify') }} method="post">
-            <label for="moin-newitem">{{ _("Item name") }}</label>
-            {% if item_name %}
-                <input type="text" id="moin-newitem" name="newitem" placeholder="{{ _("Enter item name here") }}" value="{{ item_name }}/" required="required"/>
-            {% else %}
-                <input type="text" id="moin-newitem" name="newitem" placeholder="{{ _("Enter item name here") }}" required="required"/>
-            {% endif %}
-            <input class="moin-button" type="submit" value="{{ _("Create") }}"/>
-        </form>
-        <div id="moin-upload-cont">
-            <div class="hint">
-                <p>{{ _("Enter Item name and click Create button above to edit or upload one item.
-                    To upload multiple files click the button below to open a file selection dialog,
-                    or drag and drop multiple files here.") }}
-                </p>
-            </div>
-            {% set submit_url = url_for('.jfu_server', item_name=item_name) %}
-            {{ forms.render_file_uploader(submit_url) }}
         </div>
-    </div>
 
-    {# If this is an index of subitems, display links to Global Index and all parent subitems. #}
-    <div>
-        {% if item_name: %}
-            <div class="moin-index-path">
-                <a href="{{ url_for('frontend.index') }}" title="{{ _("Global Index") }}">
-                    <i class="fa fa-level-up"></i>
-                </a>
-                <span class="moin-path-separator">{{ ("/") }}</span>
-                {% for i in range(0, item_names|count) %}
-                    {% set fullname = item_names[:i+1]|join('/') %}
-                    {% set relname = item_names[i] %}
-                    {% if loop.last %}
-                        {{ relname }}
+        {# Hidden New Item content that is revealed if user clicks New Item button above. #}
+        <div class="moin-newitem-selection {% if not form['show_create_item'] %}hidden{% endif %}">
+            <span>
+                <label>{{ _("Item name") }}<br>
+                    <input type="text" id="moin-newitem" name="new_name" placeholder="{{ _("Enter item name here") }}" form="create-item-form">
+                </label>
+                <button class="moin-button" id="create-new-item-btn" form="create-item-form">{{ _("Create") }}</button>
+            </span>
+            <div id="moin-upload-cont">
+                <div class="hint">
+                    <p>{{ _("Enter Item name and click Create button above to edit or upload one item.
+                        To upload multiple files click the button below to open a file selection dialog,
+                        or drag and drop multiple files here.") }}
+                    </p>
+                </div>
+                {% set submit_url = url_for('.jfu_server', item_name=item_name) %}
+                {{ forms.render_file_uploader(submit_url, "upload-file-form") }}
+            </div>
+        </div>
+
+        {# If this is an index of subitems, display links to Global Index and all parent subitems. #}
+        <div>
+            {% if item_name: %}
+                <div class="moin-index-path">
+                    <a href="{{ url_for('frontend.index') }}" title="{{ _("Global Index") }}">
+                        <i class="fa fa-level-up"></i>
+                    </a>
+                    <span class="moin-path-separator">{{ ("/") }}</span>
+                    {% for i in range(0, item_names|count) %}
+                        {% set fullname = item_names[:i+1]|join('/') %}
+                        {% set relname = item_names[i] %}
+                        {% if loop.last %}
+                            {{ relname }}
+                        {% else %}
+                            <a href="{{ url_for('frontend.index', item_name=fullname) }}" title="{{ relname }}">{{ relname }}</a>
+                            <span class="moin-path-separator">{{ ("/") }}</span>
+                        {% endif %}
+                    {% endfor %}
+                </div>
+            {% endif %}
+        </div>
+
+        <div class='moin-clr'></div>
+        {% if files or dirs %}
+            {# display row of buttons, Show All, followed by first letter of items. #}
+            <div id="moin-initials">
+                {# one button will be highlighted via the selected class, either Show All or some letter. #}
+                {% if not startswith %}
+                    <a class="selected moin-button" href="{{ url_for('frontend.index', item_name=item_name) }}">
+                        <i class="fa fa-th"></i>
+                        {{ _("Show All") }}
+                    </a>
+                {% else %}
+                    <a class="moin-button" href="{{ url_for('frontend.index', item_name=item_name) }}">
+                        <i class="fa fa-th"></i>
+                        {{ _("Show All") }}
+                    </a>
+                {% endif %}
+                {% for initial in initials %}
+                    {% if startswith == initial %}
+                        <a class="selected moin-button" href="{{ url_for('frontend.index', item_name=item_name, startswith=initial, initials=','.join(initials)) }}">{{ initial }}</a>
                     {% else %}
-                        <a href="{{ url_for('frontend.index', item_name=fullname) }}" title="{{ relname }}">{{ relname }}</a>
-                        <span class="moin-path-separator">{{ ("/") }}</span>
+                        <a class="moin-button" href="{{ url_for('frontend.index', item_name=item_name, startswith=initial, initials=','.join(initials)) }}">{{ initial }}</a>
                     {% endif %}
                 {% endfor %}
             </div>
         {% endif %}
-    </div>
 
-    <div class='moin-clr'></div>
-    {% if files or dirs %}
-        {# display row of buttons, Show All, followed by first letter of items. #}
-        <div id="moin-initials">
-            {# one button will be highlighted via the selected class, either Show All or some letter. #}
-            {% if not startswith %}
-                <a class="selected moin-button" href="{{ url_for('frontend.index', item_name=item_name) }}">
-                    <i class="fa fa-th"></i>
-                    {{ _("Show All") }}
-                </a>
-            {% else %}
-                <a class="moin-button" href="{{ url_for('frontend.index', item_name=item_name) }}">
-                    <i class="fa fa-th"></i>
-                    {{ _("Show All") }}
-                </a>
-            {% endif %}
-            {% for initial in initials %}
-                {% if startswith == initial %}
-                    <a class="selected moin-button" href="{{ url_for('frontend.index', item_name=item_name, startswith=initial, initials=','.join(initials)) }}">{{ initial }}</a>
-                {% else %}
-                    <a class="moin-button" href="{{ url_for('frontend.index', item_name=item_name, startswith=initial, initials=','.join(initials)) }}">{{ initial }}</a>
-                {% endif %}
-            {% endfor %}
-        </div>
-    {% endif %}
+        {# Finally! this is what user wants to see - the list of items. jfu.js needs moin-index class. #}
+        <table class="moin-index moin-sortable">
+            <thead>
+                <tr>
+                    <th class="sorter-false moin-num-rows" title='{{ _("Number Items") }}'></th>
+                    <th>Name</th>
+                    <th>Size</th>
+                    <th>Revisions</th>
+                    <th>Editor</th>
+                    <th>Modified</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for e in files %}
+                    {{ render_file_entry(e) }}
+                {% endfor %}
+            </tbody>
+        </table>
 
-    {# Finally! this is what user wants to see - the list of items. jfu.js needs moin-index class. #}
-    <table class="moin-index moin-sortable">
-        <thead>
-            <tr>
-                <th class="sorter-false moin-num-rows" title='{{ _("Number Items") }}'></th>
-                <th>Name</th>
-                <th>Size</th>
-                <th>Revisions</th>
-                <th>Editor</th>
-                <th>Modified</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for e in files %}
-                {{ render_file_entry(e) }}
-            {% endfor %}
-        </tbody>
-    </table>
+    {{ gen.form.close() }}
 
-    {# initially hidden by CSS, index_action.js displays this as a popup
-    if user clicks on Delete or Destroy button #}
-    <div id="popup" class="moin-new-item">
+    <form id="create-item-form" method="post" action="{{ url_for('frontend.index', item_name=item_name, action='create-new-item') }}" enctype="multipart/form-data"></form>
+    <form id="upload-file-form" method="post" action="{{ url_for('frontend.index', item_name=item_name, action='upload-file') }}" enctype="multipart/form-data"></form>
+
+    {# initially hidden by CSS, index_action.js displays this as a popup if user clicks on Delete or Destroy button #}
+    <div id="popup" {% if action != 'delete' and action != 'destroy' %}class="hidden"{% endif %}>
         <div id="popup-for-action" class="popup-container">
             <div class="popup-header">
-                <input type="button" class="popup-closer popup-cancel" value="{{ _("X") }}" title="{{ _("Close") }}"/>
+                <button name="popup-close" class="popup-closer" title="{{ _("Close") }} formaction="{{ url_for('frontend.index', item_name=item_name, action='close') }}"">{{ _("X") }}</button>
                 <span>{{ _("Add optional comment for change log.") }}</span>
             </div>
             <div class="popup-body">
-                <form id="popup-form">
+                <form id="popup-form" method="post">
+                <input type="hidden" name="delete-action" value="{{ action }}">
+                <input type="hidden" name="selected-names" value="{{ selected_names }}">
                 <div class="caution">
-                    <p class="popup-selected-names">{{ _("Selected names: ") }}<span class="popup-names"></span></p>
-                    <p class="popup-alias-names">{{ _("Alias names: ") }}<span class="popup-names"></span></p>
+                    <p class="popup-selected-names">{{ _("Selected names: ") }}<span class="popup-names">{{ ', '.join(selected_names) }}</span></p>
+                    <p class="popup-alias-names">{{ _("Alias names: ") }}<span class="popup-names">{{ ', '.join(alias_names) }}</span></p>
                     <p>
-                        <input type="checkbox" id="moin-do-subitems"/>
+                        <input type="checkbox" name="moin-do-subitems" id="moin-do-subitems">
                         <label for="moin-do-subitems">{{ _("Check to remove subitems") }}</label>
                     </p>
-                    <p class="popup-subitem-names">{{ _("Subitem names: ") }}<span class="popup-names"></span></p>
-                    <p class="popup-rejected-names hidden">{{ _("Rejected names, permission denied: ") }}<span class="popup-names"></span></p>
+                    <p class="popup-subitem-names">{{ _("Subitem names: ") }}<span class="popup-names">{{ ', '.join(subitem_names) }}</span></p>
+                    <p class="popup-rejected-names{% if not rejected_names %} hidden{% endif %}">{{ _("Rejected names, permission denied: ") }}<span class="popup-names">{{ ', '.join(rejected_names) }}</span></p>
                 </div>
-                <input type="text" class="popup-comment" id="moin-comment" placeholder="{{ _("Enter your comment") }}"/>
-                <input type="hidden" class="popup-action" value=""/>
+                <input type="text" class="popup-comment" name="moin-comment" placeholder="{{ _("Enter your comment") }}">
                 <br/>
-                <input type="submit" class="moin-button popup-submit" value="{{ _("Submit") }}" />
-                <input type="button" class="moin-button popup-cancel" value="{{ _("Cancel") }}"/>
+                <button type="submit" name="popup-submit" class="moin-button" formaction="{{ url_for('frontend.index', item_name=item_name, action='submit-deletion') }}">{{ _("Submit") }}</button>
+                <button type="submit" name="popup-cancel" class="moin-button" formaction="{{ url_for('frontend.index', item_name=item_name, action='cancel') }}">{{ _("Cancel") }}</button>
                 </form>
             </div>
         </div>
     </div>
+
     {# lightbox is used by jquery and css to dim and disable underlying page when above popup is triggered #}
     <div id="lightbox">&nbsp;</div>
 {% endblock %}

--- a/src/moin/themes/modernized/static/css/theme.css
+++ b/src/moin/themes/modernized/static/css/theme.css
@@ -42,7 +42,7 @@ table.navigation { background:var(--page_color); float:right; margin:2px; }
 #moin-create-table tbody tr td a {color:var(--link_color); }
 
 /* forms */
-label { display:block; font-weight:bold; }
+label { font-weight:bold; }
 input,
 select { padding:3px; background:var(--page_color); border:var(--border_style);
     border-radius:2px; }


### PR DESCRIPTION
Supported operations for no JS use
* downloading a single item
* new item creation as part of 'New Item'
* file upload as part of 'New Item'
* deletion and destruction of selected items
* listing namespace

If JavaScript is activated in the browser, it will still be used as before.

Noteworthy change in the Index view:
When creating a new item the name of the current item will always be used as base name. The item name form input field is now initially empty. Before, the form input field was pre-filled with the name of the current item. A newly create item will always  be a subitem if the current item.

Fixes #2249 