### PR TITLE
mediawiki: fix empty table cells and missing linebreaks in pre block

### DIFF
--- a/src/moin/converters/mediawiki_in.py
+++ b/src/moin/converters/mediawiki_in.py
@@ -738,7 +738,7 @@ class Converter(ConverterMacro):
             </nowiki>
             |
             <pre>
-            (?P<nowiki_text_pre> .*? )
+            (?P<nowiki_text_pre> [\s\S]*? )
             </pre>
             |
             <code>
@@ -903,7 +903,10 @@ class Converter(ConverterMacro):
                 # text may be None
                 if pre_text:
                     if len(tags):
-                        tags[-1].text.append(pre_text)
+                        if self.nowiki_tag == "pre":
+                            tags[-1].text.append(pre_text + "\n")
+                        else:
+                            tags[-1].text.append(pre_text)
                         post_line = []
                     else:
                         post_line = [pre_text]

--- a/src/moin/converters/mediawiki_in.py
+++ b/src/moin/converters/mediawiki_in.py
@@ -3,6 +3,7 @@
 # Copyright: 2007 MoinMoin:ReimarBauer
 # Copyright: 2008-2010 MoinMoin:BastianBlank
 # Copyright: 2010 MoinMoin:DmitryAndreev
+# Copyright: 2026 MoinMoin:UlrichB
 # License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
 
 """
@@ -196,7 +197,7 @@ class Converter(ConverterMacro):
                 element = moin_page.table_row()
                 stack.push(element)
             cells = m.group("cells")
-            if cells:
+            if cells is not None:
                 cells = cells.split("||")
                 for cell in cells:
                     if stack.top_check("table-cell"):


### PR DESCRIPTION
Fixes following issues in `help-en/mediawiki`:

Empty table cells or a single `'|'` in a row were not treated as table cells:

```
'''MWTODO:''' An attempt to create a one cell table with a border 20 pixels wide. This fails, the contents of the table cell precede the table and the table is empty causing HTML validation errors.

{|style="border-style: solid; border-width: 20px"
|
Hello
|}
```
In preformatted code using the `<pre>` tag line breaks should be preserved:

```
'''MWTODO:''' This page generated numerous HTML validation errors. The detail below has lost line formatting because of other bugs.

<pre><code>
Result: 17 errors / 14 warnings

Info: W3c Online Validation

line 509 column 103 - Error: Attribute xmlns:ns1 not allowed here.
[...]
</code></pre>
```

Update of the help page will be done in a seperate PR.

Related to #1704.