### PR TITLE
Fix template base.html

### DIFF
--- a/src/moin/templates/base.html
+++ b/src/moin/templates/base.html
@@ -52,7 +52,7 @@
 
                 {{ favicon }}
 
-                <script {{ utils.nonce() }}">
+                <script {{ utils.nonce() }}>
                     window.elixNonce = "{{ csp_nonce() }}";
                     window.svgeditNonce = "{{ csp_nonce() }}";
                 </script>


### PR DESCRIPTION
A double quote character was inadvertently left over when introducing macro utils.nonce(). It is removed now.