### PR TITLE
More footnote fixes.

### DIFF
--- a/src/moin/converters/_tests/test__wiki_macro.py
+++ b/src/moin/converters/_tests/test__wiki_macro.py
@@ -76,8 +76,8 @@ class TestConverter:
             "FootNote",
             "note",
             "text",
-            '<p><note note-class="footnote"><note-body>note</note-body></note></p>',
-            '<note note-class="footnote"><note-body>note</note-body></note>',
+            '<p><note note-class="footnote"><p>note</p></note></p>',
+            '<note note-class="footnote"><p>note</p></note>',
         ),
         ("TableOfContents", None, "text", "<table-of-content />", "text"),
         (

--- a/src/moin/converters/_tests/test_docbook_in.py
+++ b/src/moin/converters/_tests/test_docbook_in.py
@@ -285,14 +285,14 @@ class TestConverter(Base):
     data = [
         (
             "<article><para>Text Para<footnote><para>Text Footnote</para></footnote></para></article>",
-            # <page><body><div html:class="article"><p>Text Para<note note-class="footnote"><note-body><p>Text Footnote</p></note-body></note></p></div></body></page>
-            '/page/body/div/p[text()="Text Para"]/note[@note-class="footnote"]/note-body/p[text()="Text Footnote"]',
+            # <page><body><div html:class="article"><p>Text Para<note note-class="footnote"><p>Text Footnote</p></note></p></div></body></page>
+            '/page/body/div/p[text()="Text Para"]/note[@note-class="footnote"]/p[text()="Text Footnote"]',
         ),
         (
             '<article><para>text<footnote xml:id="fn42"><para>footnote with id</para><para>second paragraph</para></footnote></para></article>',
             # TODO: the footnote's ID should go to the <note>, not its first content element.
-            # <div html:class="db-article"><p>text<note note-class="footnote"><note-body><p xml:id="fn42">footnote with id</p><p>second paragraph</p></note-body></note></p></div>
-            '/page/body/div/p[text()="text"]/note[@note-class="footnote"]/note-body/p[text()="second paragraph"]',
+            # <div html:class="db-article"><p>text<note note-class="footnote"><p xml:id="fn42">footnote with id</p><p>second paragraph</p></note></p></div>
+            '/page/body/div/p[text()="text"]/note[@note-class="footnote"]/p[text()="second paragraph"]',
         ),
         (
             "<article><para><quote>text</quote></para></article>",

--- a/src/moin/converters/_tests/test_docbook_in.py
+++ b/src/moin/converters/_tests/test_docbook_in.py
@@ -289,9 +289,10 @@ class TestConverter(Base):
             '/page/body/div/p[text()="Text Para"]/note[@note-class="footnote"]/note-body/p[text()="Text Footnote"]',
         ),
         (
-            "<article><para>Text Para<footnote><para>Text Footnote</para><para>second paragraph</para></footnote></para></article>",
-            # <page><body><div html:class="article"><p>Text Para<note note-class="footnote"><note-body><p>Text Footnote</p><p>Second paragraph</p></note-body></note></p></div></body></page>
-            '/page/body/div/p[text()="Text Para"]/note[@note-class="footnote"]/note-body/p[text()="second paragraph"]',
+            '<article><para>text<footnote xml:id="fn42"><para>footnote with id</para><para>second paragraph</para></footnote></para></article>',
+            # TODO: the footnote's ID should go to the <note>, not its first content element.
+            # <div html:class="db-article"><p>text<note note-class="footnote"><note-body><p xml:id="fn42">footnote with id</p><p>second paragraph</p></note-body></note></p></div>
+            '/page/body/div/p[text()="text"]/note[@note-class="footnote"]/note-body/p[text()="second paragraph"]',
         ),
         (
             "<article><para><quote>text</quote></para></article>",

--- a/src/moin/converters/_tests/test_docbook_in.py
+++ b/src/moin/converters/_tests/test_docbook_in.py
@@ -290,9 +290,8 @@ class TestConverter(Base):
         ),
         (
             '<article><para>text<footnote xml:id="fn42"><para>footnote with id</para><para>second paragraph</para></footnote></para></article>',
-            # TODO: the footnote's ID should go to the <note>, not its first content element.
-            # <div html:class="db-article"><p>text<note note-class="footnote"><p xml:id="fn42">footnote with id</p><p>second paragraph</p></note></p></div>
-            '/page/body/div/p[text()="text"]/note[@note-class="footnote"]/p[text()="second paragraph"]',
+            # <div html:class="db-article"><p>text<note note-class="footnote" xml:id="fn42"><p>footnote with id</p><p>second paragraph</p></note></p></div>
+            '/page/body/div/p[text()="text"]/note[@note-class="footnote"][@xml:id="fn42"][p[text()="footnote with id"]]/p[text()="second paragraph"]',
         ),
         (
             "<article><para><quote>text</quote></para></article>",

--- a/src/moin/converters/_tests/test_docbook_out.py
+++ b/src/moin/converters/_tests/test_docbook_out.py
@@ -185,9 +185,9 @@ class TestConverter(Base):
     data = [
         # Footnote conversion
         (
-            '<page><body><p>Text simpara<note page:note-class="footnote"><note-body>Text Footnote</note-body></note></p></body></page>',
-            # <article><simpara>Text simpara<footnote>Text Footnote</footnote></simpara></article>
-            '/article/simpara[text()="Text simpara"]/footnote[simpara="Text Footnote"]',
+            '<page><body><p>simple text<note page:note-class="footnote"><p>footnote content</p></note></p></body></page>',
+            # <article><simpara>simple text<footnote>footnote content</footnote></simpara></article>
+            '/article/simpara[text()="simple text"]/footnote[simpara="footnote content"]',
         ),
         # Link conversion
         (

--- a/src/moin/converters/_tests/test_html_out.py
+++ b/src/moin/converters/_tests/test_html_out.py
@@ -325,7 +325,7 @@ class TestConverterPage(Base):
         (
             '<page><body><p>Text<note note-class="footnote"><p>Note</p></note></p></body></page>',
             # <div>
-            #   <p>Text<sup class="moin-footnote" id="note-0-1-ref"><a href="#note-0-1">1</a></sup></p>
+            #   <p>Text<sup role="doc-noteref" id="note-0-1-ref"><a href="#note-0-1">1</a></sup></p>
             #   <div class="moin-footnotes">
             #     <aside id="note-0-1" role="doc-footnote">
             #        <sup><a href="#note-0-1-ref">1</a></sup>
@@ -334,13 +334,13 @@ class TestConverterPage(Base):
             #   </div>
             # </div>
             # check footnote reference:
-            '/div[p[text()="Text"]/sup[@id="note-0-1-ref"]/a[@href="#note-0-1"][text()="1"]]',
+            '/div[p[text()="Text"]/sup[@id="note-0-1-ref"][@role="doc-noteref"]/a[@href="#note-0-1"][text()="1"]]',
         ),
         (
             '<page><body><p>Text<note note-class="footnote"><p>Note</p></note></p></body></page>',
             # <same output as above>
             # check footnote (at end of document)
-            '/div/div[@class="moin-footnotes"]/aside[@id="note-0-1"][sup/a[@href="#note-0-1-ref"][text()="1"]]/p[text()="Note"]',
+            '/div/div[@class="moin-footnotes"]/aside[@id="note-0-1"][@role="doc-footnote"][sup/a[@href="#note-0-1-ref"][text()="1"]]/p[text()="Note"]',
         ),
     ]
 

--- a/src/moin/converters/_tests/test_html_out.py
+++ b/src/moin/converters/_tests/test_html_out.py
@@ -321,18 +321,26 @@ class TestConverterPage(Base):
         self.conv = ConverterPage()
 
     data = [
-        # Footnotes are replaced by a footnote-reference and moved to the bottom.
-        (  # footnote-reference
-            '<page><body><p>Text<note note-class="footnote"><note-body>Note</note-body></note></p></body></page>',
-            # <div><p>Text<sup class="moin-footnote" id="note-0-1-ref">\n<a href="#note-0-1">1</a>\n</sup></p>
-            # <div class="moin-footnotes"><p id="note-0-1"><sup><a href="#note-0-1-ref">1</a></sup>\nNote</p></div></div>
+        # Footnotes are replaced by a footnote-reference and rendered at the page bottom.
+        (
+            '<page><body><p>Text<note note-class="footnote"><p>Note</p></note></p></body></page>',
+            # <div>
+            #   <p>Text<sup class="moin-footnote" id="note-0-1-ref"><a href="#note-0-1">1</a></sup></p>
+            #   <div class="moin-footnotes">
+            #     <aside id="note-0-1" role="doc-footnote">
+            #        <sup><a href="#note-0-1-ref">1</a></sup>
+            #        <p>Note</p>
+            #      </aside>
+            #   </div>
+            # </div>
+            # check footnote reference:
             '/div[p[text()="Text"]/sup[@id="note-0-1-ref"]/a[@href="#note-0-1"][text()="1"]]',
         ),
-        (  # footnote at the bottom
-            '<page><body><p>Text<note note-class="footnote"><note-body>Note</note-body></note></p></body></page>',
-            # <div><p>Text<sup class="moin-footnote" id="note-0-1-ref">\n<a href="#note-0-1">1</a>\n</sup></p>
-            # <div class="moin-footnotes"><aside id="note-0-1" role="doc-footnote"><sup><a href="#note-0-1-ref">1</a></sup>Note</aside></div></div>
-            '/div/div/aside[@id="note-0-1"][text()="Note"]/sup/a[@href="#note-0-1-ref"][text()="1"]',
+        (
+            '<page><body><p>Text<note note-class="footnote"><p>Note</p></note></p></body></page>',
+            # <same output as above>
+            # check footnote (at end of document)
+            '/div/div[@class="moin-footnotes"]/aside[@id="note-0-1"][sup/a[@href="#note-0-1-ref"][text()="1"]]/p[text()="Note"]',
         ),
     ]
 

--- a/src/moin/converters/_tests/test_mediawiki_in.py
+++ b/src/moin/converters/_tests/test_mediawiki_in.py
@@ -55,7 +55,7 @@ class TestConverter:
         ("aaa<br />bbb", "<page><body><p>aaa<line-break />bbb</p></body></page>"),
         (
             "aaa <ref> sdf </ref> test\n\n asd",
-            '<page><body><p>aaa <note note-class="footnote"><note-body> sdf </note-body></note> test</p><p> asd</p></body></page>',
+            '<page><body><p>aaa <note note-class="footnote"><p> sdf </p></note> test</p><p> asd</p></body></page>',
         ),
         (
             """=level 1=

--- a/src/moin/converters/_tests/test_moinwiki_out.py
+++ b/src/moin/converters/_tests/test_moinwiki_out.py
@@ -182,9 +182,9 @@ class TestConverter(Base):
 
     data = [
         ('<page:note page:note-class="footnote"><page:p>test</page:p></page:note>', "<<FootNote(test)>>"),
-        (  # TODO: start second paragraph on a new line.
+        (
             '<page:note page:note-class="footnote"><page:p>first\nparagraph</page:p><page:p>second\nparagraph</page:p></page:note>',
-            "<<FootNote(first paragraph  second paragraph)>>",
+            "<<FootNote(first paragraph<<BR>>second paragraph)>>",
         ),
         ('<page:tag><page:table-of-content page:outline-level="2" /></page:tag>', "<<TableOfContents(2)>>\n"),
         (

--- a/src/moin/converters/_tests/test_moinwiki_out.py
+++ b/src/moin/converters/_tests/test_moinwiki_out.py
@@ -181,9 +181,10 @@ class TestConverter(Base):
         self.do(input, output)
 
     data = [
-        (
-            '<page:note page:note-class="footnote"><page:note-body>test</page:note-body></page:note>',
-            "<<FootNote(test)>>",
+        ('<page:note page:note-class="footnote"><page:p>test</page:p></page:note>', "<<FootNote(test)>>"),
+        (  # TODO: start second paragraph on a new line.
+            '<page:note page:note-class="footnote"><page:p>first\nparagraph</page:p><page:p>second\nparagraph</page:p></page:note>',
+            "<<FootNote(first paragraph  second paragraph)>>",
         ),
         ('<page:tag><page:table-of-content page:outline-level="2" /></page:tag>', "<<TableOfContents(2)>>\n"),
         (

--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -240,20 +240,20 @@ class TestConverter:
     data = [
         (
             "Text [1]_\n\n.. [1] manually numbered *footnote*",
-            '<p>Text<note note-class="footnote"><p>manually numbered <emphasis>footnote</emphasis></p></note></p>',
+            '<p>Text<note id="footnote-1" note-class="footnote"><p>manually numbered <emphasis>footnote</emphasis></p></note></p>',
         ),
         (
             "Text [#]_\n\n.. [#] auto-numbered *footnote*",
-            '<p>Text<note note-class="footnote"><p>auto-numbered <emphasis>footnote</emphasis></p></note></p>',
+            '<p>Text<note id="footnote-1" note-class="footnote"><p>auto-numbered <emphasis>footnote</emphasis></p></note></p>',
         ),
-        (  # TODO: keep the footnote ID
-            "Text [#fn42]_\n\n.. [#fn42] auto-label *footnote*",
-            '<p>Text<note note-class="footnote">'
-            "<p>auto-label <emphasis>footnote</emphasis></p></note></p>",
+        (
+            "Two references [#fn42]_ to the same footnote [#fn42]_\n\n.. [#fn42] auto-label *footnote*",
+            '<p>Two references<note id="fn42" note-class="footnote"><p>auto-label <emphasis>footnote</emphasis></p></note>'
+            ' to the same footnote<note note-class="footnote"><p>auto-label <emphasis>footnote</emphasis></p></note></p>',
         ),
         (
             "Text [*]_\n\n.. [*] auto-symbol footnote\n\n   with second paragraph",
-            '<p>Text<note note-class="footnote"><p>auto-symbol footnote</p><p>with second paragraph</p></note></p>',
+            '<p>Text<note id="footnote-1" note-class="footnote"><p>auto-symbol footnote</p><p>with second paragraph</p></note></p>',
         ),
     ]
 

--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -248,6 +248,11 @@ class TestConverter:
             '<p>Text<note note-class="footnote"><note-body>'
             "<p>auto-numbered <emphasis>footnote</emphasis></p></note-body></note></p>",
         ),
+        (  # TODO: keep the footnote ID
+            "Text [#fn42]_\n\n.. [#fn42] auto-label *footnote*",
+            '<p>Text<note note-class="footnote"><note-body>'
+            "<p>auto-label <emphasis>footnote</emphasis></p></note-body></note></p>",
+        ),
         (
             "Text [*]_\n\n.. [*] auto-symbol footnote\n\n   with second paragraph",
             '<p>Text<note note-class="footnote"><note-body><p>auto-symbol footnote</p>'

--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -240,23 +240,20 @@ class TestConverter:
     data = [
         (
             "Text [1]_\n\n.. [1] manually numbered *footnote*",
-            '<p>Text<note note-class="footnote"><note-body>'
-            "<p>manually numbered <emphasis>footnote</emphasis></p></note-body></note></p>",
+            '<p>Text<note note-class="footnote"><p>manually numbered <emphasis>footnote</emphasis></p></note></p>',
         ),
         (
             "Text [#]_\n\n.. [#] auto-numbered *footnote*",
-            '<p>Text<note note-class="footnote"><note-body>'
-            "<p>auto-numbered <emphasis>footnote</emphasis></p></note-body></note></p>",
+            '<p>Text<note note-class="footnote"><p>auto-numbered <emphasis>footnote</emphasis></p></note></p>',
         ),
         (  # TODO: keep the footnote ID
             "Text [#fn42]_\n\n.. [#fn42] auto-label *footnote*",
-            '<p>Text<note note-class="footnote"><note-body>'
-            "<p>auto-label <emphasis>footnote</emphasis></p></note-body></note></p>",
+            '<p>Text<note note-class="footnote">'
+            "<p>auto-label <emphasis>footnote</emphasis></p></note></p>",
         ),
         (
             "Text [*]_\n\n.. [*] auto-symbol footnote\n\n   with second paragraph",
-            '<p>Text<note note-class="footnote"><note-body><p>auto-symbol footnote</p>'
-            "<p>with second paragraph</p></note-body></note></p>",
+            '<p>Text<note note-class="footnote"><p>auto-symbol footnote</p><p>with second paragraph</p></note></p>',
         ),
     ]
 

--- a/src/moin/converters/_wiki_macro.py
+++ b/src/moin/converters/_wiki_macro.py
@@ -37,7 +37,7 @@ class ConverterMacro(ConverterBase):
 
         text = args
         text = self.macro_text(text)  # footnotes may have markup, macro_text is likely overridden
-        elem_body = moin_page.note_body(children=text)
+        elem_body = moin_page.p(children=text)
         attrib = {moin_page.note_class: "footnote"}
         elem = moin_page.note(attrib=attrib, children=[elem_body])
 

--- a/src/moin/converters/docbook_in.py
+++ b/src/moin/converters/docbook_in.py
@@ -761,14 +761,14 @@ class Converter:
         """
         <footnote> --> <note note-class="footnote">
         """
-        attrib = {}
-        key = moin_page("note-class")
-        attrib[key] = "footnote"
+        attrib = {moin_page.note_class: "footnote"}
+        note = self.new(moin_page.note, attrib=attrib, children=[])
         children = self.do_children(element, depth)
         if len(children) > 1 and html.data_lineno in children[1].attrib:
             # must delete lineno because footnote will be placed near end of page and out of sequence
             del children[1].attrib[html.data_lineno]
-        return self.new(moin_page.note, attrib=attrib, children=children)
+        note.extend(children)
+        return note
 
     def visit_docbook_formalpara(self, element, depth):
         """

--- a/src/moin/converters/docbook_in.py
+++ b/src/moin/converters/docbook_in.py
@@ -759,16 +759,16 @@ class Converter:
 
     def visit_docbook_footnote(self, element, depth):
         """
-        <footnote> --> <note note-class="footnote"><note-body>
+        <footnote> --> <note note-class="footnote">
         """
         attrib = {}
         key = moin_page("note-class")
         attrib[key] = "footnote"
-        children = self.new(moin_page("note-body"), attrib={}, children=self.do_children(element, depth))
-        if len(children) > 1 and html.data_lineno in children._children[1].attrib:
+        children = self.do_children(element, depth)
+        if len(children) > 1 and html.data_lineno in children[1].attrib:
             # must delete lineno because footnote will be placed near end of page and out of sequence
-            del children._children[1].attrib[html.data_lineno]
-        return self.new(moin_page.note, attrib=attrib, children=[children])
+            del children[1].attrib[html.data_lineno]
+        return self.new(moin_page.note, attrib=attrib, children=children)
 
     def visit_docbook_formalpara(self, element, depth):
         """

--- a/src/moin/converters/docbook_out.py
+++ b/src/moin/converters/docbook_out.py
@@ -349,27 +349,16 @@ class Converter:
 
     def visit_moinpage_note(self, element):
         """
-        <note note-class="footnote"><note-body>text</note-body></note>
+        <note note-class="footnote"><p>text</p></note>
           --> <footnote><simpara>text</simpara></footnote>
         """
+        if len(element) == 0:
+            # Moin uses an empty <note> as placeholder for a "footnotes" list;
+            # there is no such placeholder in DocBook.
+            return
         note_class = element.get(moin_page("note-class"))
-        # We only convert footnote, we do not convert endnote yet
-        if note_class != "footnote":
-            return
-
-        # We will check the presence of a body
-        body = None
-        for child in element:
-            if isinstance(child, ET.Element):
-                if child.tag.uri == moin_page:
-                    if child.tag.name == "note-body":
-                        body = self.do_children(child)
-        # We process note only with note-body child
-        if not body:
-            return
-
-        body = self.new(docbook.simpara, attrib={}, children=body)
-        return self.new(docbook.footnote, attrib={}, children=[body])
+        if note_class == "footnote":  # as of 2026/05, all notes are footnotes
+            return self.new(docbook.footnote, attrib={}, children=self.do_children(element))
 
     def visit_moinpage_object(self, element):
         """

--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -844,7 +844,7 @@ class ConverterPage(Converter):
         id = f'{self._id.get_id("note-placement")}-{label}'
 
         elem_ref = ET.XML(
-            f'<html:sup xmlns:html="{html}" html:id="note-{id}-ref" html:class="moin-footnote">'
+            f'<html:sup xmlns:html="{html}" html:id="note-{id}-ref" html:role="doc-noteref">'
             f'<html:a html:href="#note-{id}">{label}</html:a>'
             "</html:sup>"
         )

--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -825,7 +825,7 @@ class ConverterPage(Converter):
 
     def visit_moinpage_note(self, elem):
         # TODO: Check note-class? (As of 2026-05-20, it is always "footnote".)
-        #       cls = elem.get(moin_page.note_class, "")
+        #       note_class = elem.get(moin_page.note_class, "")
         top = self._special_stack[-1]
         if len(elem) == 0:
             # <<FootNote>> without argument
@@ -839,12 +839,7 @@ class ConverterPage(Converter):
             self._id.gen_id("note-placement")
             return footnotes_div
 
-        body = None
-        for child in elem:
-            if child.tag.uri == moin_page:
-                if child.tag.name == "note-body":
-                    body = self.do_children(child)
-
+        body = self.do_children(elem)
         label = self._id.gen_id("note")
         id = f'{self._id.get_id("note-placement")}-{label}'
 

--- a/src/moin/converters/mediawiki_in.py
+++ b/src/moin/converters/mediawiki_in.py
@@ -499,7 +499,7 @@ class Converter(ConverterMacro):
         # stack.top_check('emphasis'):
         if footnote_begin is not None:
             stack.push(moin_page.note(attrib={moin_page.note_class: "footnote"}))
-            stack.push(moin_page.note_body())
+            stack.push(moin_page.p())
         elif footnote_end is not None:
             stack.pop()
             stack.pop()

--- a/src/moin/converters/moinwiki_out.py
+++ b/src/moin/converters/moinwiki_out.py
@@ -348,7 +348,9 @@ class Converter:
         note_class = elem.get(moin_page.note_class, "")
         if note_class == "footnote":  # as of 2026/05, all notes are footnotes
             # macro content must be on one line
+            self.status.append("macro")
             content = self.open_children(elem).rstrip().replace("\n", " ")
+            self.status.pop()
             return f"<<FootNote({content})>>"
 
     def open_moinpage_nowiki(self, elem):
@@ -458,6 +460,11 @@ class Converter:
                 ret = Moinwiki.p + self.open_children(elem) + Moinwiki.p
             else:
                 ret = self.open_children(elem) + Moinwiki.p
+        elif self.status[-2] == "macro":  # macro content, must be on one line
+            if self.last_closed == "p":
+                ret = Moinwiki.linebreak + self.open_children(elem)
+            else:
+                ret = self.open_children(elem)
         elif self.status[-2] == "table":
             if self.last_closed and self.last_closed != "table_cell" and self.last_closed != "table_row":
                 ret = Moinwiki.linebreak + self.open_children(elem)

--- a/src/moin/converters/moinwiki_out.py
+++ b/src/moin/converters/moinwiki_out.py
@@ -343,11 +343,13 @@ class Converter:
         return f'{Moinwiki.literal}{"".join(elem.itertext())}{Moinwiki.literal}'
 
     def open_moinpage_note(self, elem):
-        class_ = elem.get(moin_page.note_class, "")
-        if class_:
-            if class_ == "footnote":
-                return f"<<FootNote({self.open_children(elem)})>>"
-        return "\n<<FootNote()>>\n"
+        if len(elem) == 0:  # empty <note> (placeholder for a "footnotes" list)
+            return "\n<<FootNote()>>\n"
+        note_class = elem.get(moin_page.note_class, "")
+        if note_class == "footnote":  # as of 2026/05, all notes are footnotes
+            # macro content must be on one line
+            content = self.open_children(elem).rstrip().replace("\n", " ")
+            return f"<<FootNote({content})>>"
 
     def open_moinpage_nowiki(self, elem):
         """{{{#!wiki ... or {{{#!highlight ... etc."""

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -440,18 +440,13 @@ class NodeVisitor:
         footnote = node.document.ids[node["refid"]]  # get matching footnote element
         attrib = {moin_page.note_class: "footnote"}
         self.open_moin_page_node(moin_page.note(attrib=attrib))
-        self.open_moin_page_node(moin_page.note_body())
         for child in footnote.children[1:]:
             walkabout(child, self)
-        self.close_moin_page_node()
         self.close_moin_page_node()
         raise nodes.SkipNode
         # TODO:
         # * Multiple references to one footnote print the same footnote text
         #   several times.
-        # * Handle markup in footnote content.
-        #   (Footnotes contain block-elements in rST, DocBook, and Markdown
-        #   and may contain inline elements in Moin and Mediawiki.)
 
     def depart_footnote_reference(self, node):
         pass

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -69,6 +69,7 @@ class NodeVisitor:
         self.header_size = 1
         self.last_lineno = 0
         self.current_lineno = 0
+        self.footnote_ids = set()  # IDs of already handled footnotes
 
     def dispatch_visit(self, node):
         """
@@ -437,8 +438,13 @@ class NodeVisitor:
 
     def visit_footnote_reference(self, node):
         # insert the referenced footnote here
-        footnote = node.document.ids[node["refid"]]  # get matching footnote element
+        refid = node["refid"]
+        footnote = node.document.ids[refid]  # get matching footnote element
         attrib = {moin_page.note_class: "footnote"}
+        # keep footnote ID for additional references (unless it is already used)
+        if refid not in self.footnote_ids:
+            attrib[moin_page.id] = refid
+            self.footnote_ids.add(refid)
         self.open_moin_page_node(moin_page.note(attrib=attrib))
         for child in footnote.children[1:]:
             walkabout(child, self)

--- a/src/moin/converters/rst_out.py
+++ b/src/moin/converters/rst_out.py
@@ -581,11 +581,14 @@ class Converter:
         return ret
 
     def open_moinpage_note(self, elem):
-        class_ = elem.get(moin_page.note_class, "")
-        if class_:
+        if len(elem) == 0:
+            # Moin uses an empty <note> as placeholder for a "footnotes" list;
+            # the rST ``.. footnotes::`` directive is not yet implemented
+            return ""
+        note_class = elem.get(moin_page.note_class, "")
+        if note_class == "footnote":  # as of 2026/05, all notes are footnotes
             self.status.append("list")
-            if class_ == "footnote":
-                self.footnotes.append(self.open_children(elem))
+            self.footnotes.append(self.open_children(elem))
             self.status.pop()
         return " [#]_ "
 


### PR DESCRIPTION
Drop `<note-body>` MoinPage element.

Graceful degradation for footnotes with more than one paragraph.

Keep footnote IDs from rST and DocBook source.

Closes #2270.