### PR TITLE
Fix +convert endpoint

### DIFF
--- a/src/moin/apps/_tests/utils.py
+++ b/src/moin/apps/_tests/utils.py
@@ -46,6 +46,14 @@ def login(client: FlaskClient, username: str, password: str, next: str = "http:/
     assert client.get_cookie("session")
 
 
+def convert_item(
+    client: FlaskClient, item_name: str, data: dict[str, Any], expected_status_code: int = 302
+) -> TestResponse:
+    response = client.post(url_for("frontend.convert_item", item_name=item_name), data=data)
+    assert response.status_code == expected_status_code
+    return response
+
+
 def modify_item(
     client: FlaskClient, item_name: str, data: dict[str, Any], expected_status_code: int = 302
 ) -> TestResponse:

--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -17,7 +17,14 @@ from flask import url_for
 from werkzeug.datastructures import FileStorage
 
 from moin import current_app, flaskg, user
-from moin.apps._tests.utils import create_user, login, modify_item, make_modify_form_data, set_user_in_client_session
+from moin.apps._tests.utils import (
+    create_user,
+    login,
+    convert_item,
+    modify_item,
+    make_modify_form_data,
+    set_user_in_client_session,
+)
 from moin.apps.frontend import views
 
 if TYPE_CHECKING:
@@ -377,16 +384,23 @@ class TestFrontendNew:
     def test_modify_item_show_preview(self, client):
 
         create_user("björn", "Xiwejr622")
-
-        content = "New item content."
-
         login(client, "björn", "Xiwejr622")
-
         modify_item(
             client,
             "quokka",
-            make_modify_form_data("quokka", content=content, preview="Preview"),
+            make_modify_form_data("quokka", content="New item content.", preview="Preview"),
             expected_status_code=200,
+        )
+
+    def test_convert_item_to_markdown(self, client):
+        create_user("björn", "Xiwejr622")
+        login(client, "björn", "Xiwejr622")
+        modify_item(client, "test1", make_modify_form_data("test1", content="moin test."))
+        convert_item(
+            client,
+            "test1",
+            # form data for for template "convert.html"
+            {"new_type": "text/x-markdown;charset=utf-8", "comment": "test"},
         )
 
 

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -889,7 +889,7 @@ def convert_item(item_name):
                 # expand DOM only when converting to dissimilar item types (moin and creole are similar)
                 dom = item.content._expand_document(dom, RenderContext())
 
-        conv_out = reg.get(type_moin_document, Type(form["new_type"].value))
+        conv_out = reg.get(type_moin_document, Type(form["new_type"].value), context=RenderContext())
         out = conv_out(dom)
     except Exception:
         logger.exception("Error converting item: %s", item.fqname)


### PR DESCRIPTION
Conversion to markdown failed because of a missing parameter when creating the markdown converter.