### PR TITLE
test: add unit tests for RandomItem and RandomQuote macros

### DIFF
--- a/src/moin/macros/_tests/test_RandomItem.py
+++ b/src/moin/macros/_tests/test_RandomItem.py
@@ -1,0 +1,63 @@
+# Copyright: 2022 MoinMoin
+# License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
+
+"""
+MoinMoin - tests for moin.macros.RandomItem.
+"""
+
+import pytest
+
+from moin.macros.RandomItem import Macro
+from moin.utils.tree import xlink
+from moin._tests import update_item
+from moin.constants.keys import CONTENTTYPE, ITEMTYPE, REV_NUMBER
+
+meta = {CONTENTTYPE: "text/x.moin.wiki;charset=utf-8", ITEMTYPE: "default", REV_NUMBER: 1}
+
+
+@pytest.mark.usefixtures("_req_ctx")
+class TestRandomItem:
+
+    def test_no_arguments(self):
+        macro_object = Macro()
+        argument = []
+        res = macro_object.macro("content", argument, "page_url", "alternative")
+        assert res is None
+
+    def test_one_argument(self):
+        macro_object = Macro()
+        argument = ["1"]
+        res = macro_object.macro("content", argument, "page_url", "alternative")
+        assert res is None
+
+    def test_with_one_updated(self):
+        update_item("item1", meta, data="Hello world")
+
+        macro_object = Macro()
+        argument = ["1"]
+        res = macro_object.macro("content", argument, "page_url", "alternative")
+        assert len(res) == 1
+        assert res[0].attrib[xlink.href] == "wiki:///item1"
+
+    def test_with_update_items(self):
+        update_item("item1", meta, data="Hello world")
+        update_item("item2", meta, data="Moin Moin Wiki")
+        update_item("item3", meta, data="Test file")
+
+        macro_object = Macro()
+        argument = ["2"]
+        count = 2
+        res = macro_object.macro("content", argument, "page_url", "alternative")
+        assert len(res) == (2 * count) - 1
+        assert res[0].text in ["item1", "item2", "item3"]
+
+    def test_multiple_items(self):
+        macro_object = Macro()
+        argument = ["10"]
+        count = 5
+
+        for i in range(count):
+            update_item(f"item{i}", meta, data=f"Moin Moin Wiki {i}")
+
+        res = macro_object.macro("content", argument, "page_url", "alternative")
+        assert len(res) == (2 * count) - 1

--- a/src/moin/macros/_tests/test_RandomQuote.py
+++ b/src/moin/macros/_tests/test_RandomQuote.py
@@ -1,0 +1,79 @@
+# Copyright: 2022 MoinMoin
+# License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
+
+"""
+MoinMoin - tests for moin.macros.RandomQuote.
+"""
+
+import pytest
+from moin.macros.RandomQuote import Macro
+from moin._tests import update_item
+from moin.utils.iri import Iri
+from moin.constants.keys import CONTENTTYPE, ITEMTYPE, REV_NUMBER
+from moin.utils.tree import html
+
+meta = {CONTENTTYPE: "text/x.moin.wiki;charset=utf-8", ITEMTYPE: "default", REV_NUMBER: 1}
+page_url = Iri(scheme="wiki", authority="", path="/TestPage")
+
+
+@pytest.mark.usefixtures("_req_ctx")
+class TestRandomQuote:
+
+    def test_default_item_not_exists(self):
+        macro_object = Macro()
+        argument = []
+        res = macro_object.macro("content", argument, page_url, "alternative")
+        assert res.tag == html.div
+
+    def test_default_item_exists(self):
+        macro_object = Macro()
+        argument = []
+        update_item("FortuneCookies", meta, data="* First quote\n* Second quote")
+        res = macro_object.macro("content", argument, page_url, "alternative")
+        assert res is not None
+        assert res.tag != html.div
+
+    def test_non_exits_item(self):
+        macro_object = Macro()
+        argument = ["Random page"]
+        update_item("FortuneCookies", meta, data="* First quote\n* Second quote")
+        update_item("item1", meta, data="* First quote\n* Second quote")
+        res = macro_object.macro("content", argument, page_url, "alternative")
+        assert res.tag == html.div
+
+    def test_no_quotes_in_item(self):
+        macro_object = Macro()
+        argument = []
+        update_item("FortuneCookies", meta, data="First quote\n Second quote")
+        res = macro_object.macro("content", argument, page_url, "alternative")
+        assert res.tag == html.div
+
+    def test_single_quote_in_item(self):
+        macro_object = Macro()
+        argument = ["item1"]
+        update_item("item1", meta, data="First quote\n* Second quote")
+        res = macro_object.macro("content", argument, page_url, "alternative")
+        assert res.tag != html.div
+        assert res is not None
+
+    def test_item_name_with_surrounding_quotes(self):
+        macro_object = Macro()
+        argument = ["'item1'"]
+        update_item("item1", meta, data="* First quote\n* Second quote")
+        res = macro_object.macro("content", argument, page_url, "alternative")
+        assert res.tag != html.div
+        assert res is not None
+
+    def test_invalid_item_name(self):
+        macro_object = Macro()
+        argument = ["/InvalidItem"]
+        res = macro_object.macro("content", argument, page_url, "alternative")
+        assert res.tag == html.div
+
+    def test_mixed_quotes_in_item(self):
+        macro_object = Macro()
+        argument = ["item1"]
+        update_item("item1", meta, data="First quote\n* Second quote\n Third quote")
+        res = macro_object.macro("content", argument, page_url, "alternative")
+        assert res.tag != html.div
+        assert res is not None


### PR DESCRIPTION
This PR adds dedicated unit tests for `src/moin/macros/RandomItem.py`, `src/moin/macros/RandomQuote.py`.

test_RandomQuote.py:

Validates the default behavior when no argument is given (falling back to the FortuneCookies wiki item).
Tests proper handling of non-existent items and items with missing read access.
Ensures accurate parsing of items containing no valid quotes, a single quote, or a mix of valid quotes and ignored text.
Confirms it successfully strips surrounding quotes from the input argument 
Verifies graceful failure when given an invalid item name.

test_RandomItem.py:

Tests the macro behavior when called with no arguments or when no wiki items exist to be fetched.
Verifies that requesting a specific number of random items 
Ensures that if the requested quantity exceeds the total number of available itemS, the macro handles the upper bound safely without crashing.