### PR TITLE
Fix image conversion from docbook to markdown 

### DIFF
--- a/src/moin/converters/_tests/test_markdown_in_out.py
+++ b/src/moin/converters/_tests/test_markdown_in_out.py
@@ -230,13 +230,11 @@ class TestConverter:
         ('\n![Alt text](png "Optional title")', '\n![Alt text](png "Optional title")\n'),
         ("![Alt text](png)", "![Alt text](png)\n"),
         ('![Alt text][logo]\n[logo]: png "Optional title attribute"', '![Alt text](png "Optional title attribute")\n'),
-        # alt defined twice
         (
             "![remote image](http://static.moinmo.in/logos/moinmoin.png)",
-            '![remote image](http://static.moinmo.in/logos/moinmoin.png){: alt="remote image"}\n',
+            "![remote image](http://static.moinmo.in/logos/moinmoin.png)\n",
         ),
-        # alt defined twice
-        ("![Alt text](http://test.moinmo.in/png)", '![Alt text](http://test.moinmo.in/png){: alt="Alt text"}\n'),
+        ("![Alt text](http://test.moinmo.in/png)", "![Alt text](http://test.moinmo.in/png)\n"),
     ]
 
     @pytest.mark.parametrize("input,output", data)

--- a/src/moin/converters/markdown_out.py
+++ b/src/moin/converters/markdown_out.py
@@ -81,7 +81,7 @@ class Converter(ConverterBase):
     Convert application/x.moin.document to Markdown markup.
     """
 
-    namespaces = {moin_page.namespace: "moinpage", xinclude: "xinclude"}
+    namespaces = {moin_page.namespace: "moinpage", xinclude.namespace: "xinclude", xlink.namespace: "xlink"}
 
     # elements with identical tagname in Moinpage and Markdown and no special handling
     simple_inline_tags = {"del", "ins", "kbd", "s", "samp", "sub", "sup"}
@@ -186,6 +186,7 @@ class Converter(ConverterBase):
                 "span",
                 "table",
                 "a",
+                "object",
             ):
                 attrib = self.attribute_list(elem)
                 if attrib:
@@ -366,7 +367,7 @@ class Converter(ConverterBase):
 
         Transcluded objects are expanded in output because Markdown does not support transclusions.
         """
-        href = elem.get(xlink.href, elem.get(xinclude.href, ""))
+        href = elem.get(xinclude.href, elem.get(xlink.href, ""))
         if isinstance(href, Iri):
             href = str(href)
             href = urllib.parse.unquote(href)

--- a/src/moin/items/content.py
+++ b/src/moin/items/content.py
@@ -93,7 +93,7 @@ from moin.utils.mime import Type, type_moin_document
 from moin.utils.mimetype import MimeType
 from moin.utils.registry import RegistryBase
 from moin.utils.send_file import send_file
-from moin.utils.tree import moin_page, html, xlink, docbook
+from moin.utils.tree import moin_page, html, xinclude, xlink, docbook
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -371,7 +371,11 @@ class Content:
 
     def render_data_xml(self):
         doc = self.internal_representation()
-        return conv_serialize(doc, {moin_page.namespace: "", xlink.namespace: "xlink", html.namespace: "html"}, "xml")
+        return conv_serialize(
+            doc,
+            {moin_page.namespace: "", xinclude.namespace: "xinclude", xlink.namespace: "xlink", html.namespace: "html"},
+            "xml",
+        )
 
     def render_data_highlight(self):
         # override this in child classes


### PR DESCRIPTION
related to #1298

**Behavior with current master:**

Docbook markup

```
<article xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink'>

<mediaobject>
<imageobject>
  <imagedata format="png" fileref="help-common/logo.png"/>
</imageobject>
</mediaobject>

<mediaobject>
  <audioobject>
    <audiodata fileref="help-common/audio.mp3"/>
  </audioobject>
</mediaobject>

</article>

```

DOM tree generated with +dom view

```
<body>
<div html:class="db-article">
<div html:class="db-mediaobject">
<ns2:include type="image/png" html:alt="help-common/logo.png" ns2:href="wiki.local:help-common/logo.png"/>
</div>
<div html:class="db-mediaobject">
<ns2:include type="audio/" html:alt="help-common/audio.mp3" ns2:href="wiki.local:help-common/audio.mp3"/>
</div>
</div>
</body>

```

converted to markdown

```
![logo.png](logo.png){: alt="help-common/logo.png" type="image/png"}{: page-href="wiki:///help-common/logo.png" lang="en" dir="ltr" data-href="/help-common/logo.png" class="moin-transclusion"}

![Your Browser does not support HTML5 audio/video element.](audio.mp3){: type="audio/mpeg" alt="help-common/audio.mp3"}{: page-href="wiki:///help-common/audio.mp3" lang="en" dir="ltr" data-href="/help-common/audio.mp3" class="moin-transclusion"}

```

DOM

```
<body>
<p>
<ns1:include html:alt="help-common/logo.png" ns1:href="wiki.local:logo.png"/>
}{: page-href="wiki:///help-common/logo.png" lang="en" dir="ltr" data-href="/help-common/logo.png" class="moin-transclusion"
</p>
<p>
<ns1:include html:alt="help-common/audio.mp3" ns1:href="wiki.local:audio.mp3"/>
}{: page-href="wiki:///help-common/audio.mp3" lang="en" dir="ltr" data-href="/help-common/audio.mp3" class="moin-transclusion"
</p>
</body>

```

------

**New behavior**

DOM for docbook

```
<body>
<div html:class="db-article">
<div html:class="db-mediaobject">
<xinclude:include type="image/png" html:alt="help-common/logo.png" xinclude:href="wiki.local:help-common/logo.png"/>
</div>
<div html:class="db-mediaobject">
<xinclude:include type="audio/" html:alt="help-common/audio.mp3" xinclude:href="wiki.local:help-common/audio.mp3"/>
</div>
</div>
</body>

```
after conversion

```
![logo.png](help-common/logo.png){: page-href="wiki:///help-common/logo.png" lang="en" dir="ltr" data-href="/help-common/logo.png" class="moin-transclusion"}

![Your Browser does not support HTML5 audio/video element.](audio.mp3){: page-href="wiki:///help-common/audio.mp3" lang="en" dir="ltr" data-href="/help-common/audio.mp3" class="moin-transclusion"}

```

DOM

```
body>
<p>
<xinclude:include html:alt="logo.png" xinclude:href="wiki.local:help-common/logo.png"/>
</p>
<p>
<xinclude:include html:alt="Your Browser does not support HTML5 audio/video element." xinclude:href="wiki.local:audio.mp3"/>
</p>
</body>

```
