### PR TITLE
More footnote fixes.

### DIFF
--- a/docs/user/rest.rst
+++ b/docs/user/rest.rst
@@ -43,7 +43,7 @@ __ https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections
 
   The first adornment style encountered is registered as page title style
   (<h1> in HTML), the second style is assigned to level 2,
-  the third style to level 3, and so on.\ [#fn:document-title]_
+  the third style to level 3, and so on. [#fn:document-title]_
 
 * Once established, adornment styles must be consistent.
   Skipping a heading level results in a parsing error.
@@ -61,7 +61,7 @@ __ https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections
            =======
 
      - The first encountered style becomes the `page title`_ (if it is
-       unique)\ [#fn:document-title]_.
+       unique) [#fn:document-title]_.
 
    * - ::
 

--- a/src/moin/converters/_tests/test_docbook_in.py
+++ b/src/moin/converters/_tests/test_docbook_in.py
@@ -289,6 +289,11 @@ class TestConverter(Base):
             '/page/body/div/p[text()="Text Para"]/note[@note-class="footnote"]/note-body/p[text()="Text Footnote"]',
         ),
         (
+            "<article><para>Text Para<footnote><para>Text Footnote</para><para>second paragraph</para></footnote></para></article>",
+            # <page><body><div html:class="article"><p>Text Para<note note-class="footnote"><note-body><p>Text Footnote</p><p>Second paragraph</p></note-body></note></p></div></body></page>
+            '/page/body/div/p[text()="Text Para"]/note[@note-class="footnote"]/note-body/p[text()="second paragraph"]',
+        ),
+        (
             "<article><para><quote>text</quote></para></article>",
             # <page><body><div html:class="article"><p><quote>text</quote></para></article>
             '/page/body/div/p[quote="text"]',

--- a/src/moin/converters/_tests/test_html_out.py
+++ b/src/moin/converters/_tests/test_html_out.py
@@ -331,8 +331,8 @@ class TestConverterPage(Base):
         (  # footnote at the bottom
             '<page><body><p>Text<note note-class="footnote"><note-body>Note</note-body></note></p></body></page>',
             # <div><p>Text<sup class="moin-footnote" id="note-0-1-ref">\n<a href="#note-0-1">1</a>\n</sup></p>
-            # <div class="moin-footnotes"><p id="note-0-1"><sup><a href="#note-0-1-ref">1</a></sup>\nNote</p></div></div>
-            '/div/div/p[@id="note-0-1"][text()="Note"]/sup/a[@href="#note-0-1-ref"][text()="1"]',
+            # <div class="moin-footnotes"><aside id="note-0-1" role="doc-footnote"><sup><a href="#note-0-1-ref">1</a></sup>Note</aside></div></div>
+            '/div/div/aside[@id="note-0-1"][text()="Note"]/sup/a[@href="#note-0-1-ref"][text()="1"]',
         ),
     ]
 

--- a/src/moin/converters/_tests/test_html_out.py
+++ b/src/moin/converters/_tests/test_html_out.py
@@ -332,7 +332,7 @@ class TestConverterPage(Base):
             '<page><body><p>Text<note note-class="footnote"><note-body>Note</note-body></note></p></body></page>',
             # <div><p>Text<sup class="moin-footnote" id="note-0-1-ref">\n<a href="#note-0-1">1</a>\n</sup></p>
             # <div class="moin-footnotes"><p id="note-0-1"><sup><a href="#note-0-1-ref">1</a></sup>\nNote</p></div></div>
-            '/div/div/p[@id="note-0-1"][text()="\nNote"]/sup/a[@href="#note-0-1-ref"][text()="1"]',
+            '/div/div/p[@id="note-0-1"][text()="Note"]/sup/a[@href="#note-0-1-ref"][text()="1"]',
         ),
     ]
 

--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -238,11 +238,11 @@ class TestConverter:
         self.do(input, output)
 
     data = [
-        ("Abra [1]_\n\n.. [1] arba", '<p>Abra <note note-class="footnote"><note-body>arba</note-body></note></p>'),
-        ("Abra [#]_\n\n.. [#] arba", '<p>Abra <note note-class="footnote"><note-body>arba</note-body></note></p>'),
+        ("Abra [1]_\n\n.. [1] arba", '<p>Abra<note note-class="footnote"><note-body>arba</note-body></note></p>'),
+        ("Abra [#]_\n\n.. [#] arba", '<p>Abra<note note-class="footnote"><note-body>arba</note-body></note></p>'),
         (
             "Text [*]_\n\n.. [*] auto-symbol footnote",
-            '<p>Text <note note-class="footnote"><note-body>auto-symbol footnote</note-body></note></p>',
+            '<p>Text<note note-class="footnote"><note-body>auto-symbol footnote</note-body></note></p>',
         ),
     ]
 

