### PR TITLE
Fix issue: class `_Stack` has no member `last_lineno`

### DIFF
--- a/src/moin/converters/_util.py
+++ b/src/moin/converters/_util.py
@@ -124,7 +124,7 @@ class _Stack:
         if bottom:
             self._list.append(self.Item(bottom))
         self.iter_content = iter_content
-        self.last_lineno_attr = 0
+        self.last_lineno = 0
         self._add_lineno = add_lineno
 
     def __len__(self):


### PR DESCRIPTION
This fixes an issue introduced in commit 07eb655 (part of pull request #2306).