### PR TITLE
Fix use of macro nonce() in moin templates

### DIFF
--- a/src/moin/templates/base.html
+++ b/src/moin/templates/base.html
@@ -70,7 +70,7 @@
                     {{ stylesheets }}
                 {%- endblock %}
                 {% if css_classes %}
-                    <style {{ utils.nonce() }}">
+                    <style {{ utils.nonce() }}>
                       {% for name, definition in css_classes.items() %}
                         .{{ name }} { {{ definition }} }
                       {% endfor %}
@@ -100,12 +100,12 @@
 
         {%- block body_scripts %}
             <script src="{{ url_for('static', filename='js/jquery.min.js') }}" {{ utils.nonce() }}></script>
-            <script src="{{ url_for('static', filename='js/jquery.i18n.min.js') }}" {{ utils.nonce() }}"></script>
-            <script src="{{ url_for('frontend.template', filename='dictionary.js') }}" {{ utils.nonce() }}"></script>
-            <script src="{{ url_for('static', filename='js/jquery.autosize.min.js') }}" {{ utils.nonce() }}"></script>
-            <script src="{{ url_for('static', filename='js/jquery.tablesorter.min.js') }}" {{ utils.nonce() }}"></script>
-            <script src="{{ url_for('static', filename='js/common.js') }}" {{ utils.nonce() }}"></script>
-            <script type="module" src="{{ url_for('static', filename='js/svgeditor.js') }}" {{ utils.nonce() }}"></script>
+            <script src="{{ url_for('static', filename='js/jquery.i18n.min.js') }}" {{ utils.nonce() }}></script>
+            <script src="{{ url_for('frontend.template', filename='dictionary.js') }}" {{ utils.nonce() }}></script>
+            <script src="{{ url_for('static', filename='js/jquery.autosize.min.js') }}" {{ utils.nonce() }}></script>
+            <script src="{{ url_for('static', filename='js/jquery.tablesorter.min.js') }}" {{ utils.nonce() }}></script>
+            <script src="{{ url_for('static', filename='js/common.js') }}" {{ utils.nonce() }}></script>
+            <script type="module" src="{{ url_for('static', filename='js/svgeditor.js') }}" {{ utils.nonce() }}></script>
             {{- scripts }}
         {%- endblock %}
 

--- a/src/moin/templates/index.html
+++ b/src/moin/templates/index.html
@@ -337,7 +337,7 @@ a checkbox, an invisible link used by js for download, a link to the item
 
 {% block body_scripts %}
     {{ super() }}
-    <script src="{{ url_for('static', filename='js/index_action.js') }}" {{ utils.nonce() }}"></script>
-    <script src="{{ url_for('static', filename='js/jfu.js') }}" {{ utils.nonce() }}"></script>
+    <script src="{{ url_for('static', filename='js/index_action.js') }}" {{ utils.nonce() }}></script>
+    <script src="{{ url_for('static', filename='js/jfu.js') }}" {{ utils.nonce() }}></script>
     {{ utils.file_uploader_scripts() }}
 {% endblock %}

--- a/src/moin/templates/modify_text_html.html
+++ b/src/moin/templates/modify_text_html.html
@@ -11,8 +11,8 @@
     {% import "utils.html" as utils with context %}
 
     {% macro extra_head() %}
-        <script src="{{ url_for('static', filename='js/ckeditor5.umd.js') }}" {{ utils.nonce() }}"></script>
-        <script src="{{ url_for('static', filename='js/editor.js') }}" {{ utils.nonce() }}"></script>
+        <script src="{{ url_for('static', filename='js/ckeditor5.umd.js') }}" {{ utils.nonce() }}></script>
+        <script src="{{ url_for('static', filename='js/editor.js') }}" {{ utils.nonce() }}></script>
         <link rel="stylesheet" href="{{ url_for('static', filename='css/ckeditor5.css') }}">
         {#- prevent ckeditor css from making body font-size 12px #}
         <style>body {font-size: 1em;}</style>

--- a/src/moin/templates/search.html
+++ b/src/moin/templates/search.html
@@ -85,6 +85,6 @@
 {% endblock %}
 
 {% block body_scripts %}
-    <script src="{{ url_for('static', filename='js/jquery.min.js') }}" {{ utils.nonce() }}"></script>
-    <script src="{{ url_for('static', filename='js/search.js') }}" {{ utils.nonce() }}"></script>
+    <script src="{{ url_for('static', filename='js/jquery.min.js') }}" {{ utils.nonce() }}></script>
+    <script src="{{ url_for('static', filename='js/search.js') }}" {{ utils.nonce() }}></script>
 {% endblock %}

--- a/src/moin/templates/utils.html
+++ b/src/moin/templates/utils.html
@@ -11,8 +11,8 @@ nonce="{{ csp_nonce() }}"
 {%- endmacro %}
 
 {% macro file_uploader_scripts() %}
-    <script src="{{ url_for('static', filename='js/vendor/jquery.ui.widget.js') }}" {{ nonce() }}"></script>
-    <script src="{{ url_for('static', filename='js/jquery.fileupload.js') }}" {{ nonce() }}"></script>
+    <script src="{{ url_for('static', filename='js/vendor/jquery.ui.widget.js') }}" {{ nonce() }}></script>
+    <script src="{{ url_for('static', filename='js/jquery.fileupload.js') }}" {{ nonce() }}></script>
 {%- endmacro %}
 
 {# "item" must be passed because of flakey jinja2 context passing #}


### PR DESCRIPTION
A double quote character was inadvertently left over when introducing macro utils.nonce(). It is removed now.