### PR TITLE
markdown_in: add table-of-content to the list of block_elements …

### DIFF
--- a/src/moin/converters/markdown_in.py
+++ b/src/moin/converters/markdown_in.py
@@ -49,7 +49,9 @@ if TYPE_CHECKING:
 
 logging = log.getLogger(__name__)
 
-block_elements = "p h blockcode ol ul pre address blockquote dl div fieldset form hr noscript table".split()
+block_elements = (
+    "p h blockcode ol ul pre address blockquote dl div fieldset form hr noscript table table-of-content".split()
+)
 BLOCK_ELEMENTS = {moin_page(x) for x in block_elements}
 
 


### PR DESCRIPTION
…to avoid p tag

The problem was following: When using this markdown

```
Markdown Example for TOC macro

[TOC]

## First Heading 
```

the markdown_in converter creates this DOM-tree

```
<page page-href="wiki:///markdown_toc">
<body>
<p>Markdown Example for TOC macro</p>
<p>
<table-of-content/>
</p>
<h outline-level="2">First Heading</h>
</body>
</page>
```

and as a result invalid HTML5 code. <p> can only contain phrasing content.