### PR TITLE
Improve figure support.

### DIFF
--- a/src/moin/converters/_tests/test_docbook_in.py
+++ b/src/moin/converters/_tests/test_docbook_in.py
@@ -565,7 +565,18 @@ class TestConverter(Base):
             # '/page/body/div/div[@html-tag="aside"][@html:class="sidebar"][@html:title="Title"]',
             '/page/body/div/aside[@html:class="sidebar"]',
         ),
-        # TODO: figures
+        (
+            '<article><figure><mediaobject><imageobject><imagedata fileref="test.png"/></imageobject></mediaobject><title>Testbild</title></figure></article>',
+            # <page><body><div html:class="db-article"><figure><div html:class="db-mediaobject"><xinclude:include type="image/" html:alt="test.png" xinclude:href="wiki.local:test.png" /></div><figcaption>Testbild</figcaption></figure></div></body></page>
+            '/page/body/div/figure/div/xinclude:include[@xinclude:href="wiki.local:test.png"]',
+            # TODO: <title> -> <figcaption>
+            # '/page/body/div/figure/figcaption[text()="Testbild"]',
+        ),
+        (
+            '<article><informalfigure><mediaobject><imageobject><imagedata fileref="test.png"/></imageobject></mediaobject></informalfigure></article>',
+            # <page><body><div html:class="db-article"><figure><div html:class="db-mediaobject"><xinclude:include type="image/" html:alt="test.png" xinclude:href="wiki.local:test.png" /></div></figure></div></body></page>
+            '/page/body/div/figure/div/xinclude:include[@xinclude:href="wiki.local:test.png"]',
+        ),
     ]
 
     @pytest.mark.parametrize("input,xpath", data)

--- a/src/moin/converters/_tests/test_html_in.py
+++ b/src/moin/converters/_tests/test_html_in.py
@@ -219,6 +219,11 @@ class TestConverter(Base):
             # <page><body><div><blockquote>Block quote</blockquote></body></page>
             '/page/body/div[blockquote="Block quote"]',
         ),
+        (
+            '<html><figure><img src="uri:test" /><figcaption>Testbild</figcaption></figure></html>',
+            # <page><body><figure><object xlink:href="uri:test" /><figcaption>Testbild</figcaption></figure></body></page>
+            '/page/body/figure/figcaption[text()="Testbild"]',
+        ),
     ]
 
     @pytest.mark.parametrize("input,xpath", data)

--- a/src/moin/converters/_tests/test_html_in_out.py
+++ b/src/moin/converters/_tests/test_html_in_out.py
@@ -200,7 +200,12 @@ class TestConverter(Base):
     data = [
         # ('<html><div><img src="uri:test" /></div></html>',
         #  '/page/body/div/object/@xlink:href="uri:test"'),
-        ('<html><div><object data="href"></object></div></html>', '/div/div/object[@data="href"]')
+        ('<html><div><object data="href"></object></div></html>', '/div/div/object[@data="href"]'),
+        (
+            '<html><figure><img src="uri:test" /><figcaption>Testbild</figcaption></figure></html>',
+            # <page><body><figure><object xlink:href="uri:test" /><figcaption>Testbild</figcaption></figure></body></page>
+            '/div/figure/figcaption[text()="Testbild"]',
+        ),
     ]
 
     @pytest.mark.parametrize("input,xpath", data)

--- a/src/moin/converters/docbook_in.py
+++ b/src/moin/converters/docbook_in.py
@@ -329,7 +329,6 @@ class Converter:
         "dedication",
         "epigraph",
         "example",
-        "figure",  # TODO there is a moinpage.figure!
         "equation",
         "part",
         "partintro",
@@ -344,7 +343,7 @@ class Converter:
         "taskprerequisites",
         "taskrelated",
         "tasksummary",
-        "title",
+        "title",  # TODO: <title> in a <figure> should become a <figcaption>
     }
 
     # DocBook has admonition as individual element, but the DOM Tree
@@ -378,10 +377,13 @@ class Converter:
     simple_tags: Final = {
         "code": moin_page.code,
         "computeroutput": moin_page.samp,
+        "figure": moin_page.figure,
         "glossdef": moin_page("list-item-body"),
         "glossentry": moin_page("list-item"),
         "glosslist": moin_page("list"),
         "glossterm": moin_page("list-item-label"),
+        "informalfigure": moin_page.figure,
+        "listitem": moin_page("list-item-body"),
         "literal": moin_page.literal,
         "markup": moin_page.code,
         "para": moin_page.p,
@@ -394,7 +396,6 @@ class Converter:
         "subscript": moin_page.sub,
         "superscript": moin_page.sup,
         "term": moin_page("list-item-label"),
-        "listitem": moin_page("list-item-body"),
         "thead": moin_page("table-header"),
         "tfoot": moin_page("table-footer"),
         "tbody": moin_page("table-body"),
@@ -410,7 +411,6 @@ class Converter:
         "formalpara",
         "informalequation",
         "informalexample",
-        "informalfigure",
         "informalfigure",
         "orderedlist",
         "sect1",
@@ -807,14 +807,6 @@ class Converter:
         """
         attrib = {}
         attrib[html.class_] = "db-example"
-        return self.new_copy(moin_page("div"), element, depth, attrib=attrib)
-
-    def visit_docbook_informalfigure(self, element, depth):
-        """
-        <informalfigure> --> <div html:class="figure">
-        """
-        attrib = {}
-        attrib[html.class_] = "db-figure"
         return self.new_copy(moin_page("div"), element, depth, attrib=attrib)
 
     def visit_docbook_inline(self, element, depth):

--- a/src/moin/converters/html_in.py
+++ b/src/moin/converters/html_in.py
@@ -53,6 +53,8 @@ class HtmlTags:
         "code",
         "del",
         "div",
+        "figure",
+        "figcaption",
         "ins",
         "kbd",
         "p",

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -417,7 +417,7 @@ class NodeVisitor:
         self.close_moin_page_node()
 
     def visit_figure(self, node):
-        self.open_moin_page_node(moin_page.figure(attrib={moin_page.class_: "moin-figure"}), node)
+        self.open_moin_page_node(moin_page.figure(), node)
 
     def depart_figure(self, node):
         self.close_moin_page_node()

--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -676,9 +676,9 @@ li.moin-selected-groups { font-size: 1em; font-weight: bold; }
 .moin-wikiconfighelp i.fa:hover { cursor: pointer; }
 .moin-wikiconfighelp table { width: 100%; }
 
-/* reST figures */
+/* figures */
 
-.moin-figure { text-align: center; }
+figure { text-align: center; }
 figcaption { font-weight: bold; }
 
 /* moin-flash */


### PR DESCRIPTION
The `<figure>` element for formal illustrations is defined in MoinPage, HTML5, DocBook, and rST.

* Define "figure" and "figcaption" as "symmetric tags" (HTML == MoinPage) to fully support figures in HTML.

* Convert DocBook `<informalfigure>` and `<figure>` to `<moinpage:figure>`. 

Drop moin_page.class "moin-figure"
 (redundant with a native `<moinpage:figure">` element).
Simplify rST-in figure handling.

Open Issues
===========

Keep styling `<figure>` with `text-align: center`
or drop this rule in "common.css"?

TODO: 
  DocBook In: Convert a `<title>` in a `<figure>` to a `<figcaption>`.