### PR TITLE
MoinWiki-Out: Correct handling of unsupported 'kbd' and 'samp' Moin d…

### DIFF
--- a/src/moin/converters/moinwiki_out.py
+++ b/src/moin/converters/moinwiki_out.py
@@ -288,7 +288,7 @@ class Converter:
 
     def open_moinpage_kbd(self, elem):
         # there is no specific markup for user input (<kbd>)
-        self.open_moinpage_literal()
+        return f'{Moinwiki.literal}{"".join(elem.itertext())}{Moinwiki.literal}'
 
     def open_moinpage_line_break(self, elem):
         return Moinwiki.linebreak
@@ -556,7 +556,7 @@ class Converter:
 
     def open_moinpage_samp(self, elem):
         # there is no specific markup for computer output (<samp>)
-        self.open_moinpage_literal()
+        return f'{Moinwiki.literal}{"".join(elem.itertext())}{Moinwiki.literal}'
 
     def open_moinpage_separator(self, elem, hr_class_prefix="moin-hr"):
         hr_ending = "\n"


### PR DESCRIPTION
…om elements

Fixes missing argument in call of open_moinpage_literal. Output item content as literal.