### PR TITLE
Fix atom feed crash on history entries for renamed items

### DIFF
--- a/src/moin/apps/feed/_tests/test_feed.py
+++ b/src/moin/apps/feed/_tests/test_feed.py
@@ -48,3 +48,39 @@ def test_global_atom_with_an_item(client):
     assert rv.headers["Content-Type"] == "application/atom+xml"
     assert rv.text.startswith("<?xml")
     assert "checking if the cache invalidation works" in rv.text
+
+
+def test_global_atom_with_a_renamed_item(client):
+    """
+    Regression test: the feed history loop looks up each historical
+    revision by the name it had at that point in time. If the item has
+    since been renamed, a name-based lookup for an old revision no longer
+    resolves (the current item doesn't answer to that name any more), and
+    used to crash rendering that entry instead of showing it.
+    """
+
+    create_user("moin", "Xiwejr622")
+
+    login(client, "moin", "Xiwejr622")
+
+    old_name = "OldName"
+    new_name = "NewName"
+
+    # two revisions before the rename: the second one has a parent revid,
+    # which is what actually reaches the crashing diff-render code path
+    # below (a revision with no parent takes a different, unaffected
+    # rendering path).
+    response = modify_item(client, old_name, make_modify_form_data(old_name, comment="first revision"))
+    assert response.status_code == 302
+    response = modify_item(client, old_name, make_modify_form_data(old_name, comment="before rename"))
+    assert response.status_code == 302
+
+    response = client.post(
+        url_for("frontend.rename_item", item_name=old_name), data={"target": new_name, "comment": "renamed"}
+    )
+    assert response.status_code == 302
+
+    rv = client.get(url_for("feed.atom"))
+    assert rv.status_code == 200
+    assert rv.headers["Content-Type"] == "application/atom+xml"
+    assert "MoinMoin feels unhappy" not in rv.text

--- a/src/moin/apps/feed/views.py
+++ b/src/moin/apps/feed/views.py
@@ -19,9 +19,20 @@ from whoosh.query import Term, And, Every
 
 from moin import current_app, flaskg, log
 from moin.i18n import _
-from moin.constants.keys import NAME, NAME_EXACT, NAMESPACE, COMMENT, MTIME, REVID, ALL_REVS, PARENTID, LATEST_REVS
+from moin.constants.keys import (
+    NAME,
+    NAME_EXACT,
+    NAMESPACE,
+    COMMENT,
+    MTIME,
+    REVID,
+    ALL_REVS,
+    PARENTID,
+    LATEST_REVS,
+    ITEMID,
+)
 from moin.themes import get_editor_info, render_template
-from moin.items import Item
+from moin.items import Item, NonExistentContent
 from moin.utils.crypto import cache_key
 from moin.utils.interwiki import url_for_item
 from moin.utils.markup import safe_markup
@@ -85,7 +96,19 @@ def atom(item_name: str) -> Response:
             previous_revid = rev.meta.get(PARENTID)
             this_rev = rev
             try:
-                hl_item = Item.create(name, rev_id=this_revid)
+                # Look up by itemid, not by this revision's historical name:
+                # if the item has since been renamed, a name-based lookup
+                # for an old revision fails (the current item no longer
+                # answers to that name) and Item.create silently falls back
+                # to a DummyItem/NonExistentContent. itemid is stable across
+                # renames.
+                hl_item = Item.create(f"@itemid/{rev.meta[ITEMID]}", rev_id=this_revid)
+                if isinstance(hl_item.content, NonExistentContent):
+                    # Genuinely gone (not just renamed) -- the index still
+                    # has this revision, but storage does not. Raise a clear
+                    # error rather than let an AttributeError from deep in
+                    # the call below stand in for the real cause.
+                    raise LookupError(f"revision {this_revid} of {name!r} is indexed but missing from storage")
                 if previous_revid is not None:
                     # HTML diff for subsequent revisions
                     previous_rev = item[previous_revid]


### PR DESCRIPTION
The feed history loop looked up each historical revision by the name that revision had at the time (rev.fqname.fullname). If the item has since been renamed, that name no longer resolves to the item, so Item.create() silently falls back to a DummyItem/NonExistentContent, and calling render_data_diff_atom() on it raised an unhandled AttributeError for every affected revision.

Look up by itemid instead, which is stable across renames. Also explicitly detect the case where an indexed revision is genuinely missing from storage (not just renamed) and raise a clear error for it rather than relying on an incidental AttributeError.