### PR TITLE
docs: move RTD version selector to sidebar, hide flyout (fixes #2195)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,7 +122,7 @@ html_style = "custom.css"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {"flyout_display": "hidden", "version_selector": True, "language_selector": False}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []


### PR DESCRIPTION
Changes in docs/conf.py:
- flyout_display: "hidden" — hides the bottom-right RTD flyout
- version_selector: True — renders version selector in sidebar
- language_selector: False — moin has no multi-language RTD builds