### PR TITLE
DocBook-Out: Support "html-tag" attribute.

### DIFF
--- a/src/moin/converters/_tests/test_docbook_out.py
+++ b/src/moin/converters/_tests/test_docbook_out.py
@@ -283,6 +283,26 @@ class TestConverter(Base):
             # <article><simpara>a <citetitle>Title of Cited Work</citetitle></simpara></article>
             '/article/simpara/citetitle[text()="Title of Cited Work"]',
         ),
+        (  # <emphasis page:html-tag="dfn"> --> <firstterm>
+            '<page><body><p>A <emphasis page:html-tag="dfn">mopple</emphasis> is …</p></body></page>',
+            # <article><simpara>A <firstterm>mopple</firstterm> is …</simpara></article>
+            '/article/simpara/firstterm[text()="mopple"]',
+        ),
+        (  # <emphasis page:html-tag="i"> --> <foreignphrase>
+            '<page><body><p>They reached a <emphasis page:html-tag="i">cul de sac</emphasis>.</p></body></page>',
+            # <article><simpara>They reached a <foreignphrase>cul de sac</foreignphrase>.</simpara></article>
+            '/article/simpara/foreignphrase[text()="cul de sac"]',
+        ),
+        (  # <emphasis page:html-tag="var"> --> <varname>
+            '<page><body><p><emphasis page:html-tag="var">x</emphasis> = 3</p></body></page>',
+            # <article><simpara><varname>x</varname> = 3</simpara></article>
+            '/article/simpara/varname[text()="x"]',
+        ),
+        (  # <span page:html-tag="abbr"> --> <abbrev>
+            '<page><body><p><span page:html-tag="abbr">DOM</span> stands for …</p></body></page>',
+            # <article><simpara><abbrev>DOM</abbrev> stands for …</simpara></article>
+            '/article/simpara/abbrev[text()="DOM"]',
+        ),
     ]
 
     @pytest.mark.parametrize("input,xpath", data)

--- a/src/moin/converters/docbook_out.py
+++ b/src/moin/converters/docbook_out.py
@@ -55,6 +55,19 @@ class Converter(ConverterBase):
         "sup": docbook.superscript,
     }
 
+    # HTML tags that do not have equivalents in the Moinpage DOM tree are
+    # stored in the html-tag attribute, e.g. <emphasis html-tag="cite">
+    html_tags = {
+        "abbr": docbook.abbrev,
+        # "address": ??? # contact info != docbook.address == postal address
+        "cite": docbook.citetitle,
+        "dfn": docbook.firstterm,
+        "i": docbook.foreignphrase,
+        # "mark": ???  # marked or highlighted for reference purposes
+        # "small": ???  # side comment (small print)
+        "var": docbook.varname,
+    }
+
     @classmethod
     def _factory(cls, input: Type, output: Type, **kwargs: Any) -> Self:
         return cls(**kwargs)
@@ -277,9 +290,9 @@ class Converter(ConverterBase):
         return self.do_children(element)
 
     def visit_moinpage_emphasis(self, element):
-        # emphasized text
-        if element.attrib.get(moin_page("html-tag")) == "cite":
-            return self.new_copy(docbook.citetitle, element, attrib={})
+        # emphasized text, typically styled italic
+        if element.get(moin_page.html_tag) in self.html_tags:
+            return self.new_copy(self.html_tags[element.get(moin_page.html_tag)], element, attrib={})
         return self.new_copy(docbook.emphasis, element, attrib={})
 
     def visit_moinpage_h(self, element):
@@ -516,7 +529,8 @@ class Converter(ConverterBase):
         "Moinpage" tree to define specific element (sub)types or formatting.
         So it may stand for different inline elements (cf. html_in/html_out).
         """
-        # TODO: Add support for special "html:class" attribute values.
+        if element.get(moin_page.html_tag) in self.html_tags:
+            return self.new_copy(self.html_tags[element.get(moin_page.html_tag)], element, attrib={})
         if cls := element.get(html.class_):
             if cls.startswith("db-"):
                 tagname = cls.removeprefix("db-")


### PR DESCRIPTION
HTML tags that do not have equivalents in the Moinpage DOM tree, are stored in the html-tag attribute, e.g. `<emphasis html-tag="cite">`.

Export the corresponding DocBook element for the (5 of 8) "html-tag" values defined in `html_in.py` that do have a DocBook analogue.