### PR TITLE
new "moinpage" element `<noteref>`

### DIFF
--- a/src/moin/converters/_tests/test_docbook_in.py
+++ b/src/moin/converters/_tests/test_docbook_in.py
@@ -294,6 +294,11 @@ class TestConverter(Base):
             '/page/body/div/p[text()="text"]/note[@note-class="footnote"][@xml:id="fn42"][p[text()="footnote with id"]]/p[text()="second paragraph"]',
         ),
         (
+            '<article><para>additional footnote reference<footnoteref linkend="fn42" /></para></article>',
+            # <div html:class="db-article"><p>additional footnoteref reference<noteref xlink:href="#fn42" /></p></div>
+            '/page/body/div/p[text()="additional footnote reference"]/noteref[@xlink:href="#fn42"]',
+        ),
+        (
             "<article><para><quote>text</quote></para></article>",
             # <page><body><div html:class="article"><p><quote>text</quote></para></article>
             '/page/body/div/p[quote="text"]',

--- a/src/moin/converters/_tests/test_html_out.py
+++ b/src/moin/converters/_tests/test_html_out.py
@@ -335,7 +335,28 @@ class TestConverterPage(Base):
             # </div>
             '/div[p[text()="Text"]/sup[@id="note-0-1-ref"][@role="doc-noteref"]/a[@href="#note-0-1"][text()="1"]]'
             '/div[@class="moin-footnotes"]/aside[@id="note-0-1"][@role="doc-footnote"][sup/a[@href="#note-0-1-ref"][text()="1"]]/p[text()="Note"]',
-        )
+        ),
+        (
+            '<page><body><p>text<note id="fn42" html:class="custom" note-class="footnote"><p>footnote with ID</p></note></p></body></page>',
+            # <div>
+            #   <p>text<sup id="fn42-ref" role="doc-noteref"><a href="#fn42">1</a></sup></p>
+            #   <div class="moin-footnotes">
+            #     <aside class="custom" id="fn42" role="doc-footnote">
+            #       <sup><a href="#fn42-ref">1</a></sup>
+            #       <p>footnote with ID</p>
+            #     </aside>
+            #   </div>
+            # </div>
+            '/div[p[text()="text"]/sup[@id="fn42-ref"][@role="doc-noteref"]/a[@href="#fn42"][text()="1"]]'
+            '/div[@class="moin-footnotes"]'
+            '/aside[@class="custom"][@id="fn42"][@role="doc-footnote"][sup/a[@href="#fn42-ref"][text()="1"]]'
+            '/p[text()="footnote with ID"]',
+        ),
+        (  # DocBook IDs are converted to ``xml:id``
+            '<page><body><p>text<note xml:id="fn42" html:class="custom" note-class="footnote"><p>footnote with ID</p></note></p></body></page>',
+            # <same output as above>
+            '/div[p[text()="text"]/sup[@id="fn42-ref"][@role="doc-noteref"]/a[@href="#fn42"][text()="1"]]',
+        ),
     ]
 
     @pytest.mark.parametrize("input,xpath", data)

--- a/src/moin/converters/_tests/test_html_out.py
+++ b/src/moin/converters/_tests/test_html_out.py
@@ -333,15 +333,9 @@ class TestConverterPage(Base):
             #      </aside>
             #   </div>
             # </div>
-            # check footnote reference:
-            '/div[p[text()="Text"]/sup[@id="note-0-1-ref"][@role="doc-noteref"]/a[@href="#note-0-1"][text()="1"]]',
-        ),
-        (
-            '<page><body><p>Text<note note-class="footnote"><p>Note</p></note></p></body></page>',
-            # <same output as above>
-            # check footnote (at end of document)
-            '/div/div[@class="moin-footnotes"]/aside[@id="note-0-1"][@role="doc-footnote"][sup/a[@href="#note-0-1-ref"][text()="1"]]/p[text()="Note"]',
-        ),
+            '/div[p[text()="Text"]/sup[@id="note-0-1-ref"][@role="doc-noteref"]/a[@href="#note-0-1"][text()="1"]]'
+            '/div[@class="moin-footnotes"]/aside[@id="note-0-1"][@role="doc-footnote"][sup/a[@href="#note-0-1-ref"][text()="1"]]/p[text()="Note"]',
+        )
     ]
 
     @pytest.mark.parametrize("input,xpath", data)

--- a/src/moin/converters/_tests/test_html_out.py
+++ b/src/moin/converters/_tests/test_html_out.py
@@ -357,6 +357,13 @@ class TestConverterPage(Base):
             # <same output as above>
             '/div[p[text()="text"]/sup[@id="fn42-ref"][@role="doc-noteref"]/a[@href="#fn42"][text()="1"]]',
         ),
+        (
+            '<page><body><p>Two refs<note id="fn42" note-class="footnote"><p>labeled footnote</p></note></p>'
+            '<p>... to the same footnote.<noteref xlink:href="#fn42" /></p></body></page>',
+            #
+            '/div[p[text()="Two refs"]/sup[@id="fn42-ref"][@role="doc-noteref"]/a[@href="#fn42"][text()="1"]]'
+            '/p[text()="... to the same footnote."]/sup[@role="doc-noteref"]/a[@href="#fn42"][text()="1"]',
+        ),
     ]
 
     @pytest.mark.parametrize("input,xpath", data)

