### PR TITLE
DocBook-In/Out: Fix placement of "standard attributes".

### DIFF
--- a/src/moin/converters/_tests/test_docbook_in.py
+++ b/src/moin/converters/_tests/test_docbook_in.py
@@ -110,6 +110,11 @@ class TestConverter(Base):
             # <page><body><div html:class="article"><p xml:base="http://base.tld" xml:id="id" xml:lang="en">Text</p></div></body></page>
             '/page/body/div/p[@xml:base="http://base.tld"][@xml:id="id"][@xml:lang="en"][text()="Text"]',
         ),
+        (  # place standard attributes at the element, not its first child
+            '<article><para xml:id="myid">emphasised  <emphasis>text</emphasis></para></article>',
+            # <page><body><div html:class="db-article"><p xml:id="myid">emphasised  <emphasis>text</emphasis></p></div></body></page>
+            '/page/body/div/p[@xml:id="myid"]/emphasis[text()="text"]',
+        ),
         # ANCHOR --> SPAN
         (
             '<article><para>bla bla<anchor xml:id="point_1" />bla bla</para></article>',

--- a/src/moin/converters/_tests/test_docbook_out.py
+++ b/src/moin/converters/_tests/test_docbook_out.py
@@ -76,10 +76,12 @@ class TestConverter(Base):
         # Unknown admonition
         ('<page><body><admonition page:type="none"><p>Text</p></admonition></body></page>', '/article[simpara="Text"]'),
         # XML attributes: we support all the xml standard attributes
-        (
-            '<page><body><p xml:base="http://base.tld" xml:id="id" xml:lang="en">Text</p></body></page>',
-            # <article><simpara xml:base="http://base.tld" xml:id="id" xml:lang="en">Text</p></body></page>
-            '/article/simpara[@xml:base="http://base.tld"][@xml:id="id"][@xml:lang="en"][text()="Text"]',
+        (  # TODO: the values end up on the first child element!
+            '<page><body><p xml:base="http://base.tld" xml:id="myid" xml:lang="en">emphasised  <emphasis>text</emphasis></p></body></page>',
+            # actual:  <simpara>emphasised  <emphasis xml:base="http://base.tld" xml:id="myid" xml:lang="en">text</emphasis></simpara>
+            '/article/simpara/emphasis[@xml:base="http://base.tld"][@xml:id="myid"][@xml:lang="en"][text()="text"]',
+            # desired: <simpara xml:base="http://base.tld" xml:id="myid" xml:lang="en">emphasised  <emphasis>text</emphasis></simpara>
+            # '/article/simpara[@xml:base="http://base.tld"][@xml:id="myid"][@xml:lang="en"]/emphasis[text()="text"]',
         ),
         # Para with title
         (

--- a/src/moin/converters/_tests/test_docbook_out.py
+++ b/src/moin/converters/_tests/test_docbook_out.py
@@ -76,18 +76,17 @@ class TestConverter(Base):
         # Unknown admonition
         ('<page><body><admonition page:type="none"><p>Text</p></admonition></body></page>', '/article[simpara="Text"]'),
         # XML attributes: we support all the xml standard attributes
-        (  # TODO: the values end up on the first child element!
-            '<page><body><p xml:base="http://base.tld" xml:id="myid" xml:lang="en">emphasised  <emphasis>text</emphasis></p></body></page>',
-            # actual:  <simpara>emphasised  <emphasis xml:base="http://base.tld" xml:id="myid" xml:lang="en">text</emphasis></simpara>
-            '/article/simpara/emphasis[@xml:base="http://base.tld"][@xml:id="myid"][@xml:lang="en"][text()="text"]',
-            # desired: <simpara xml:base="http://base.tld" xml:id="myid" xml:lang="en">emphasised  <emphasis>text</emphasis></simpara>
-            # '/article/simpara[@xml:base="http://base.tld"][@xml:id="myid"][@xml:lang="en"]/emphasis[text()="text"]',
-        ),
-        # Para with title
         (
-            '<page><body><p html:title="Title">Text</p></body></page>',
-            # <article><simpara xml:base="http://base.tld" xml:id="id" xml:lang="en">Text</p></body></page>
-            '/article/para[text()="Text"][title="Title"]',
+            '<page><body><p xml:base="http://base.tld" xml:id="myid" xml:lang="en">emphasised  <emphasis>text</emphasis></p></body></page>',
+            # <article><simpara xml:base="http://base.tld" xml:id="myid" xml:lang="en">emphasised  <emphasis>text</emphasis></simpara></article>
+            '/article/simpara[@xml:base="http://base.tld"][@xml:id="myid"][@xml:lang="en"]/emphasis[text()="text"]',
+        ),
+        # Para with title/tooltip
+        # TODO: fix handling (see `docbook_out.Converter.visit_moinpage_p()`)
+        (
+            '<page><body><p html:title="tooltip" xml:id="myid">Text</p></body></page>',
+            # <article><para><title>Title</title>Text</para></article>
+            '/article/para[@xml:id="myid"][text()="Text"][title="tooltip"]',
         ),
     ]
 
@@ -169,9 +168,9 @@ class TestConverter(Base):
             '/article/table[caption="Title"][thead/tr[td="Header"]][tfoot/tr[td="Footer"]][tbody/tr[td="Cell"]]',
         ),
         (
-            '<page><body><table><table-body><table-row><table-cell page:number-columns-spanned="2">Cell</table-cell></table-row></table-body></table></body></page>',
-            # <article><table><tbody><tr><td colspan="2">Cell</td></tr></tbody></table></article>
-            '/article/table/tbody/tr/td[@colspan="2"][text()="Cell"]',
+            '<page><body><table xml:id="myid"><table-body><table-row><table-cell page:number-columns-spanned="2">Cell</table-cell></table-row></table-body></table></body></page>',
+            # <article><table xml:id="myid"><tbody><tr><td colspan="2">Cell</td></tr></tbody></table></article>
+            '/article/table[@xml:id="myid"]/tbody/tr/td[@colspan="2"][text()="Cell"]',
         ),
         (
             '<page><body><table><table-body><table-row><table-cell page:number-rows-spanned="2">Cell</table-cell></table-row></table-body></table></body></page>',
@@ -187,9 +186,9 @@ class TestConverter(Base):
     data = [
         # Footnote conversion
         (
-            '<page><body><p>simple text<note page:note-class="footnote"><p>footnote content</p></note></p></body></page>',
-            # <article><simpara>simple text<footnote>footnote content</footnote></simpara></article>
-            '/article/simpara[text()="simple text"]/footnote[simpara="footnote content"]',
+            '<page><body><p>simple text<note page:note-class="footnote" xml:id="myid"><p>footnote content</p></note></p></body></page>',
+            # <article><simpara>simple text<footnote xml:id="myid">footnote content</footnote></simpara></article>
+            '/article/simpara[text()="simple text"]/footnote[@xml:id="myid"][simpara="footnote content"]',
         ),
         # Link conversion
         (
@@ -271,9 +270,9 @@ class TestConverter(Base):
         ),
         # BLOCKQUOTE --> BLOCKQUOTE
         (
-            '<page><body><blockquote page:source="Socrates">One thing only I know, and that is that I know nothing.</blockquote></body></page>',
-            # <article><blockquote><attribution>Socrates</attribution><simpara>One thing ... nothing</simpara></blockquote></article>
-            '/article/blockquote[attribution="Socrates"][simpara="One thing only I know, and that is that I know nothing."]',
+            '<page><body><blockquote page:source="Socrates" xml:id="myid">One thing only I know, and that is that I know nothing.</blockquote></body></page>',
+            # <article><blockquote xml:id="myid"><attribution>Socrates</attribution><simpara>One thing ... nothing</simpara></blockquote></article>
+            '/article/blockquote[@xml:id="myid"][attribution="Socrates"][simpara="One thing only I know, and that is that I know nothing."]',
         ),
     ]
 
@@ -288,9 +287,9 @@ class TestConverter(Base):
             '/article/simpara/inlinemediaobject/imageobject/imagedata[@fileref="pics.png"]',
         ),
         (
-            '<page><body><p><object xlink:href="sound.wav" page:type="audio/" /></p></body></page>',
-            # <article><simpara><inlinemediaobject><audioobject><audiodata fileref="sound.wav"></audioobject></inlinemediaobject></simpara></article>
-            '/article/simpara/inlinemediaobject/audioobject/audiodata[@fileref="sound.wav"]',
+            '<page><body><p><object xlink:href="sound.wav" page:type="audio/" xml:lang="fr" /></p></body></page>',
+            # <article><simpara><inlinemediaobject xml:lang="fr"><audioobject><audiodata fileref="sound.wav"></audioobject></inlinemediaobject></simpara></article>
+            '/article/simpara/inlinemediaobject[@xml:lang="fr"]/audioobject/audiodata[@fileref="sound.wav"]',
         ),
         (
             '<page><body><p><object xlink:href="video.ogg" page:type="video/" /></p></body></page>',
@@ -306,7 +305,7 @@ class TestConverter(Base):
     data = [
         (
             '<page><body><div html:class="db-article"><p>a <emphasis page:html-tag="cite">Title of Cited Work</emphasis></p></div></body></page>',
-            # <article><para>a <citetitle>Title of Cited Work</citetitle></para></article>
+            # <article><simpara>a <citetitle>Title of Cited Work</citetitle></simpara></article>
             '/article/simpara/citetitle[text()="Title of Cited Work"]',
         )
     ]

--- a/src/moin/converters/docbook_in.py
+++ b/src/moin/converters/docbook_in.py
@@ -500,8 +500,11 @@ class Converter:
 
         It first converts the children of the element,
         and then the element itself.
+
+        The "standard attributes" `xml:id`, `xml:base`, `xml:lang`,
+        and `data-lineno` are copied to the new element. Attributes
+        in `attrib` have precedence.
         """
-        # TODO: should element attribs override explicitely given attribs or vice versa?
         attrib = self.get_standard_attributes(element) | attrib
         children = self.do_children(element, depth)
         return self.new(tag, attrib, children)

--- a/src/moin/converters/docbook_in.py
+++ b/src/moin/converters/docbook_in.py
@@ -441,11 +441,6 @@ class Converter:
         self.heading_level = 0
         self.is_section = False
 
-        # We store the standard attributes of an element.
-        # Once we have been able to put it into an output element,
-        # we clear this attribute.
-        self.standard_attribute = {}
-
         # We will create an element tree from the DocBook content
         try:
             # XXX: The XML parser need bytestring.
@@ -497,9 +492,6 @@ class Converter:
         """
         Return a new element for the DocBook Tree.
         """
-        if self.standard_attribute:
-            attrib.update(self.standard_attribute)
-            self.standard_attribute = {}
         return ET.Element(tag, attrib=attrib, children=children)
 
     def new_copy(self, tag, element, depth, attrib):
@@ -509,23 +501,23 @@ class Converter:
         It first converts the children of the element,
         and then the element itself.
         """
+        # TODO: should element attribs override explicitely given attribs or vice versa?
+        attrib = self.get_standard_attributes(element) | attrib
         children = self.do_children(element, depth)
         return self.new(tag, attrib, children)
 
-    def get_standard_attributes(self, element):
+    def get_standard_attributes(self, element) -> dict:
         """
-        We will extract the standard attributes of the element, if any.
-        We save the result in our standard attribute.
+        Return the "standard attributes" of the element.
+
+        TODO: Clear the intention of this method, rename or fix.
+              (see docbook_out.Converter.get_standard_attributes()).
         """
         result = {}
         for key, value in element.attrib.items():
             if key.uri == xml and key.name in ["id", "base", "lang"] or key.name == "data-lineno":
                 result[key] = value
-        if result:
-            # We clear standard_attribute, if ancestror attribute
-            # was stored and has not been written in to the output,
-            # anyway the new standard attributes will get higher priority
-            self.standard_attribute = result
+        return result
 
     def visit(self, element, depth):
         """
@@ -628,14 +620,14 @@ class Converter:
         object_data. If it is not possible, we return a paragraph
         with the content of text_object.
         """
-        attrib = {}
+        attrib = self.get_standard_attributes(element)
         preferred_format, data_tag, mimetype = self.media_tags[element.tag.name]
         if not object_data:
             if not text_object:
                 return
             else:
                 children = self.do_children(element, depth + 1)
-                return self.new(moin_page.p, attrib={}, children=children)
+                return self.new(moin_page.p, attrib, children)
         # We try to determine the best object to show
         for obj in object_data:
             format = obj.get("format")  # format is optional: <imagedata format="jpeg" fileref="jpeg.jpg"/>
@@ -654,7 +646,7 @@ class Converter:
         if object_to_show is None:
             # we could not find any suitable object, return the text_object replacement.
             children = self.do_children(text_object, depth + 1)
-            return self.new(moin_page.p, attrib={}, children=children)
+            return self.new(moin_page.p, attrib, children)
 
         href = object_to_show.get("fileref")
         if not href:
@@ -727,7 +719,7 @@ class Converter:
                     children.extend(self.do_children(child, depth + 1))
             else:
                 children.append(child)
-        attrib = {}
+        attrib = self.get_standard_attributes(element)
         attrib[moin_page("source")] = source[0]
         return self.new(moin_page.blockquote, attrib=attrib, children=children)
 
@@ -754,6 +746,7 @@ class Converter:
         """
         Return a table within a table-cell.
         """
+        # "standard_attributes" go to the `table_element`
         table_element = self.new_copy(moin_page.table, element, depth, attrib={})
         return self.new(moin_page("table-cell"), attrib={}, children=[table_element])
 
@@ -761,21 +754,20 @@ class Converter:
         """
         <footnote> --> <note note-class="footnote">
         """
-        attrib = {moin_page.note_class: "footnote"}
-        note = self.new(moin_page.note, attrib=attrib, children=[])
+        attrib = self.get_standard_attributes(element) | {moin_page.note_class: "footnote"}
         children = self.do_children(element, depth)
         if len(children) > 1 and html.data_lineno in children[1].attrib:
             # must delete lineno because footnote will be placed near end of page and out of sequence
             del children[1].attrib[html.data_lineno]
-        note.extend(children)
-        return note
+        return self.new(moin_page.note, attrib, children)
 
     def visit_docbook_footnoteref(self, element, depth):
         """
         <footnoteref linkend='fn' /> --> <noteref xlink:href='#fn' />
         """
-        href = "#" + element.get("linkend")
-        return self.new(moin_page.noteref, attrib={xlink.href: href}, children=[])
+        attrib = self.get_standard_attributes(element)
+        attrib[xlink.href] = "#" + element.get("linkend")
+        return self.new(moin_page.noteref, attrib, children=[])
 
     def visit_docbook_formalpara(self, element, depth):
         """
@@ -785,6 +777,8 @@ class Converter:
         </formalpara>
           --> <p html:title="Heading">Text</p>
         """
+        # TODO: despite its name, the "html:title" attribute is not a heading
+        # but a "tooltip". (rST uses ``moin_page.p(attrib={html.class_: "moin-title"})``)
         for child in element:
             if isinstance(child, ET.Element):
                 if child.tag.name == "title":
@@ -799,8 +793,8 @@ class Converter:
             # XXX: Improve error
             raise SyntaxError("para child missing for formalpara element")
 
+        attrib = self.get_standard_attributes(element)
         children = self.do_children(para_element, depth + 1)[0]
-        attrib = {}
         attrib[html("title")] = title_element[0]
         return self.new(moin_page.p, attrib=attrib, children=children)
 
@@ -840,7 +834,8 @@ class Converter:
 
     def visit_docbook_inlinemediaobject(self, element, depth):
         data_element = self.visit_data_object(element, depth)
-        attrib = {html.class_: "db-inlinemediaobject"}
+        attrib = self.get_standard_attributes(element)
+        attrib[html.class_] = "db-inlinemediaobject"
         return self.new(moin_page.span, attrib=attrib, children=[data_element])
 
     def visit_docbook_itemizedlist(self, element, depth):
@@ -886,7 +881,8 @@ class Converter:
 
     def visit_docbook_mediaobject(self, element, depth):
         data_element = self.visit_data_object(element, depth)
-        attrib = {html.class_: "db-mediaobject"}
+        attrib = self.get_standard_attributes(element)
+        attrib[html.class_] = "db-mediaobject"
         return self.new(moin_page.div, attrib=attrib, children=[data_element])
 
     def visit_docbook_olink(self, element, depth):
@@ -926,7 +922,8 @@ class Converter:
         """
         <sbr /> --> <line-break />
         """
-        return self.new(moin_page("line-break"), attrib={}, children={})
+        attrib = self.get_standard_attributes(element)
+        return self.new(moin_page("line-break"), attrib, children=[])
 
     def visit_docbook_sect(self, element, depth):
         """
@@ -955,7 +952,7 @@ class Converter:
                     element.remove(child)
         heading_level = element.tag.name[4]
         key = moin_page("outline-level")
-        attrib = {}
+        attrib = self.get_standard_attributes(element)
         attrib[key] = heading_level
         return self.new(moin_page.h, attrib=attrib, children=title)
 
@@ -990,7 +987,7 @@ class Converter:
                     # Remove the title element to avoid double conversion
                     element.remove(child)
         key = moin_page("outline-level")
-        attrib = {}
+        attrib = self.get_standard_attributes(element)
         attrib[key] = self.heading_level
         result.append(self.new(moin_page.h, attrib=attrib, children=title))
         result.extend(self.do_children(element, depth))
@@ -1135,7 +1132,7 @@ class Converter:
         class_attribute = element.get("class")
         namespace_attribute = element.get("namespace")
         # We create the attribute for our final element
-        attrib = {}
+        attrib = self.get_standard_attributes(element)
         children = []
         if class_attribute:
             attrib[html.class_] = "".join(["db-tag-", class_attribute])
@@ -1379,10 +1376,7 @@ class Converter:
 
         We also add a <table-of-content> element if needed.
         """
-        attrib = {}
-        if self.standard_attribute:
-            attrib.update(self.standard_attribute)
-            self.standard_attribute = {}
+        attrib = self.get_standard_attributes(element)
         children = []
         children.append(self.visit(element, depth))
         # We show the table of content only if it is not empty

--- a/src/moin/converters/docbook_out.py
+++ b/src/moin/converters/docbook_out.py
@@ -113,10 +113,13 @@ class Converter:
         It first converts the children of the element,
         and then the element itself.
 
+        The "standard attributes" `xml:id`, `xml:base`, `xml:lang`,
+        and `data-lineno` are copied to the new element. Attributes
+        in `attrib` have precedence.
+
         TODO: consistently return an element or None (see `new()` above).
         """
-        # TODO: should element attribs override explicitely given attribs or vice versa?
-        attrib.update(self.get_standard_attributes(element))
+        attrib = self.get_standard_attributes(element) | attrib
         children = self.do_children(element)
         return self.new(tag, attrib, children)
 

--- a/src/moin/converters/docbook_out.py
+++ b/src/moin/converters/docbook_out.py
@@ -114,18 +114,11 @@ class Converter:
         """
         Copy one element to the DocBook tree.
 
-        Convert the element, its attributes, and children.
+        It first converts the children of the element,
+        and then the element itself.
         """
-        # new_element = self.new(tag, attrib, children=[])
-        if self.standard_attribute:
-            attrib.update(self.standard_attribute)
-            self.standard_attribute = {}
-        new_element = ET.Element(tag, attrib=attrib, children=[])
-        new_element.extend(self.do_children(element))
-        if self.current_section > 0:
-            self.section_children[self.current_section].append(new_element)
-        else:
-            return new_element
+        children = self.do_children(element)
+        return self.new(tag, attrib, children)
 
     def get_standard_attributes(self, element):
         """

--- a/src/moin/converters/docbook_out.py
+++ b/src/moin/converters/docbook_out.py
@@ -54,11 +54,6 @@ class Converter:
         "sup": docbook.superscript,
     }
 
-    # We store the standard attributes of an element.
-    # Once we have been able to put it into an output element,
-    # we clear this attribute.
-    standard_attribute = {}
-
     @classmethod
     def _factory(cls, input: Type, output: Type, **kwargs: Any) -> Self:
         return cls()
@@ -100,11 +95,12 @@ class Converter:
 
     def new(self, tag, attrib, children):
         """
-        Return a new element in the DocBook tree.
+        Return a new element in the DocBook tree or attach it to the section.
+
+        TODO: consistently return an element or None.
+              Suggestion: always attach the new element at the "right place"
+              and also return (for additions from the calling method).
         """
-        if self.standard_attribute:
-            attrib.update(self.standard_attribute)
-            self.standard_attribute = {}
         if self.current_section > 0:
             self.section_children[self.current_section].append(ET.Element(tag, attrib=attrib, children=children))
         else:
@@ -116,24 +112,36 @@ class Converter:
 
         It first converts the children of the element,
         and then the element itself.
+
+        TODO: consistently return an element or None (see `new()` above).
         """
+        # TODO: should element attribs override explicitely given attribs or vice versa?
+        attrib.update(self.get_standard_attributes(element))
         children = self.do_children(element)
         return self.new(tag, attrib, children)
 
-    def get_standard_attributes(self, element):
+    def get_standard_attributes(self, element) -> dict:
         """
-        We will extract the standard attributes of the element, if any.
-        We save the result in standard_attribute.
+        Return the "standard attributes" of the element.
+
+        TODO:
+          * Clear the intention of this method, rename or fix:
+
+            This method extracts all attributes of the "xml" namespace.
+            DocBook elements support 34 `common attributes`__.  Out of them
+            3 use the "xml" namespace (xml:base, xml:id, xml:lang) and
+            10 use the "xlink" namespace (but hrefs use "linkend" instead of "xlink:href").
+
+          * Convert  "moin:id" to "xml:id".
+            Convert ``xlink:href=``#target-id`` to ``linkend="target-id"``.
+
+        __ https://tdg.docbook.org/tdg/5.1/ref-elements.html#common.attributes
         """
         result = {}
         for key, value in element.attrib.items():
             if key.uri == xml:
                 result[key] = value
-        if result:
-            # We clear standard_attribute, if ancestror attribute
-            # was stored and has not been written in to the output,
-            # anyway the new standard attributes will get higher priority
-            self.standard_attribute = result
+        return result
 
     def visit(self, element):
         """
@@ -161,9 +169,6 @@ class Converter:
         We will choose the most appropriate procedure to convert
         the element according to the tag name
         """
-        # Save the standard attribute of the element
-        self.get_standard_attributes(element)
-
         # Check if we can a simple conversion
         if element.tag.name in self.simple_tags:
             return self.visit_simple_tag(element)
@@ -217,8 +222,9 @@ class Converter:
         <blockcode>text</blockcode> --> <screen><![CDATA[text]]></scren>
         """
         code_str = "".join(element)
+        attrib = self.get_standard_attributes(element)
         children = "".join(["<![CDATA[", code_str, "]]>"])
-        return self.new(docbook.screen, attrib={}, children=children)
+        return self.new(docbook.screen, attrib, children)
 
     def visit_moinpage_blockquote(self, element):
         """
@@ -233,6 +239,10 @@ class Converter:
                 <simpara>text</text>
             </blockquote>
 
+        TODO: Do we really want to add an attribution to "Unknown"?
+              The <attribution> is optional in DocBook 5.1.
+              https://tdg.docbook.org/tdg/5.1/blockquote.html
+
         Expand::
 
         <blockquote source="author">text</blockquote>
@@ -246,12 +256,13 @@ class Converter:
         """
         author = element.get(moin_page("source"))
         if not author:
-            # TODO: Internationalization
+            # TODO: Internationalization (or just leave out)
             author = "Unknown"
         attribution = self.new(docbook("attribution"), attrib={}, children=[author])
         children = self.do_children(element)
         para = self.new(docbook("simpara"), attrib={}, children=children)
-        return self.new(docbook("blockquote"), attrib={}, children=[attribution, para])
+        attrib = self.get_standard_attributes(element)
+        return self.new(docbook("blockquote"), attrib, children=[attribution, para])
 
     def visit_moinpage_emphasis(self, element):
         # emphasized text
@@ -358,7 +369,8 @@ class Converter:
             return
         note_class = element.get(moin_page("note-class"))
         if note_class == "footnote":  # as of 2026/05, all notes are footnotes
-            return self.new(docbook.footnote, attrib={}, children=self.do_children(element))
+            attrib = self.get_standard_attributes(element)
+            return self.new(docbook.footnote, attrib, children=self.do_children(element))
 
     def visit_moinpage_object(self, element):
         """
@@ -394,7 +406,8 @@ class Converter:
                 return
         else:
             return
-        return self.new(docbook.inlinemediaobject, attrib={}, children=[object_element])
+        object_attrib = self.get_standard_attributes(element)
+        return self.new(docbook.inlinemediaobject, attrib=object_attrib, children=[object_element])
 
     def visit_moinpage_table(self, element):
         # TODO: Attributes conversion
@@ -404,9 +417,9 @@ class Converter:
             title = f"Table {self.table_counter}"
         self.table_counter += 1
         caption = ET.Element(docbook("caption"), attrib={}, children=[title])
-        children = [caption]
-        children.extend(self.do_children(element))
-        return self.new(docbook.table, attrib={}, children=children)
+        attrib = self.get_standard_attributes(element)
+        children = [caption, *self.do_children(element)]
+        return self.new(docbook.table, attrib, children)
 
     def visit_moinpage_table_body(self, element):
         # TODO: Attributes conversion
@@ -481,15 +494,20 @@ class Converter:
         If we have a title attribute for p, we return a para,
         with a <title> child.
         Otherwise we return a <simpara>.
+
+        TODO: select the correct element type, the correct representation of a title or tooltip!
+              * `html:title` == "tooltip" != <db:title>  https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute
+              * paragraph with title requires <formalpara> (<para> does not allow <title> as child),
+              * <para> allows "block-level"/"body" elements as children, <simpara> only inline children.
         """
         title_attr = element.get(html("title"))
         if title_attr:
-            print(title_attr)
+            attrib = self.get_standard_attributes(element)
             children = []
             title_elem = self.new(docbook("title"), attrib={}, children=[title_attr])
             children.append(title_elem)
             children.extend(self.do_children(element))
-            return self.new(docbook.para, attrib={}, children=children)
+            return self.new(docbook.para, attrib, children)
         else:
             return self.new_copy(docbook.simpara, element, attrib={})
 


### PR DESCRIPTION
Revert changes to `docbook_out.py` that slipped into commit [MediaWiki In: footnote fixes.](https://github.com/moinwiki/moin/compare/5d001cd966f7e9ee59467730167cefd68255985f).

In both, `docbook_in.py` and `docbook_out.py`:

Change `Converter.get_standard_attributes()` to return the dict of
attributes deemed to be "standard" instead of saving it in an instance variable.
    
Remove the call to `get_standard_attributes()` from the "dispatcher method"
`Converter.visit()`.

Call `get_standard_attributes()` in `new_copy()` and the more specific
`visit_...()` methods and pass the result to `new()`.

Adapt tests.

Add TODO comments for issues with the code that came to light while checking
for the right places to change...
    
Closes #2279