### PR TITLE
Make LDAP authentication unittests work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ strict = false
 minversion = "9.0.0"
 addopts = ["--ignore=_ui_tests"]
 norecursedirs = [".git", "_build", "tmp*", "env*", "dlc", "wiki", "support"]
+env_files = [".env", ".env.test"]
 
 [tool.ruff]
 line-length = 120

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,6 +1,7 @@
 tox>=4.21.0
 psutil
 pytest>=9.0.0
+pytest-env>=1.6.0
 # we use lxml.etree for xpath-based testing
 lxml
 # for sitetesting

--- a/src/moin/_tests/ldap_testbase.py
+++ b/src/moin/_tests/ldap_testbase.py
@@ -69,32 +69,10 @@ LDAP_ROOTDN = f"cn=root,{LDAP_BASEDN}"
 LDAP_ROOTPW = "secret"
 
 
-def check_environ():
-    """Check whether the system environment can run these tests.
-
-    Return a failure reason string if we can't, or None if everything looks OK.
-    """
-    if ldap is None:
-        return "You need python-ldap installed to use ldap_testbase."
-    slapd = False
-    try:
-        p = subprocess.Popen([SLAPD_EXECUTABLE, "-V"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        pid = p.pid
-        rc = p.wait()
-        if pid and rc == 1:
-            slapd = True  # it works
-    except OSError as err:
-        import errno
-
-        if not (err.errno == errno.ENOENT or (err.errno == 3 and os.name == "nt")):
-            raise
-    if not slapd:
-        return f"Can't start {SLAPD_EXECUTABLE} (see SLAPD_EXECUTABLE)."
-    return None
-
-
 class Slapd:
-    """Manage a slapd process for testing purposes."""
+    """
+    Manage a slapd process for testing purposes.
+    """
 
     def __init__(
         self,
@@ -152,7 +130,9 @@ class Slapd:
 
 
 class LdapEnvironment:
-    """Manage a (temporary) environment for running a slapd."""
+    """
+    Manage a (temporary) environment for running a slapd.
+    """
 
     # default DB_CONFIG bdb configuration file contents
     DB_CONFIG = """\
@@ -167,6 +147,37 @@ class LdapEnvironment:
 
 #set_tas_spins 0
 """
+
+    @staticmethod
+    def check() -> str | None:
+        """
+        Check whether the system environment can run these tests.
+
+        Return a failure reason string if we can't, or None if everything looks OK.
+        """
+        if ldap is None:
+            return "You need python-ldap installed to use ldap_testbase."
+
+        if not os.path.exists(LDAP_SCHEMA_DIR) or not os.path.exists(LDAP_MODULE_PATH):
+            return "Your LDAP test configuration seems to be invalid."
+
+        slapd = False
+        try:
+            p = subprocess.Popen([SLAPD_EXECUTABLE, "-V"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            pid = p.pid
+            rc = p.wait()
+            if pid and rc == 1:
+                slapd = True  # it works
+        except OSError as err:
+            import errno
+
+            if not (err.errno == errno.ENOENT or (err.errno == 3 and os.name == "nt")):
+                raise
+
+        if not slapd:
+            return f"Can't start {SLAPD_EXECUTABLE} (see SLAPD_EXECUTABLE)."
+
+        return None
 
     def __init__(
         self,

--- a/src/moin/_tests/ldap_testbase.py
+++ b/src/moin/_tests/ldap_testbase.py
@@ -57,12 +57,12 @@ except ImportError:
 
 # filename of LDAP server executable - if it is not
 # in your PATH, you have to give full path/filename.
-SLAPD_EXECUTABLE = "slapd"
+SLAPD_EXECUTABLE = os.getenv("SLAPD_EXECUTABLE", "slapd")
 
-LDAP_PORT = 13890
+LDAP_PORT = int(os.getenv("LDAP_PORT", "3890"))
 LDAP_SERVER_URI = f"ldap://127.0.0.1:{LDAP_PORT}"
-LDAP_SCHEMA_DIR = "/etc/openldap/schema"
-LDAP_MODULE_PATH = "/usr/lib/openldap"
+LDAP_SCHEMA_DIR = os.getenv("LDAP_SCHEMA_DIR", "/etc/ldap/schema")
+LDAP_MODULE_PATH = os.getenv("LDAP_MODULE_PATH", "/usr/lib/ldap")
 
 LDAP_BASEDN = "ou=testing,dc=example,dc=org"
 LDAP_ROOTDN = f"cn=root,{LDAP_BASEDN}"

--- a/src/moin/_tests/ldap_testbase.py
+++ b/src/moin/_tests/ldap_testbase.py
@@ -40,10 +40,11 @@ import shutil
 import tempfile
 import time
 import base64
-from io import StringIO
 import signal
 import subprocess
 import hashlib
+
+from io import StringIO
 
 try:
     # needs python-ldap
@@ -57,6 +58,15 @@ except ImportError:
 # filename of LDAP server executable - if it is not
 # in your PATH, you have to give full path/filename.
 SLAPD_EXECUTABLE = "slapd"
+
+LDAP_PORT = 13890
+LDAP_SERVER_URI = f"ldap://127.0.0.1:{LDAP_PORT}"
+LDAP_SCHEMA_DIR = "/etc/openldap/schema"
+LDAP_MODULE_PATH = "/usr/lib/openldap"
+
+LDAP_BASEDN = "ou=testing,dc=example,dc=org"
+LDAP_ROOTDN = f"cn=root,{LDAP_BASEDN}"
+LDAP_ROOTPW = "secret"
 
 
 def check_environ():
@@ -93,7 +103,7 @@ class Slapd:
         debug_flags="",  # None,  # for -d stats,acl,args,trace,sync,config
         proto="ldap",
         ip="127.0.0.1",
-        port=3890,  # use -h proto://ip:port
+        port=LDAP_PORT,  # use -h proto://ip:port
         service_name="",  # defaults to -n executable:port, use None to not use -n
     ):
         self.executable = executable
@@ -164,16 +174,18 @@ class LdapEnvironment:
         rootdn,
         rootpw,
         instance=0,  # use different values when running multiple LdapEnvironments
-        schema_dir="/etc/ldap/schema",  # directory with schemas
-        coding="utf-8",  # coding used for config files
+        module_path=LDAP_MODULE_PATH,
+        schema_dir=LDAP_SCHEMA_DIR,  # directory with schemas
+        encoding="utf-8",  # coding used for config files
         timeout=10,  # how long to wait for slapd starting [s]
     ):
         self.basedn = basedn
         self.rootdn = rootdn
         self.rootpw = rootpw
         self.instance = instance
+        self.module_path = module_path
         self.schema_dir = schema_dir
-        self.coding = coding
+        self.encoding = encoding
         self.ldap_dir = None
         self.slapd_conf = None
         self.timeout = timeout
@@ -189,29 +201,29 @@ class LdapEnvironment:
 
         # create DB_CONFIG for bdb backend
         db_config_fname = os.path.join(self.ldap_db_dir, "DB_CONFIG")
-        f = open(db_config_fname, "w")
-        f.write(db_config)
-        f.close()
+        with open(db_config_fname, "w", encoding=self.encoding) as f:
+            f.write(db_config)
 
-        hash_pw = hashlib.new("md5", self.rootpw.encode(self.coding))
+        hash_pw = hashlib.new("md5", self.rootpw.encode(self.encoding))
         rootpw = "{MD5}" + base64.b64encode(hash_pw.digest()).decode()
 
         # create slapd.conf from content template in slapd_config
         slapd_config = slapd_config % {
             "ldap_dir": self.ldap_dir,
             "ldap_db_dir": self.ldap_db_dir,
+            "module_path": self.module_path,
             "schema_dir": self.schema_dir,
             "basedn": self.basedn,
             "rootdn": self.rootdn,
             "rootpw": rootpw,
         }
         self.slapd_conf = os.path.join(self.ldap_dir, "slapd.conf")
-        with open(self.slapd_conf, "w", encoding=self.coding) as f:
+        with open(self.slapd_conf, "w", encoding=self.encoding) as f:
             f.write(slapd_config)
 
     def start_slapd(self):
         """Start a slapd and optionally wait until it responds."""
-        self.slapd = Slapd(config=self.slapd_conf, port=3890 + self.instance)
+        self.slapd = Slapd(config=self.slapd_conf, port=LDAP_PORT + self.instance)
         started = self.slapd.start(timeout=self.timeout)
         return started
 
@@ -240,7 +252,7 @@ class LdapEnvironment:
 try:
     import pytest
 
-    class LDAPTstBase:
+    class LDAPTestBase:
         """Test base class for pytest-based tests that need an LDAP server.
 
         Inherit your test class from this base class to test LDAP functionality.

--- a/src/moin/_tests/ldap_testdata.py
+++ b/src/moin/_tests/ldap_testdata.py
@@ -5,10 +5,6 @@
 MoinMoin - LDAP test data.
 """
 
-BASEDN = "ou=testing,dc=example,dc=org"
-ROOTDN = f"cn=root,{BASEDN}"
-ROOTPW = "secret"
-
 SLAPD_CONFIG = """\
 # See slapd.conf(5) for details on configuration options.
 
@@ -17,7 +13,10 @@ include %(schema_dir)s/cosine.schema
 include %(schema_dir)s/inetorgperson.schema
 #include %(schema_dir)s/misc.schema
 
-moduleload back_bdb.la
+modulepath %(module_path)s
+moduleload back_mdb.la
+
+loglevel 255
 
 threads 2
 
@@ -35,7 +34,7 @@ allow bind_anon_dn
 
 # Test-Datenbank ou=testing,dc=example,dc=org ################
 
-database bdb
+database mdb
 
 directory %(ldap_db_dir)s
 suffix "%(basedn)s"
@@ -46,11 +45,6 @@ lastmod on
 index uid eq
 
 checkpoint 200 5
-
-# Entries to cache in memory
-cachesize 500
-# Search results to cache in memory
-idlcachesize 50
 
 sizelimit -1
 """

--- a/src/moin/auth/_tests/test_ldap_login.py
+++ b/src/moin/auth/_tests/test_ldap_login.py
@@ -18,14 +18,14 @@ from moin._tests.ldap_testbase import (
     LDAP_ROOTPW,
     SLAPD_EXECUTABLE,
 )
-from moin._tests.ldap_testbase import LDAPTestBase, LdapEnvironment, check_environ
+from moin._tests.ldap_testbase import LDAPTestBase, LdapEnvironment
 from moin._tests.ldap_testdata import LDIF_CONTENT, SLAPD_CONFIG
 from moin._tests import wikiconfig
 
-msg = check_environ()
-if msg:
-    pytestmark = pytest.mark.skip(msg)
-del msg
+if message := LdapEnvironment.check():
+    pytestmark = pytest.mark.skip(reason=message)
+
+del message
 
 ldap = pytest.importorskip("ldap")
 

--- a/src/moin/auth/_tests/test_ldap_login.py
+++ b/src/moin/auth/_tests/test_ldap_login.py
@@ -8,11 +8,19 @@ MoinMoin - moin.auth.ldap tests.
 
 import pytest
 
-
-from moin._tests.ldap_testbase import LDAPTstBase, LdapEnvironment, check_environ, SLAPD_EXECUTABLE
-from moin._tests.ldap_testdata import BASEDN, LDIF_CONTENT, ROOTDN, ROOTPW, SLAPD_CONFIG
-from moin._tests import wikiconfig
 from moin.auth import handle_login
+
+from moin._tests.ldap_testbase import (
+    LDAP_SERVER_URI,
+    LDAP_PORT,
+    LDAP_BASEDN,
+    LDAP_ROOTDN,
+    LDAP_ROOTPW,
+    SLAPD_EXECUTABLE,
+)
+from moin._tests.ldap_testbase import LDAPTestBase, LdapEnvironment, check_environ
+from moin._tests.ldap_testdata import LDIF_CONTENT, SLAPD_CONFIG
+from moin._tests import wikiconfig
 
 msg = check_environ()
 if msg:
@@ -22,10 +30,10 @@ del msg
 ldap = pytest.importorskip("ldap")
 
 
-class TestLDAPServer(LDAPTstBase):
-    basedn = BASEDN
-    rootdn = ROOTDN
-    rootpw = ROOTPW
+class TestLDAPServer(LDAPTestBase):
+    basedn = LDAP_BASEDN
+    rootdn = LDAP_ROOTDN
+    rootpw = LDAP_ROOTPW
     slapd_config = SLAPD_CONFIG
     ldif_content = LDIF_CONTENT
 
@@ -42,10 +50,10 @@ class TestLDAPServer(LDAPTstBase):
         assert b"userb" in uids
 
 
-class TestMoinLDAPLogin(LDAPTstBase):
-    basedn = BASEDN
-    rootdn = ROOTDN
-    rootpw = ROOTPW
+class TestMoinLDAPLogin(LDAPTestBase):
+    basedn = LDAP_BASEDN
+    rootdn = LDAP_ROOTDN
+    rootpw = LDAP_ROOTPW
     slapd_config = SLAPD_CONFIG
     ldif_content = LDIF_CONTENT
 
@@ -54,44 +62,44 @@ class TestMoinLDAPLogin(LDAPTstBase):
         class Config(wikiconfig.Config):
             from moin.auth.ldap_login import LDAPAuth
 
-            # TODO: get these vars from the test environment
-            server_uri = "ldap://127.0.0.1:3890"
-            base_dn = "ou=testing,dc=example,dc=org"
+            server_uri = LDAP_SERVER_URI
+            base_dn = LDAP_BASEDN
             ldap_auth1 = LDAPAuth(server_uri=server_uri, base_dn=base_dn, autocreate=True)
             auth = [ldap_auth1]
 
         return Config
 
+    @pytest.mark.usefixtures("_req_ctx")
     def testMoinLDAPLogin(self):
         """Just try accessing the LDAP server and see if usera and userb are in LDAP."""
 
         # tests that must not authenticate:
-        u = handle_login(None, username="", password="")
-        assert u is None
-        u = handle_login(None, username="usera", password="")
-        assert u is None
-        u = handle_login(None, username="usera", password="userawrong")
-        assert u is None
-        u = handle_login(None, username="userawrong", password="usera")
-        assert u is None
+        user = handle_login(None, username="", password="")
+        assert user is None
+        user = handle_login(None, username="usera", password="")
+        assert user is None
+        user = handle_login(None, username="usera", password="userawrong")
+        assert user is None
+        user = handle_login(None, username="userawrong", password="usera")
+        assert user is None
 
         # tests that must authenticate:
-        u1 = handle_login(None, username="usera", password="usera")
-        assert u1 is not None
-        assert u1.valid
+        user1 = handle_login(None, username="usera", password="usera")
+        assert user1 is not None
+        assert user1.valid
 
-        u2 = handle_login(None, username="userb", password="userb")
-        assert u2 is not None
-        assert u2.valid
+        user2 = handle_login(None, username="userb", password="userb")
+        assert user2 is not None
+        assert user2.valid
 
         # check if usera and userb have different ids:
-        assert u1.profile["itemid"] != u2.profile["itemid"]
+        assert user1.profile["itemid"] != user2.profile["itemid"]
 
 
-class TestBugDefaultPasswd(LDAPTstBase):
-    basedn = BASEDN
-    rootdn = ROOTDN
-    rootpw = ROOTPW
+class TestBugDefaultPasswd(LDAPTestBase):
+    basedn = LDAP_BASEDN
+    rootdn = LDAP_ROOTDN
+    rootpw = LDAP_ROOTPW
     slapd_config = SLAPD_CONFIG
     ldif_content = LDIF_CONTENT
 
@@ -101,9 +109,8 @@ class TestBugDefaultPasswd(LDAPTstBase):
             from moin.auth.ldap_login import LDAPAuth
             from moin.auth import MoinAuth
 
-            # TODO: get these vars from the test environment
-            server_uri = "ldap://127.0.0.1:3890"
-            base_dn = "ou=testing,dc=example,dc=org"
+            server_uri = LDAP_SERVER_URI
+            base_dn = LDAP_BASEDN
             ldap_auth = LDAPAuth(server_uri=server_uri, base_dn=base_dn, autocreate=True)
             moin_auth = MoinAuth()
             auth = [ldap_auth, moin_auth]
@@ -115,37 +122,38 @@ class TestBugDefaultPasswd(LDAPTstBase):
         self.ldap_env.stop_slapd()
         self.ldap_env.destroy_env()
 
+    @pytest.mark.usefixtures("_req_ctx")
     def testBugDefaultPasswd(self):
         """Login via LDAP (this creates user profile and up to 1.7.0rc1 it put
         a default password there), then try logging in via moin login using
         that default password or an empty password.
         """
         # do a LDAPAuth login (as a side effect, this autocreates the user profile):
-        u1 = handle_login(None, username="usera", password="usera")
-        assert u1 is not None
-        assert u1.valid
+        user1 = handle_login(None, username="usera", password="usera")
+        assert user1 is not None
+        assert user1.valid
 
         # now we kill the LDAP server:
         # self.ldap_env.slapd.stop()
 
         # now try a MoinAuth login:
         # try the default password that worked in 1.7 up to rc1:
-        u2 = handle_login(None, username="usera", password="{SHA}NotStored")
-        assert u2 is None
+        user2 = handle_login(None, username="usera", password="{SHA}NotStored")
+        assert user2 is None
 
         # try using no password:
-        u2 = handle_login(None, username="usera", password="")
-        assert u2 is None
+        user2 = handle_login(None, username="usera", password="")
+        assert user2 is None
 
         # try using wrong password:
-        u2 = handle_login(None, username="usera", password="wrong")
-        assert u2 is None
+        user2 = handle_login(None, username="usera", password="wrong")
+        assert user2 is None
 
 
 class TestTwoLdapServers:
-    basedn = BASEDN
-    rootdn = ROOTDN
-    rootpw = ROOTPW
+    basedn = LDAP_BASEDN
+    rootdn = LDAP_ROOTDN
+    rootpw = LDAP_ROOTPW
     slapd_config = SLAPD_CONFIG
     ldif_content = LDIF_CONTENT
 
@@ -185,9 +193,9 @@ class TestTwoLdapServers:
 
 
 class TestLdapFailover:
-    basedn = BASEDN
-    rootdn = ROOTDN
-    rootpw = ROOTPW
+    basedn = LDAP_BASEDN
+    rootdn = LDAP_ROOTDN
+    rootpw = LDAP_ROOTPW
     slapd_config = SLAPD_CONFIG
     ldif_content = LDIF_CONTENT
 
@@ -211,12 +219,11 @@ class TestLdapFailover:
         class Config(wikiconfig.Config):
             from moin.auth.ldap_login import LDAPAuth
 
-            # TODO: get these vars from the test environment
-            server_uri = "ldap://127.0.0.1:3891"
-            base_dn = "ou=testing,dc=example,dc=org"
+            server_uri = LDAP_SERVER_URI
+            base_dn = LDAP_BASEDN
             ldap_auth1 = LDAPAuth(server_uri=server_uri, base_dn=base_dn, name="ldap1", autocreate=True, timeout=1)
             # short timeout, faster testing
-            server_uri = "ldap://127.0.0.1:3892"
+            server_uri = f"ldap://127.0.0.1:{LDAP_PORT + 1}"
             ldap_auth2 = LDAPAuth(server_uri=server_uri, base_dn=base_dn, name="ldap2", autocreate=True, timeout=1)
             auth = [ldap_auth1, ldap_auth2]
 
@@ -231,18 +238,19 @@ class TestLdapFailover:
                 pass  # One will fail, because it is already stopped
             ldap_env.destroy_env()
 
+    @pytest.mark.usefixtures("_req_ctx")
     def testMoinLDAPFailOver(self):
         """Try if it does a failover to a secondary LDAP, if the primary fails."""
 
         # authenticate user (with primary slapd):
-        u1 = handle_login(None, username="usera", password="usera")
-        assert u1 is not None
-        assert u1.valid
+        user1 = handle_login(None, username="usera", password="usera")
+        assert user1 is not None
+        assert user1.valid
 
         # now we kill our primary LDAP server:
         self.ldap_envs[0].slapd.stop()
 
         # try if we can still authenticate (with the second slapd):
-        u2 = handle_login(None, username="usera", password="usera")
-        assert u2 is not None
-        assert u2.valid
+        user2 = handle_login(None, username="usera", password="usera")
+        assert user2 is not None
+        assert user2.valid

--- a/src/moin/auth/ldap_login.py
+++ b/src/moin/auth/ldap_login.py
@@ -18,16 +18,19 @@ support in libldap2 (see dependency on gnutls) and also in python-ldap.
 TODO: allow more configuration (display name, ...) by using callables as parameters
 """
 
-from moin import log, user
+from __future__ import annotations
+
 from moin.i18n import _
 from moin.auth import BaseAuth, CancelLogin, ContinueLogin
+from moin.log import getLogger
+from moin.user import User
 
-logging = log.getLogger(__name__)
+logger = getLogger(__name__)
 
 try:
     import ldap
 except ImportError as err:
-    logging.error(f"You need to have python-ldap installed ({err!s}).")
+    logger.error(f"You need to have python-ldap installed ({err!s}).")
     raise
 
 
@@ -37,9 +40,9 @@ class LDAPAuth(BaseAuth):
     for that user. The session is kept by Moin automatically.
     """
 
+    name = "ldap"
     login_inputs = ["username", "password"]
     logout_possible = True
-    name = "ldap"
 
     def __init__(
         self,
@@ -106,7 +109,7 @@ class LDAPAuth(BaseAuth):
         self.email_callback = email_callback
         self.name_callback = name_callback
 
-        self.coding = coding
+        self.encoding = coding
         self.timeout = timeout
 
         self.start_tls = start_tls
@@ -122,9 +125,98 @@ class LDAPAuth(BaseAuth):
 
         self.report_invalid_credentials = report_invalid_credentials
 
-    def login(self, user_obj, **kw):
-        username = kw.get("username")
-        password = kw.get("password")
+    def _connect(self):
+        server = self.server_uri
+
+        logger.debug(f"Trying to initialize {server!r}.")
+        conn = ldap.initialize(server)
+        logger.debug(f"Connected to LDAP server {server!r}.")
+
+        if self.start_tls and server.startswith("ldap:"):
+            logger.debug(f"Trying to start TLS to {server!r}.")
+            try:
+                conn.start_tls_s()
+                logger.debug(f"Using TLS to {server!r}.")
+            except (ldap.SERVER_DOWN, ldap.CONNECT_ERROR) as err:
+                logger.warning(f"Couldn't establish TLS to {server!r} (err: {err!s}).")
+                raise
+
+        return conn
+
+    def _search(self, conn, **arguments):
+
+        # you can use %(username)s and %(password)s here to get the stuff entered in the form:
+        binddn = self.bind_dn % arguments
+        bindpw = self.bind_pw % arguments
+        conn.simple_bind_s(binddn, bindpw)
+        logger.debug(f"Bound with binddn {binddn!r}")
+
+        # you can use %(username)s here to get the stuff entered in the form:
+        filterstr = self.search_filter % arguments
+        logger.debug(f"Searching {filterstr!r}")
+
+        attrs = [
+            getattr(self, attr)
+            for attr in ["email_attribute", "displayname_attribute", "surname_attribute", "givenname_attribute"]
+            if getattr(self, attr) is not None
+        ]
+
+        lusers = conn.search_st(self.base_dn, self.scope, filterstr, attrlist=attrs, timeout=self.timeout)
+
+        # we remove entries with dn == None to get the real result list:
+        lusers = [(_dn, _ldap_dict) for _dn, _ldap_dict in lusers if _dn is not None]
+        for _dn, _ldap_dict in lusers:
+            logger.debug(f"dn:{_dn!r}")
+            for key, val in _ldap_dict.items():
+                if key == "userPassword":
+                    val = "****"
+                logger.debug(f"    {key!r}: {val!r}")
+
+        if (result_length := len(lusers)) != 1:
+            error_message = None
+            if result_length > 1:
+                logger.warning(f"Search found more than one ({result_length}) matches for {filterstr!r}.")
+            if result_length == 0:
+                logger.debug(f"Search found no matches for {filterstr!r}.")
+            if self.report_invalid_credentials:
+                error_message = _("Invalid username or password.")
+            return None, error_message
+
+        return lusers[0], None
+
+    def _username(self, ldap_dict, username) -> str | None:
+        if self.name_callback:
+            username = self.name_callback(ldap_dict)
+        return username
+
+    def _display_name(self, ldap_dict) -> str | None:
+        try:
+            display_name = ldap_dict[self.displayname_attribute][0]
+        except (KeyError, IndexError):
+            display_name = ""
+        if not display_name:
+            sn = ldap_dict.get(self.surname_attribute, [""])[0]
+            gn = ldap_dict.get(self.givenname_attribute, [""])[0]
+            if sn and gn:
+                display_name = f"{sn}, {gn}"
+            elif sn:
+                display_name = sn
+        return display_name
+
+    def _email(self, ldap_dict) -> str | None:
+        if self.email_callback is None:
+            if self.email_attribute:
+                email = ldap_dict.get(self.email_attribute, [""])[0]
+            else:
+                email = None
+        else:
+            email = self.email_callback(ldap_dict)
+        return email
+
+    def login(self, user_obj, **kwargs):
+
+        username = kwargs.get("username")
+        password = kwargs.get("password")
 
         # we require non-empty password as ldap bind does a anon (not password
         # protected) bind if the password is empty and SUCCEEDS!
@@ -132,12 +224,11 @@ class LDAPAuth(BaseAuth):
             return ContinueLogin(user_obj, _("Missing password. Please enter user name and password."))
 
         try:
+            user = None
+            dn = None
+
             try:
-                u = None
-                dn = None
-                server = self.server_uri
-                coding = self.coding
-                logging.debug("Setting misc. ldap options...")
+                logger.debug("Setting misc. ldap options...")
                 ldap.set_option(ldap.OPT_PROTOCOL_VERSION, ldap.VERSION3)  # ldap v2 is outdated
                 ldap.set_option(ldap.OPT_REFERRALS, self.referrals)
                 ldap.set_option(ldap.OPT_NETWORK_TIMEOUT, self.timeout)
@@ -155,122 +246,66 @@ class LDAPAuth(BaseAuth):
                         if value is not None:
                             ldap.set_option(option, value)
 
-                logging.debug(f"Trying to initialize {server!r}.")
-                conn = ldap.initialize(server)
-                logging.debug(f"Connected to LDAP server {server!r}.")
+                conn = self._connect()
 
-                if self.start_tls and server.startswith("ldap:"):
-                    logging.debug(f"Trying to start TLS to {server!r}.")
-                    try:
-                        conn.start_tls_s()
-                        logging.debug(f"Using TLS to {server!r}.")
-                    except (ldap.SERVER_DOWN, ldap.CONNECT_ERROR) as err:
-                        logging.warning(f"Couldn't establish TLS to {server!r} (err: {err!s}).")
-                        raise
+                ldap_user, error_message = self._search(conn, username=username, password=password)
 
-                # you can use %(username)s and %(password)s here to get the stuff entered in the form:
-                binddn = self.bind_dn % locals()
-                bindpw = self.bind_pw % locals()
-                conn.simple_bind_s(binddn, bindpw)
-                logging.debug(f"Bound with binddn {binddn!r}")
+                if ldap_user is None:
+                    return ContinueLogin(user_obj, error_message)
 
-                # you can use %(username)s here to get the stuff entered in the form:
-                filterstr = self.search_filter % locals()
-                logging.debug(f"Searching {filterstr!r}")
-                attrs = [
-                    getattr(self, attr)
-                    for attr in ["email_attribute", "displayname_attribute", "surname_attribute", "givenname_attribute"]
-                    if getattr(self, attr) is not None
-                ]
-                lusers = conn.search_st(self.base_dn, self.scope, filterstr, attrlist=attrs, timeout=self.timeout)
-                # we remove entries with dn == None to get the real result list:
-                lusers = [(_dn, _ldap_dict) for _dn, _ldap_dict in lusers if _dn is not None]
-                for _dn, _ldap_dict in lusers:
-                    logging.debug(f"dn:{_dn!r}")
-                    for key, val in _ldap_dict.items():
-                        logging.debug(f"    {key!r}: {val!r}")
-
-                result_length = len(lusers)
-                if result_length != 1:
-                    if result_length > 1:
-                        logging.warning(f"Search found more than one ({result_length}) matches for {filterstr!r}.")
-                    if result_length == 0:
-                        logging.debug(f"Search found no matches for {filterstr!r}.")
-                    if self.report_invalid_credentials:
-                        return ContinueLogin(user_obj, _("Invalid username or password."))
-                    else:
-                        return ContinueLogin(user_obj)
-
-                dn, ldap_dict = lusers[0]
+                dn, ldap_dict = ldap_user
                 if not self.bind_once:
-                    logging.debug(f"DN found is {dn!r}, trying to bind with pw")
+                    logger.debug(f"DN found is {dn!r}, trying to bind with pw")
                     conn.simple_bind_s(dn, password)
-                    logging.debug(f"Bound with dn {dn!r} (username: {username!r})")
+                    logger.debug(f"Bound with dn {dn!r} (username: {username!r})")
 
-                if self.email_callback is None:
-                    if self.email_attribute:
-                        email = ldap_dict.get(self.email_attribute, [""])[0]
-                    else:
-                        email = None
-                else:
-                    email = self.email_callback(ldap_dict)
-
-                display_name = ""
-                try:
-                    display_name = ldap_dict[self.displayname_attribute][0]
-                except (KeyError, IndexError):
-                    pass
-                if not display_name:
-                    sn = ldap_dict.get(self.surname_attribute, [""])[0]
-                    gn = ldap_dict.get(self.givenname_attribute, [""])[0]
-                    if sn and gn:
-                        display_name = f"{sn}, {gn}"
-                    elif sn:
-                        display_name = sn
-
-                if self.name_callback:
-                    username = self.name_callback(ldap_dict)
+                email = self._email(ldap_dict)
+                display_name = self._display_name(ldap_dict)
+                username = self._username(ldap_dict, username)
 
                 if email:
-                    u = user.User(
+                    user = User(
                         auth_username=username,
                         auth_method=self.name,
                         auth_attribs=("name", "password", "email", "mailto_author"),
                         trusted=self.trusted,
                     )
-                    u.email = email
+                    user.email = email
                 else:
-                    u = user.User(
+                    user = User(
                         auth_username=username,
                         auth_method=self.name,
                         auth_attribs=("name", "password", "mailto_author"),
                         trusted=self.trusted,
                     )
-                u.name = username
-                u.display_name = display_name
-                logging.debug(
+                user.name = username
+                user.display_name = display_name
+                logger.debug(
                     "creating user object with name {!r} email {!r} display name {!r}".format(
                         username, email, display_name
                     )
                 )
 
             except ldap.INVALID_CREDENTIALS:
-                logging.debug(f"invalid credentials (wrong password?) for dn {dn!r} (username: {username!r})")
+                logger.debug(f"invalid credentials (wrong password?) for dn {dn!r} (username: {username!r})")
                 return CancelLogin(_("Invalid username or password."))
 
-            if u and self.autocreate:
-                logging.debug(f"calling create_or_update to autocreate user {u.name!r}")
-                u.create_or_update(True)
-            return ContinueLogin(u)
+            if user and self.autocreate:
+                logger.debug(f"calling create_or_update to autocreate user {user.name!r}")
+                user.create_or_update(True)
+
+            return ContinueLogin(user)
 
         except ldap.SERVER_DOWN as err:
             # looks like this LDAP server isn't working, so we just try the next
             # authenticator object in cfg.auth list (there could be some second
             # ldap authenticator that queries a backup server or any other auth
             # method).
-            logging.error(f"LDAP server {server} failed ({err!s}). Trying to authenticate with next auth list entry.")
-            return ContinueLogin(user_obj, _("LDAP server {server} failed.").format(server=server))
+            logger.error(
+                f"LDAP server {self.server_uri} failed ({err!s}). Trying to authenticate with next auth list entry."
+            )
+            return ContinueLogin(user_obj, _("LDAP server {server} failed.").format(server=self.server_uri))
 
         except:  # noqa
-            logging.exception("caught an exception, traceback follows...")
+            logger.exception("caught an exception, traceback follows...")
             return ContinueLogin(user_obj)


### PR DESCRIPTION
This PR is mainly about cleaning up the existing LDAP authentication unittests and making them work.
Part of the changes is making the LDAP test configuration configurable via environment variables. 

Please see the commit comments for details.