--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -249,7 +249,7 @@ class TestConverter:
         (
             "Two references [#fn42]_ to the same footnote [#fn42]_\n\n.. [#fn42] auto-label *footnote*",
             '<p>Two references<note id="fn42" note-class="footnote"><p>auto-label <emphasis>footnote</emphasis></p></note>'
-            ' to the same footnote<note note-class="footnote"><p>auto-label <emphasis>footnote</emphasis></p></note></p>',
+            ' to the same footnote<noteref xlink:href="#fn42" /></p>',
         ),
         (
             "Text [*]_\n\n.. [*] auto-symbol footnote\n\n   with second paragraph",

--- a/src/moin/converters/_tests/test_rst_out.py
+++ b/src/moin/converters/_tests/test_rst_out.py
@@ -191,6 +191,15 @@ class TestConverter(Base):
             '<page:page><page:body><page:p>Abra <page:note page:note-class="footnote">arba</page:note></page:p><page:p>Abra <page:note page:note-class="footnote">arba</page:note></page:p><page:p>Abra <page:note page:note-class="footnote">arba</page:note><page:note page:note-class="footnote">arba</page:note></page:p></page:body></page:page>',
             "Abra  [#]_ \n\nAbra  [#]_ \n\nAbra  [#]_  [#]_ \n\n\n.. [#] arba\n\n.. [#] arba\n\n.. [#] arba\n\n.. [#] arba\n\n",
         ),
+        (
+            '<page:page><page:body><page:p>Text<page:note xml:id="fn42" page:note-class="footnote">footnote with ID</page:note></page:p></page:body></page:page>',
+            "Text [#fn42]_ \n\n\n.. [#fn42] footnote with ID\n\n",
+        ),
+        (
+            '<page:page><page:body><page:p>Text<page:note xml:id="fn42" page:note-class="footnote"><page:p>footnote with ID</page:p></page:note></page:p>'
+            '<page:p>Additional footnote reference<page:noteref xlink:href="#fn42" /></page:p></page:body></page:page>',
+            "Text [#fn42]_ \n\nAdditional footnote reference [#fn42]_ \n\n\n.. [#fn42] footnote with ID\n\n",
+        ),
     ]
 
     @pytest.mark.parametrize("input,output", data)

--- a/src/moin/converters/docbook_in.py
+++ b/src/moin/converters/docbook_in.py
@@ -770,6 +770,13 @@ class Converter:
         note.extend(children)
         return note
 
