### PR TITLE
MediaWiki In: footnote fixes.

### DIFF
--- a/src/moin/converters/_tests/test_mediawiki_in.py
+++ b/src/moin/converters/_tests/test_mediawiki_in.py
@@ -58,6 +58,18 @@ class TestConverter:
             '<page><body><p>aaa <note note-class="footnote"><p> sdf </p></note> test</p><p> asd</p></body></page>',
         ),
         (
+            'aaa<ref name="fn42">labeled footnote</ref>',
+            '<page><body><p>aaa<note id="fn42" note-class="footnote"><p>labeled footnote</p></note></p></body></page>',
+        ),
+        (
+            'additional reference<ref name="fn42" /> to a footnote',
+            '<page><body><p>additional reference<noteref xlink:href="#fn42" /> to a footnote</p></body></page>',
+        ),
+        (
+            "custom placement of footnotes\n\n<references />",
+            "<page><body><p>custom placement of footnotes</p><p><note /></p></body></page>",
+        ),
+        (
             """=level 1=
 == level 2 ==
 ===level 3===

--- a/src/moin/converters/docbook_out.py
+++ b/src/moin/converters/docbook_out.py
@@ -114,11 +114,18 @@ class Converter:
         """
         Copy one element to the DocBook tree.
 
-        It first converts the children of the element,
-        and then the element itself.
+        Convert the element, its attributes, and children.
         """
-        children = self.do_children(element)
-        return self.new(tag, attrib, children)
+        # new_element = self.new(tag, attrib, children=[])
+        if self.standard_attribute:
+            attrib.update(self.standard_attribute)
+            self.standard_attribute = {}
+        new_element = ET.Element(tag, attrib=attrib, children=[])
+        new_element.extend(self.do_children(element))
+        if self.current_section > 0:
+            self.section_children[self.current_section].append(new_element)
+        else:
+            return new_element
 
     def get_standard_attributes(self, element):
         """

--- a/src/moin/converters/html_out.py
+++ b/src/moin/converters/html_out.py
@@ -863,7 +863,7 @@ class ConverterPage(Converter):
     def visit_moinpage_noteref(self, elem):
         # additional references to a note (footnote, ...)
         top = self._special_stack[-1]  # SpecialPage instance `special_root`
-        href = elem.get(xlink.href)
+        href = elem.get(xlink.href, "#noteref with missing href")
         label = top._footnote_labels.get(href[1:], href)
         child = html.a(attrib={html.href: href}, children=[label])
         return html.sup(attrib={html.role: "doc-noteref"}, children=[child])

--- a/src/moin/converters/mediawiki_in.py
+++ b/src/moin/converters/mediawiki_in.py
@@ -497,10 +497,23 @@ class Converter(ConverterMacro):
     def inline_footnote_repl(
         self, stack, footnote, footnote_begin=None, footnote_text=None, footnote_end=None, footnote_start=None
     ):
-        # stack.top_check('emphasis'):
-        if footnote_begin is not None:
-            stack.push(moin_page.note(attrib={moin_page.note_class: "footnote"}))
-            stack.push(moin_page.p())
+        if footnote.startswith("<references"):
+            # custom placement (https://www.mediawiki.org/wiki/Help:Cite)
+            stack.top_append(moin_page.note())
+        elif footnote_begin is not None:
+            # extract ID (e.g. 'fn3' from '<ref name="fn3">')
+            arguments = _TableArguments()(footnote_begin)  # '_TableArguments' works also for XML-style attributes
+            if footnote_begin.endswith("/>"):  # empty tag -> additional reference to footnote with ID
+                attrib = {}
+                if "name" in arguments:
+                    attrib[xlink.href] = "#" + arguments["name"]
+                stack.top_append(moin_page.noteref(attrib=attrib))
+            else:
+                attrib = {moin_page.note_class: "footnote"}
+                if "name" in arguments:
+                    attrib[moin_page.id] = arguments["name"]
+                stack.push(moin_page.note(attrib=attrib))
+                stack.push(moin_page.p())
         elif footnote_end is not None:
             stack.pop()
             stack.pop()


### PR DESCRIPTION
Support footnotes with ID, additional references, and custom placement.

* Convert "name" attribute of a MediaWiki `<ref>` to an ID.
* Convert empty `<ref>` to a `<noteref>` (additional reference to a footnote with ID).
* Convert `<references />` to an empty `<note>` (placeholder for custom placement of footnotes so far).