### PR TITLE
rst_in: ensure <figcaption> is the last child of <figure> ...

### DIFF
--- a/src/moin/converters/_tests/test_rst_in.py
+++ b/src/moin/converters/_tests/test_rst_in.py
@@ -515,6 +515,21 @@ text""",
         self.do(input, output)
 
     data = [
+        (
+            ".. image:: png\n   :alt: alternate text png\n   :align: center\n   :height: 100\n   :width: 200\n",
+            '<xinclude:include html:alt="alternate text png" html:class="center" html:height="100" html:width="200" xinclude:href="wiki.local:png" />',
+        ),
+        (
+            ".. figure:: png\n   :alt: alternate text png\n   :height: 100\n   :width: 200\n\n   Moin Logo\n\n   This logo replaced the MoinMoin Man\n   logo long ago.\n",
+            '<figure><xinclude:include html:alt="alternate text png" html:height="100" html:width="200" xinclude:href="wiki.local:png" /><p>This logo replaced the MoinMoin Man\nlogo long ago.</p><figcaption>Moin Logo</figcaption></figure>',
+        ),
+    ]
+
+    @pytest.mark.parametrize("input,output", data)
+    def test_object(self, input, output):
+        self.do(input, output)
+
+    data = [
         # admonitions (hint, info, warning, error, ...)
         (
             '.. note::\n   :name: note-id\n\n   An admonition of type "note"',

--- a/src/moin/converters/rst_in.py
+++ b/src/moin/converters/rst_in.py
@@ -416,6 +416,11 @@ class NodeVisitor:
         self.open_moin_page_node(moin_page.figure(), node)
 
     def depart_figure(self, node):
+        # HTML5 requires <figcaption> to be the first or last child of <figure>
+        figcaption = self.current_node.find(moin_page.figcaption)
+        if figcaption is not None:
+            self.current_node.remove(figcaption)
+            self.current_node.append(figcaption)
         self.close_moin_page_node()
 
     def visit_footer(self, node):

--- a/src/moin/converters/rst_out.py
+++ b/src/moin/converters/rst_out.py
@@ -457,14 +457,20 @@ class Converter(ConverterBase):
             * a caption, figures have captions, images do not
             * optional text (may be several)
         """
-        ret = self.open_children(elem).replace("image", "figure")
-        ret = ret.split("\n")
+        figcaption = elem.find(moin_page.figcaption)
+        if figcaption is not None:
+            # reST expects the caption before the optional text
+            elem.remove(figcaption)
+            elem.insert(1, figcaption)
+
+        rst = self.open_children(elem).replace("image", "figure")
+        rst = rst.split("\n")
         lines = []
-        for r in ret:
-            if r.startswith(("   ", "..")) or not r:
-                lines.append(r)
+        for line in rst:
+            if line.startswith(("   ", "..")) or not line:
+                lines.append(line)
             else:
-                lines.append("   " + r)
+                lines.append("   " + line)
         return "\n".join(lines)
 
     def open_moinpage_figcaption(self, elem):


### PR DESCRIPTION
... rst_out: set caption as first child of figure

Tested with following snippet from `help-en/rst`

```
.. figure:: help-common/logo.svg
   :height: 50
   :alt: [white M in blue circle]

   Moin Logo

   The image URI does not work in the external documentation.
```

Before the HTML5 validation failed with 

```
Error: Element p not allowed as child of element figure in this context. (Suppressing
further errors from this subtree.)
From line 318, column 309; to line 318, column 311
igcaption><p>The fi
```