+    def visit_docbook_footnoteref(self, element, depth):
+        """
+        <footnoteref linkend='fn' /> --> <noteref xlink:href='#fn' />
+        """
+        href = "#" + element.get("linkend")
+        return self.new(moin_page.noteref, attrib={xlink.href: href}, children=[])
+
     def visit_docbook_formalpara(self, element, depth):
         """
         <formalpara>

--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -839,24 +839,20 @@ class ConverterPage(Converter):
             self._id.gen_id("note-placement")
             return footnotes_div
 
-        body = self.do_children(elem)
-        label = self._id.gen_id("note")
-        id = f'{self._id.get_id("note-placement")}-{label}'
+        label = self._id.gen_id("note")  # 1, 2, 3, ...
+        ID = f'note-{self._id.get_id("note-placement")}-{label}'  # note-1-1, note-1-2, ...
 
-        elem_ref = ET.XML(
-            f'<html:sup xmlns:html="{html}" html:id="note-{id}-ref" html:role="doc-noteref">'
-            f'<html:a html:href="#note-{id}">{label}</html:a>'
-            "</html:sup>"
-        )
         elem_note = ET.XML(
-            f'<html:aside xmlns:html="{html}" html:id="note-{id}" html:role="doc-footnote">'
-            f'<html:sup><html:a html:href="#note-{id}-ref">{label}</html:a></html:sup>'
+            f'<html:aside xmlns:html="{html}" html:id="{ID}" html:role="doc-footnote">'
+            f'<html:sup><html:a html:href="#{ID}-ref">{label}</html:a></html:sup>'
             "</html:aside>"
         )
-        elem_note.extend(body)
+        elem_note.extend(self.do_children(elem))
         top.add_footnote(elem_note)
 
-        return elem_ref
+        ref_attrib = {html.role: "doc-noteref", html.id_: f"{ID}-ref"}
+        ref_child = html.a(attrib={html.href: f"#{ID}"}, children=[label])
+        return html.sup(attrib=ref_attrib, children=[ref_child])
 
     def visit_moinpage_table_of_content(self, elem):
         try:

--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -679,6 +679,7 @@ class SpecialPage:
         self._footnotes = []
         self._headings = []
         self._tocs = []
+        self._footnote_labels = {}  # mapping of footnote IDs to visible labels
 
     def add_footnote(self, elem):
         self._footnotes.append(elem)
@@ -853,10 +854,19 @@ class ConverterPage(Converter):
         elem_note.attrib.update(attrib)
         elem_note.extend(self.do_children(elem))
         top.add_footnote(elem_note)
+        top._footnote_labels[ID] = label  # save mapping for additional references
 
         ref_attrib = {html.role: "doc-noteref", html.id_: f"{ID}-ref"}
         ref_child = html.a(attrib={html.href: f"#{ID}"}, children=[label])
         return html.sup(attrib=ref_attrib, children=[ref_child])
+
+    def visit_moinpage_noteref(self, elem):
+        # additional references to a note (footnote, ...)
+        top = self._special_stack[-1]  # SpecialPage instance `special_root`
+        href = elem.get(xlink.href)
+        label = top._footnote_labels.get(href[1:], href)
+        child = html.a(attrib={html.href: href}, children=[label])
+        return html.sup(attrib={html.role: "doc-noteref"}, children=[child])
 
     def visit_moinpage_table_of_content(self, elem):
         try:

--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -841,12 +841,16 @@ class ConverterPage(Converter):
 
         label = self._id.gen_id("note")  # 1, 2, 3, ...
         ID = f'note-{self._id.get_id("note-placement")}-{label}'  # note-1-1, note-1-2, ...
+        attrib = Attributes(elem).convert()
+        if attrib.get(html.id_):
+            ID = attrib[html.id]
 
         elem_note = ET.XML(
             f'<html:aside xmlns:html="{html}" html:id="{ID}" html:role="doc-footnote">'
             f'<html:sup><html:a html:href="#{ID}-ref">{label}</html:a></html:sup>'
             "</html:aside>"
         )
+        elem_note.attrib.update(attrib)
         elem_note.extend(self.do_children(elem))
         top.add_footnote(elem_note)
 

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -439,12 +439,16 @@ class NodeVisitor:
     def visit_footnote_reference(self, node):
         # insert the referenced footnote here
         refid = node["refid"]
+        if refid in self.footnote_ids:
+            attrib = {xlink.href: f"#{refid}"}
+            self.open_moin_page_node(moin_page.noteref(attrib=attrib))
+            self.close_moin_page_node()
+            raise nodes.SkipNode
         footnote = node.document.ids[refid]  # get matching footnote element
         attrib = {moin_page.note_class: "footnote"}
         # keep footnote ID for additional references (unless it is already used)
-        if refid not in self.footnote_ids:
-            attrib[moin_page.id] = refid
-            self.footnote_ids.add(refid)
+        attrib[moin_page.id] = refid
+        self.footnote_ids.add(refid)
         self.open_moin_page_node(moin_page.note(attrib=attrib))
         for child in footnote.children[1:]:
             walkabout(child, self)

--- a/src/moin/converters/rst_out.py
+++ b/src/moin/converters/rst_out.py
@@ -21,7 +21,7 @@ from emeraldtree import ElementTree as ET
 from . import ElementException
 
 from moin.utils.mime import Type, type_moin_document
-from moin.utils.tree import html, moin_page, xlink, xinclude
+from moin.utils.tree import html, moin_page, xlink, xinclude, xml
 from moin.utils.iri import Iri
 
 from . import default_registry
@@ -316,7 +316,7 @@ class Converter:
         self.delete_newlines = False
         self.line_block_indent = -4
         ret = self.open(root)
-        notes = "\n\n".join(".. [#] {}".format(note.replace("\n", "\n  ")) for note in self.footnotes)
+        notes = "\n\n".join(self.footnotes)
         if notes:
             return ret + self.define_references() + f"\n\n{notes}\n\n"
 
@@ -586,11 +586,18 @@ class Converter:
             # the rST ``.. footnotes::`` directive is not yet implemented
             return ""
         note_class = elem.get(moin_page.note_class, "")
+        ID = elem.get(moin_page.id, "") or elem.get(xml.id, "")
         if note_class == "footnote":  # as of 2026/05, all notes are footnotes
             self.status.append("list")
-            self.footnotes.append(self.open_children(elem))
+            content = self.open_children(elem).strip()
+            self.footnotes.append(f".. [#{ID}] " + content.replace("\n", "\n  "))
             self.status.pop()
-        return " [#]_ "
+        return f" [#{ID}]_ "
+
+    def open_moinpage_noteref(self, elem):
+        # <noteref xlink:href='#fn' /> --> [#fn]_
+        href = elem.get(xlink.href, None)
+        return f" [{href}]_ "
 
     def open_moinpage_object(self, elem):
         # TODO: object parameters support


### PR DESCRIPTION
The new internal "moinpage" DOM element stands for additional references
to a footnote.
It is analogous to the DocBook element `<footnoteref>`, and
the Docutils "Doctree" element `<footnote_reference>`.
    
The HTML representation is a `<sup>` with ARIA role "doc-noteref" and a
link to the footnote --- similar to the footnote reference left in place
of a `<moinpage:footnote>`.
    
Cf. issue #2273
    