### PR TITLE
Fix KeyError crash in _build_contenttype_query on invalid group value

### DIFF
--- a/src/moin/apps/feed/_tests/test_feed.py
+++ b/src/moin/apps/feed/_tests/test_feed.py
@@ -48,3 +48,39 @@ def test_global_atom_with_an_item(client):
     assert rv.headers["Content-Type"] == "application/atom+xml"
     assert rv.text.startswith("<?xml")
     assert "checking if the cache invalidation works" in rv.text
+
+
+def test_global_atom_with_a_renamed_item(client):
+    """
+    Regression test: the feed history loop looks up each historical
+    revision by the name it had at that point in time. If the item has
+    since been renamed, a name-based lookup for an old revision no longer
+    resolves (the current item doesn't answer to that name any more), and
+    used to crash rendering that entry instead of showing it.
+    """
+
+    create_user("moin", "Xiwejr622")
+
+    login(client, "moin", "Xiwejr622")
+
+    old_name = "OldName"
+    new_name = "NewName"
+
+    # two revisions before the rename: the second one has a parent revid,
+    # which is what actually reaches the crashing diff-render code path
+    # below (a revision with no parent takes a different, unaffected
+    # rendering path).
+    response = modify_item(client, old_name, make_modify_form_data(old_name, comment="first revision"))
+    assert response.status_code == 302
+    response = modify_item(client, old_name, make_modify_form_data(old_name, comment="before rename"))
+    assert response.status_code == 302
+
+    response = client.post(
+        url_for("frontend.rename_item", item_name=old_name), data={"target": new_name, "comment": "renamed"}
+    )
+    assert response.status_code == 302
+
+    rv = client.get(url_for("feed.atom"))
+    assert rv.status_code == 200
+    assert rv.headers["Content-Type"] == "application/atom+xml"
+    assert "MoinMoin feels unhappy" not in rv.text

--- a/src/moin/apps/feed/views.py
+++ b/src/moin/apps/feed/views.py
@@ -19,9 +19,20 @@ from whoosh.query import Term, And, Every
 
 from moin import current_app, flaskg, log
 from moin.i18n import _
-from moin.constants.keys import NAME, NAME_EXACT, NAMESPACE, COMMENT, MTIME, REVID, ALL_REVS, PARENTID, LATEST_REVS
+from moin.constants.keys import (
+    NAME,
+    NAME_EXACT,
+    NAMESPACE,
+    COMMENT,
+    MTIME,
+    REVID,
+    ALL_REVS,
+    PARENTID,
+    LATEST_REVS,
+    ITEMID,
+)
 from moin.themes import get_editor_info, render_template
-from moin.items import Item
+from moin.items import Item, NonExistentContent
 from moin.utils.crypto import cache_key
 from moin.utils.interwiki import url_for_item
 from moin.utils.markup import safe_markup
@@ -85,7 +96,19 @@ def atom(item_name: str) -> Response:
             previous_revid = rev.meta.get(PARENTID)
             this_rev = rev
             try:
-                hl_item = Item.create(name, rev_id=this_revid)
+                # Look up by itemid, not by this revision's historical name:
+                # if the item has since been renamed, a name-based lookup
+                # for an old revision fails (the current item no longer
+                # answers to that name) and Item.create silently falls back
+                # to a DummyItem/NonExistentContent. itemid is stable across
+                # renames.
+                hl_item = Item.create(f"@itemid/{rev.meta[ITEMID]}", rev_id=this_revid)
+                if isinstance(hl_item.content, NonExistentContent):
+                    # Genuinely gone (not just renamed) -- the index still
+                    # has this revision, but storage does not. Raise a clear
+                    # error rather than let an AttributeError from deep in
+                    # the call below stand in for the real cause.
+                    raise LookupError(f"revision {this_revid} of {name!r} is indexed but missing from storage")
                 if previous_revid is not None:
                     # HTML diff for subsequent revisions
                     previous_rev = item[previous_revid]

--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -473,3 +473,28 @@ class TestUsersettings:
         )
         form = FormClass.from_flat(request_form)
         return form
+
+
+def test_cspreport_get_does_not_crash(client):
+    """
+    Regression test: before_wiki()/teardown_wiki() skip environment setup
+    for /+cspreport/log unconditionally, since only the dedicated
+    cspreport() view is meant to handle that path. Previously that view
+    was registered POST-only, so the path itself wasn't special to
+    Werkzeug's routing -- a GET fell through to the generic show_item
+    catch-all instead, which does need flaskg.storage, and crashed with
+    AttributeError: storage since setup was skipped for it too.
+    cspreport() is now registered for all methods and rejects non-POST
+    itself with 405, so it -- not show_item -- is always the one handling
+    this path, regardless of method.
+    """
+    rv = client.get(url_for("frontend.cspreport"))
+    assert rv.status_code == 405
+
+    # the real (POST) CSP report path must still work
+    rv = client.post(
+        url_for("frontend.cspreport"),
+        data=json.dumps({"csp-report": {"document-uri": "http://localhost/"}}),
+        content_type="application/csp-report",
+    )
+    assert rv.status_code == 204

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -306,11 +306,21 @@ def lookup():
     return Response(html, status)
 
 