--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -238,11 +238,20 @@ class TestConverter:
         self.do(input, output)
 
     data = [
-        ("Abra [1]_\n\n.. [1] arba", '<p>Abra<note note-class="footnote"><note-body>arba</note-body></note></p>'),
-        ("Abra [#]_\n\n.. [#] arba", '<p>Abra<note note-class="footnote"><note-body>arba</note-body></note></p>'),
         (
-            "Text [*]_\n\n.. [*] auto-symbol footnote",
-            '<p>Text<note note-class="footnote"><note-body>auto-symbol footnote</note-body></note></p>',
+            "Text [1]_\n\n.. [1] manually numbered *footnote*",
+            '<p>Text<note note-class="footnote"><note-body>'
+            "<p>manually numbered <emphasis>footnote</emphasis></p></note-body></note></p>",
+        ),
+        (
+            "Text [#]_\n\n.. [#] auto-numbered *footnote*",
+            '<p>Text<note note-class="footnote"><note-body>'
+            "<p>auto-numbered <emphasis>footnote</emphasis></p></note-body></note></p>",
+        ),
+        (
+            "Text [*]_\n\n.. [*] auto-symbol footnote\n\n   with second paragraph",
+            '<p>Text<note note-class="footnote"><note-body><p>auto-symbol footnote</p>'
+            "<p>with second paragraph</p></note-body></note></p>",
         ),
     ]
 

--- a/src/moin/converters/docbook_in.py
+++ b/src/moin/converters/docbook_in.py
@@ -765,7 +765,7 @@ class Converter:
         key = moin_page("note-class")
         attrib[key] = "footnote"
         children = self.new(moin_page("note-body"), attrib={}, children=self.do_children(element, depth))
-        if len(children) > 1:
+        if len(children) > 1 and html.data_lineno in children._children[1].attrib:
             # must delete lineno because footnote will be placed near end of page and out of sequence
             del children._children[1].attrib[html.data_lineno]
         return self.new(moin_page.note, attrib=attrib, children=[children])

--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -854,9 +854,9 @@ class ConverterPage(Converter):
             "</html:sup>"
         )
         elem_note = ET.XML(
-            f'<html:p xmlns:html="{html}" html:id="note-{id}">'
+            f'<html:aside xmlns:html="{html}" html:id="note-{id}" html:role="doc-footnote">'
             f'<html:sup><html:a html:href="#note-{id}-ref">{label}</html:a></html:sup>'
-            "</html:p>"
+            "</html:aside>"
         )
         elem_note.extend(body)
         top.add_footnote(elem_note)

--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -824,13 +824,14 @@ class ConverterPage(Converter):
         return footnotes_div
 
     def visit_moinpage_note(self, elem):
-        # TODO: Check note-class
+        # TODO: Check note-class? (As of 2026-05-20, it is always "footnote".)
+        #       cls = elem.get(moin_page.note_class, "")
         top = self._special_stack[-1]
         if len(elem) == 0:
+            # <<FootNote>> without argument
             # explicit footnote placement:  show prior footnotes, empty stack, reset counter
             if len(top._footnotes) == 0:
                 return
-
             footnotes_div = self.create_footnotes(top)
             top.remove_footnotes()
             self._id.zero_id("note")
@@ -844,21 +845,19 @@ class ConverterPage(Converter):
                 if child.tag.name == "note-body":
                     body = self.do_children(child)
 
-        id = self._id.gen_id("note")
-        prefixed_id = "%s-%s" % (self._id.get_id("note-placement"), id)
+        label = self._id.gen_id("note")
+        id = f'{self._id.get_id("note-placement")}-{label}'
 
