### PR TITLE
MoinWiki-In Converter: Allow '?' in wiki item names

### DIFF
--- a/src/moin/converters/moinwiki_in.py
+++ b/src/moin/converters/moinwiki_in.py
@@ -790,11 +790,7 @@ class Converter(ConverterMacro):
                 link_item, fragment = link_item.rsplit("#", 1)
             else:
                 link_item, fragment = link_item, None
-            if "?" in link_item:
-                path, link_query = link_item.rsplit("?", 1)
-                query.insert(0, link_query)
-            else:
-                path, link_query = link_item, None
+            path = link_item
             if query:
                 query = "&" + "&".join(query)
             else:

--- a/src/moin/converters/moinwiki_in.py
+++ b/src/moin/converters/moinwiki_in.py
@@ -16,7 +16,7 @@ from typing import Any, Final, TYPE_CHECKING
 import re
 
 from flask import request
-from urllib.parse import urlencode
+from urllib.parse import urlencode, unquote
 
 from moin import log
 from moin.constants.contenttypes import CHARSET
@@ -796,7 +796,7 @@ class Converter(ConverterMacro):
             else:
                 query = None
             target = Iri(scheme="wiki.local", path=path, query=query, fragment=fragment)
-            text = link_item
+            text = unquote(link_item)
         else:
             target = Iri(link_url)
             text = link_url

--- a/src/moin/items/__init__.py
+++ b/src/moin/items/__init__.py
@@ -37,6 +37,8 @@ from flatland.validation import Validator
 
 from markupsafe import Markup
 
+from urllib.parse import unquote
+
 from whoosh.query import Term, Prefix, And, Or, Not
 
 from moin import current_app, flaskg, log
@@ -1519,6 +1521,7 @@ class Default(Contentful):
             item=self,
             item_name=self.name,
             fqname=self.fqname,
+            title=unquote(self.name),
             rev=self.rev,
             contenttype=self.contenttype,
             rev_navigation_ids_dates=rev_navigation_ids_dates,


### PR DESCRIPTION
In addition, revert percent encoding in item names when creating the display text.

Fixes issue #2177