### PR TITLE
Fix DocBook serialization in `frontend.views`.

### DIFF
--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -117,8 +117,6 @@ from moin.utils.mime import Type, type_moin_document
 from moin.utils.mimetype import MimeType
 from moin.utils.names import CompositeName, gen_fqnames, split_fqname
 from moin.utils.tree import html, docbook, xlink, xml
-import moin.utils.mimetype as mime_type
-from moin.utils.tree import html, docbook
 
 if TYPE_CHECKING:
     from werkzeug.wrappers import Response as ResponseBase

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -115,7 +115,7 @@ from moin.utils.interwiki import url_for_item
 from moin.utils.markup import safe_markup
 from moin.utils.mime import Type, type_moin_document
 from moin.utils.names import CompositeName, gen_fqnames, split_fqname
-from moin.utils.tree import html, docbook
+from moin.utils.tree import html, docbook, xlink, xml
 import moin.utils.mimetype as mime_type
 
 if TYPE_CHECKING:
@@ -900,7 +900,7 @@ def convert_item(item_name):
         out = conv_serialize(out, {html.namespace: ""})
         meta[CONTENTTYPE] = "text/html;charset=utf-8"
     elif form["new_type"].value == "application/docbook+xml;charset=utf-8":
-        namespaces = {docbook.namespace: ""}
+        namespaces = {docbook.namespace: "", xlink.namespace: "xlink", xml.namespace: "xml"}
         out = conv_serialize(out, namespaces)
         meta[CONTENTTYPE] = form["new_type"].value
     else:

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -901,7 +901,7 @@ def convert_item(item_name):
         meta[CONTENTTYPE] = "text/html;charset=utf-8"
     elif form["new_type"].value == "application/docbook+xml;charset=utf-8":
         namespaces = {docbook.namespace: "", xlink.namespace: "xlink", xml.namespace: "xml"}
-        out = conv_serialize(out, namespaces)
+        out = conv_serialize(out, namespaces, "xml")
         meta[CONTENTTYPE] = form["new_type"].value
     else:
         meta[CONTENTTYPE] = form["new_type"].value


### PR DESCRIPTION
DocBook format uses the "xlink" and "xml" namespaces for some element attributes. We need to tell the "serializer" of the element tree about these additional namespaces to avoid mapping of the reserved "xml" namespace to an "arbitrary" name.

Naming the XLINK namespace "xlink" seems the right thing, too.

Thanks to Roland Rüdenauer for the tip where to apply the change.

Also apply suggestion by Roland Rüdenauer to fix the tag missmatch (missing closing `</link>` tag).

Closes #2292.
Closes #2295