-        elem_ref = ET.XML("""
-<html:sup xmlns:html="{}" html:id="note-{}-ref" html:class="moin-footnote">
-<html:a html:href="#note-{}">{}</html:a>
-</html:sup>
-""".format(html, prefixed_id, prefixed_id, id))
-
-        elem_note = ET.XML("""
-<html:p xmlns:html="{}" html:id="note-{}">
-<html:sup><html:a html:href="#note-{}-ref">{}</html:a></html:sup>
-</html:p>
-""".format(html, prefixed_id, prefixed_id, id))
-
+        elem_ref = ET.XML(
+            f'<html:sup xmlns:html="{html}" html:id="note-{id}-ref" html:class="moin-footnote">'
+            f'<html:a html:href="#note-{id}">{label}</html:a>'
+            "</html:sup>"
+        )
+        elem_note = ET.XML(
+            f'<html:p xmlns:html="{html}" html:id="note-{id}">'
+            f'<html:sup><html:a html:href="#note-{id}-ref">{label}</html:a></html:sup>'
+            "</html:p>"
+        )
         elem_note.extend(body)
         top.add_footnote(elem_note)
 

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -987,9 +987,10 @@ class Parser(docutils.parsers.rst.Parser):
     __ https://docutils.sourceforge.io/docs/ref/doctree.html#target
     """
 
-    # Use class values matching the pre-defined CSS highlight rules
-    settings_default_overrides = {"syntax_highlight": "short"}
-
+    settings_default_overrides = {
+        "syntax_highlight": "short",  # use class values matching the pre-defined CSS highlight rules
+        "trim_footnote_reference_space": True,  # remove spaces before footnote references
+    }
     config_section = "MoinMoin parser"
     config_section_dependencies = ("parsers", "restructuredtext parser")
 

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -441,7 +441,8 @@ class NodeVisitor:
         attrib = {moin_page.note_class: "footnote"}
         self.open_moin_page_node(moin_page.note(attrib=attrib))
         self.open_moin_page_node(moin_page.note_body())
-        self.current_node.append("\n".join(child.astext() for child in footnote.children[1:]))
+        for child in footnote.children[1:]:
+            walkabout(child, self)
         self.close_moin_page_node()
         self.close_moin_page_node()
         raise nodes.SkipNode

--- a/src/moin/help/help-en/rst.data
+++ b/src/moin/help/help-en/rst.data
@@ -43,7 +43,7 @@ __ https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections
 
   The first adornment style encountered is registered as page title style
   (<h1> in HTML), the second style is assigned to level 2,
-  the third style to level 3, and so on.\ [#fn:document-title]_
+  the third style to level 3, and so on. [#fn:document-title]_
 
 * Once established, adornment styles must be consistent.
   Skipping a heading level results in a parsing error.
@@ -61,7 +61,7 @@ __ https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections
            =======
 
      - The first encountered style becomes the `page title`_ (if it is
-       unique)\ [#fn:document-title]_.
+       unique) [#fn:document-title]_.
 
    * - ::
 

--- a/src/moin/help/help-en/rst.meta
+++ b/src/moin/help/help-en/rst.meta
@@ -9,6 +9,7 @@
     "https://docs.python.org/3/_static/py.svg",
     "https://docs.python.org/3/library/csv.html",
     "https://docutils.sourceforge.io/FAQ.html#restructuredtext",
+    "https://docutils.sourceforge.io/docs/api/transforms.html#doctitle",
     "https://docutils.sourceforge.io/docs/peps/pep-0258.html#error-handling",
     "https://docutils.sourceforge.io/docs/ref/rst/definitions.html",
     "https://docutils.sourceforge.io/docs/ref/rst/directives.html",
@@ -108,8 +109,8 @@
   "namespace": "help-en",
   "rev_number": 1,
   "revid": "3938500a53bc47c89ad919a462787352",
-  "sha1": "6fc13cfef64fe3f9c0e0668b254c725fc917170b",
-  "size": 49418,
+  "sha1": "feb41a5e0764370db84e9cc081d3f702211a7fb9",
+  "size": 49416,
   "summary": "",
   "tags": [
     "parser",

--- a/src/moin/static/css/common.css
+++ b/src/moin/static/css/common.css
@@ -338,7 +338,9 @@ ul.moin-tags li.weight9 { font-size: 280%; }
 
 /* footnotes */
 .moin-footnotes { border-top: 1px solid var(--border-footnotes); margin: 2em; }
-.moin-footnotes p { margin: 1em; }
+[role="doc-footnote"] { margin: 1em; }  /* also overrides the generic "aside" styling below */
+[role="doc-footnote"] > sup:first-child { margin-left: -0.8em; padding-right: 0.2em; }  /* hanging indent */
+[role="doc-footnote"] > sup:first-child + * { display: inline-block; margin: 0; vertical-align: top; }
 
 /* moin default table styling */
 table { margin: .5em 0; }


### PR DESCRIPTION
DocBook-In: Fix error with footnote containing 2 paragraphs.

Avoid spurious whitespace around footnote labels.

rST-In: keep styling in footnote content.

HTML-Out: use `<aside>` for footnotes.

Fixes some of the problems in #2270