-@frontend.route("/+cspreport/log", methods=["POST"])
+@frontend.route("/+cspreport/log", methods=["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"])
 def cspreport():
     """
     content security policy report receiver
+
+    Registered for all methods, not just POST, so this exact rule -- not
+    the generic show_item catch-all -- is the one Werkzeug matches for
+    /+cspreport/log regardless of method. before_wiki()/teardown_wiki()
+    skip environment setup for this path unconditionally, so falling
+    through to show_item for a non-POST request would crash on missing
+    setup (e.g. flaskg.storage) instead of cleanly rejecting the request.
     """
+    if request.method != "POST":
+        abort(405)
+
     if request.content_type not in ["application/csp-report"]:
         abort(400, f"Invalid content type '{request.content_type}' for CSP report.")
 

--- a/src/moin/items/__init__.py
+++ b/src/moin/items/__init__.py
@@ -647,6 +647,9 @@ def _build_contenttype_query(groups: list[str]) -> Query:
     """
     queries = []
     for g in groups:
+        # skip invalid group values (e.g. None) instead of raising KeyError
+        if g not in content_registry.groups:
+            continue
         for e in content_registry.groups[g]:
             ct_unicode = str(e.content_type)
             queries.append(Term(CONTENTTYPE, ct_unicode))

--- a/src/moin/items/__init__.py
+++ b/src/moin/items/__init__.py
@@ -204,14 +204,21 @@ def wiki_matches(fq_name, fq_names, start_re=None, end_re=None):
     match = start_re.match(item_name)
     if match:
         start = match.group(1)
-    else:
+    elif words:
         start = words[0]
+    else:
+        # item_name is empty or whitespace-only (e.g. a namespace root with
+        # no item name, such as /+similar_names/help-common) -- nothing to
+        # extract a first word from.
+        start = item_name
 
     match = end_re.search(item_name)
     if match:
         end = match.group(1)
-    else:
+    elif words:
         end = words[-1]
+    else:
+        end = item_name
 
     matches = {}
     subitem = item_name + "/"

--- a/src/moin/items/_tests/test_Item.py
+++ b/src/moin/items/_tests/test_Item.py
@@ -9,7 +9,7 @@ MoinMoin - Tests for moin.items
 import pytest
 
 from moin._tests import become_trusted, update_item
-from moin.items import Item, NonExistent, IndexEntry, MixedIndexEntry
+from moin.items import Item, NonExistent, IndexEntry, MixedIndexEntry, _build_contenttype_query
 from moin.utils.names import CompositeName
 from moin.constants.keys import (
     ITEMTYPE,
@@ -542,6 +542,18 @@ class TestItem:
         item.delete("Moving item to trash.")
         item = Item.create(new_name)
         assert item.meta[TRASH]
+
+
+def test_build_contenttype_query_skips_unknown_group():
+    """
+    A selected_groups value that isn't a real content_registry key (e.g. None,
+    from a form submission with no contenttype selected) must be skipped
+    rather than raising a KeyError. Regression test for a crash reachable via
+    a plain POST to /+index/<item>/ with a blank/invalid contenttype field.
+    """
+    # should not raise, even though None and an unknown name are not real groups
+    query = _build_contenttype_query([None, "not-a-real-group"])
+    assert query is not None
 
 
 coverage_modules = ["moin.items"]

--- a/src/moin/items/_tests/test_Item.py
+++ b/src/moin/items/_tests/test_Item.py
@@ -9,7 +9,7 @@ MoinMoin - Tests for moin.items
 import pytest
 
 from moin._tests import become_trusted, update_item
-from moin.items import Item, NonExistent, IndexEntry, MixedIndexEntry, _build_contenttype_query
+from moin.items import Item, NonExistent, IndexEntry, MixedIndexEntry, _build_contenttype_query, wiki_matches
 from moin.utils.names import CompositeName
 from moin.constants.keys import (
     ITEMTYPE,
@@ -554,6 +554,21 @@ def test_build_contenttype_query_skips_unknown_group():
     # should not raise, even though None and an unknown name are not real groups
     query = _build_contenttype_query([None, "not-a-real-group"])
     assert query is not None
+
+
+def test_wiki_matches_empty_item_name():
+    """
+    An empty item_name (e.g. a namespace root with no item name of its
+    own, such as /+similar_names/help-common) used to crash with
+    IndexError: list index out of range -- wiki_matches() fell back to
+    words[0]/words[-1] without checking the word list from splitting the
+    (empty) item name was actually non-empty.
+    """
+    fq_name = CompositeName("", NAME_EXACT, "")
+    start, end, matches = wiki_matches(fq_name, set())
+    assert start == ""
+    assert end == ""
+    assert matches == {}
 
 
 coverage_modules = ["moin.items"]


### PR DESCRIPTION
A selected_groups entry that isn't a real content_registry key (e.g. None, produced by a form submission with no contenttype selected) caused an unhandled KeyError, returning a 500 for any request that triggered it -- reachable via a plain POST to /+index/<item>/ with a blank or malformed contenttype field.

Skip values that aren't real content_registry keys instead of indexing into the dict directly. Adds a regression test.