### PR TITLE
fix: preserve transcluded media paths in Markdown

### DIFF
--- a/src/moin/converters/_tests/test_markdown_out.py
+++ b/src/moin/converters/_tests/test_markdown_out.py
@@ -217,6 +217,12 @@ class TestConverter(Base):
             'html:alt="Video" html:class="moin-transclusion"></page:object>',
             "![Video](help-common/video.mp4)",
         ),
+        (
+            '<page:object xinclude:href="wiki.local:audio.mp3" html:data-href="/help-common/audio.mp3" '
+            'html:alt="help-common/audio.mp3" html:class="moin-transclusion">'
+            "Your Browser does not support HTML5 audio/video element.</page:object>",
+            "![audio.mp3](help-common/audio.mp3)",
+        ),
     ]
 
     @pytest.mark.parametrize("input,output", data)

--- a/src/moin/converters/_tests/test_markdown_out.py
+++ b/src/moin/converters/_tests/test_markdown_out.py
@@ -207,6 +207,16 @@ class TestConverter(Base):
             '<page:object xlink:href="photo.jpg" html:alt="A photo"><page:span>ignored</page:span></page:object>',
             "![A photo](photo.jpg)",
         ),
+        (
+            '<page:object xlink:href="/+get/+abcdef/audio.mp3" html:data-href="/help-common/audio.mp3" '
+            'html:alt="Audio" html:class="moin-transclusion"></page:object>',
+            "![Audio](help-common/audio.mp3)",
+        ),
+        (
+            '<page:object xlink:href="/+get/+abcdef/video.mp4" html:data-href="/help-common/video.mp4?do=show" '
+            'html:alt="Video" html:class="moin-transclusion"></page:object>',
+            "![Video](help-common/video.mp4)",
+        ),
     ]
 
     @pytest.mark.parametrize("input,output", data)

--- a/src/moin/converters/_tests/test_markdown_out.py
+++ b/src/moin/converters/_tests/test_markdown_out.py
@@ -223,6 +223,11 @@ class TestConverter(Base):
             "Your Browser does not support HTML5 audio/video element.</page:object>",
             "![audio.mp3](help-common/audio.mp3)",
         ),
+        (
+            '<page:object xlink:href="http://moinmo.in" html:data-href="http://moinmo.in" '
+            'html:class="moin-transclusion">http://moinmo.in</page:object>',
+            "![http://moinmo.in](http://moinmo.in)",
+        ),
     ]
 
     @pytest.mark.parametrize("input,output", data)

--- a/src/moin/converters/markdown_out.py
+++ b/src/moin/converters/markdown_out.py
@@ -378,8 +378,8 @@ class Converter(ConverterBase):
         Transcluded objects are expanded in output because Markdown does not support transclusions.
         """
         data_href = elem.get(html.data_href)
-        use_data_href = elem.get(xinclude.href) is None and data_href is not None
-        href = elem.get(xinclude.href, data_href if use_data_href else elem.get(xlink.href, ""))
+        use_data_href = data_href is not None
+        href = data_href if use_data_href else elem.get(xinclude.href, elem.get(xlink.href, ""))
         href_is_iri = isinstance(href, Iri)
         if href_is_iri:
             href = urllib.parse.unquote(str(href))
@@ -392,7 +392,9 @@ class Converter(ConverterBase):
         href = href.split("wiki.local:")[-1]
         if len(elem) and isinstance(elem[0], str):
             # alt text for objects is enclosed within <object...>...</object>
-            alt = elem[0]
+            # Expanded audio/video objects contain browser fallback text rather
+            # than a useful Markdown label. Use the source filename instead.
+            alt = href.rsplit("/", 1)[-1] if use_data_href else elem[0]
         else:
             alt = elem.attrib.get(html.alt, "")
         title = elem.attrib.get(html.title_, "")

--- a/src/moin/converters/markdown_out.py
+++ b/src/moin/converters/markdown_out.py
@@ -377,12 +377,18 @@ class Converter(ConverterBase):
 
         Transcluded objects are expanded in output because Markdown does not support transclusions.
         """
-        href = elem.get(xinclude.href, elem.get(xlink.href, ""))
-        if isinstance(href, Iri):
-            href = str(href)
-            href = urllib.parse.unquote(href)
-            if href.startswith("/+get/+"):
-                href = href.split("/")[-1]
+        data_href = elem.get(html.data_href)
+        use_data_href = elem.get(xinclude.href) is None and data_href is not None
+        href = elem.get(xinclude.href, data_href if use_data_href else elem.get(xlink.href, ""))
+        href_is_iri = isinstance(href, Iri)
+        if href_is_iri:
+            href = urllib.parse.unquote(str(href))
+        if use_data_href:
+            # Expanded transclusions point xlink:href at a revisioned +get URL.
+            # data-href retains the source item name needed for editable Markdown.
+            href = urllib.parse.urlsplit(urllib.parse.unquote(str(href))).path.lstrip("/")
+        elif href_is_iri and href.startswith("/+get/+"):
+            href = href.split("/")[-1]
         href = href.split("wiki.local:")[-1]
         if len(elem) and isinstance(elem[0], str):
             # alt text for objects is enclosed within <object...>...</object>

--- a/src/moin/converters/markdown_out.py
+++ b/src/moin/converters/markdown_out.py
@@ -383,10 +383,15 @@ class Converter(ConverterBase):
         href_is_iri = isinstance(href, Iri)
         if href_is_iri:
             href = urllib.parse.unquote(str(href))
+        internal_data_href = False
         if use_data_href:
             # Expanded transclusions point xlink:href at a revisioned +get URL.
             # data-href retains the source item name needed for editable Markdown.
-            href = urllib.parse.urlsplit(urllib.parse.unquote(str(href))).path.lstrip("/")
+            href = urllib.parse.unquote(str(href))
+            parsed_href = urllib.parse.urlsplit(href)
+            internal_data_href = not parsed_href.scheme and not parsed_href.netloc
+            if internal_data_href:
+                href = parsed_href.path.lstrip("/")
         elif href_is_iri and href.startswith("/+get/+"):
             href = href.split("/")[-1]
         href = href.split("wiki.local:")[-1]
@@ -394,7 +399,7 @@ class Converter(ConverterBase):
             # alt text for objects is enclosed within <object...>...</object>
             # Expanded audio/video objects contain browser fallback text rather
             # than a useful Markdown label. Use the source filename instead.
-            alt = href.rsplit("/", 1)[-1] if use_data_href else elem[0]
+            alt = href.rsplit("/", 1)[-1] if internal_data_href else elem[0]
         else:
             alt = elem.attrib.get(html.alt, "")
         title = elem.attrib.get(html.title_, "")


### PR DESCRIPTION
## Summary

- I preserve the source item path when an expanded media transclusion points at a revisioned `+get` URL.
- I remove the generated `do=show` query and leading slash before writing editable Markdown.
- I added regression coverage for both audio and video transclusions.

## Testing

- `pytest -q src/moin/converters/_tests/test_markdown_out.py src/moin/converters/_tests/test_markdown_in_out.py` (141 passed)
- `pytest -q` with the virtual environment on `PATH` (2031 passed, 17 skipped, 1 xpassed)
- `ruff check src/moin/converters/markdown_out.py src/moin/converters/_tests/test_markdown_out.py`
- `black --check src/moin/converters/markdown_out.py src/moin/converters/_tests/test_markdown_out.py`
- `git diff --check upstream/master...HEAD`

Fixes #1298
