### PR TITLE
Fix wrong label for attribute in UserSettingsOptionsForm.

### DIFF
--- a/src/moin/templates/forms.html
+++ b/src/moin/templates/forms.html
@@ -59,7 +59,7 @@ See utils.html for more macros.
 {%- endmacro %}
 
 {% macro raw_input(field, type=none) %}
-    {{ gen.input(field, type=type or field.properties.widget, class=field.properties.class_ or '', **kwargs) }}
+    {{ gen.input(field, type=type or field.properties.widget, class=field.properties.class_ or '', **kwargs ) }}
 {%- endmacro %}
 
 {% macro annotated_input(field, type=none) %}
@@ -68,7 +68,7 @@ See utils.html for more macros.
         {{ gen.label(field) }}
     </dt>
     <dd>
-        {{ raw_input(field, type) }}
+        {{ raw_input(field, type, **kwargs) }}
         {{ render_errors(field) }}
         {#- TODO make the helper more explicit and look better #}
         {%- if field.properties.helper %}

--- a/src/moin/templates/usersettings_forms.html
+++ b/src/moin/templates/usersettings_forms.html
@@ -82,14 +82,14 @@
     {{ gen.form.open(form, method="post", action=url_for('frontend.usersettings')) }}
         {{ forms.render_errors(form) -}}
         <dl>
-            {{ forms.render(form['iso_8601']) }}
-            {{ forms.render(form['mailto_author']) }}
-            {{ forms.render(form['edit_on_doubleclick']) }}
-            {{ forms.render(form['use_html_editor']) }}
-            {{ forms.render(form['use_markdown_editor']) }}
-            {{ forms.render(form['scroll_page_after_edit']) }}
-            {{ forms.render(form['show_comments']) }}
-            {{ forms.render(form['disabled']) }}
+            {{ forms.render(form['iso_8601'], id='f_iso_8601') }}
+            {{ forms.render(form['mailto_author'], id='f_mailto_author') }}
+            {{ forms.render(form['edit_on_doubleclick'], id='f_edit_on_doubleclick') }}
+            {{ forms.render(form['use_html_editor'], id='f_use_html_editor') }}
+            {{ forms.render(form['use_markdown_editor'], id='f_use_markdown_editor') }}
+            {{ forms.render(form['scroll_page_after_edit'], id='f_scroll_page_after_edit') }}
+            {{ forms.render(form['show_comments'], id='f_show_comments') }}
+            {{ forms.render(form['disabled'], id='f_disabled') }}
         </dl>
         {{ forms.render_submit(form, 'part', 'options') }}
     {{ gen.form.close() }}


### PR DESCRIPTION
Fixes 8 issues detected by Chrome Dev Tools:

The label's for attribute doesn't match any element id. This might prevent the browser from correctly autofilling the form and accessibility tools from working correctly.

Here is an example of the generated markup showing the error:

<img width="715" height="162" alt="image" src="https://github.com/user-attachments/assets/b7694f34-9acd-4840-b21d-edeada7e0b82" />

@ThomasWaldmann Is the id with suffix "_1" auto-generated by flatland what you would expect?