### PR TITLE
Fix 500 on GET /+cspreport/log, return 405 instead

### DIFF
--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -473,3 +473,28 @@ class TestUsersettings:
         )
         form = FormClass.from_flat(request_form)
         return form
+
+
+def test_cspreport_get_does_not_crash(client):
+    """
+    Regression test: before_wiki()/teardown_wiki() skip environment setup
+    for /+cspreport/log unconditionally, since only the dedicated
+    cspreport() view is meant to handle that path. Previously that view
+    was registered POST-only, so the path itself wasn't special to
+    Werkzeug's routing -- a GET fell through to the generic show_item
+    catch-all instead, which does need flaskg.storage, and crashed with
+    AttributeError: storage since setup was skipped for it too.
+    cspreport() is now registered for all methods and rejects non-POST
+    itself with 405, so it -- not show_item -- is always the one handling
+    this path, regardless of method.
+    """
+    rv = client.get(url_for("frontend.cspreport"))
+    assert rv.status_code == 405
+
+    # the real (POST) CSP report path must still work
+    rv = client.post(
+        url_for("frontend.cspreport"),
+        data=json.dumps({"csp-report": {"document-uri": "http://localhost/"}}),
+        content_type="application/csp-report",
+    )
+    assert rv.status_code == 204

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -306,11 +306,21 @@ def lookup():
     return Response(html, status)
 
 
-@frontend.route("/+cspreport/log", methods=["POST"])
+@frontend.route("/+cspreport/log", methods=["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"])
 def cspreport():
     """
     content security policy report receiver
+
+    Registered for all methods, not just POST, so this exact rule -- not
+    the generic show_item catch-all -- is the one Werkzeug matches for
+    /+cspreport/log regardless of method. before_wiki()/teardown_wiki()
+    skip environment setup for this path unconditionally, so falling
+    through to show_item for a non-POST request would crash on missing
+    setup (e.g. flaskg.storage) instead of cleanly rejecting the request.
     """
+    if request.method != "POST":
+        abort(405)
+
     if request.content_type not in ["application/csp-report"]:
         abort(400, f"Invalid content type '{request.content_type}' for CSP report.")
 


### PR DESCRIPTION
/+cspreport/log is registered only for POST, but that path isn't special to Werkzeug's routing: a GET (or any other non-POST method) to that same path fell through to the generic show_item catch-all instead. before_wiki()/teardown_wiki() skip environment setup (including flaskg.storage) for this exact path unconditionally, on the assumption only the dedicated cspreport() view would ever handle it, so the fallthrough to show_item crashed with an unhandled AttributeError instead of a clean error response.

Per review feedback from Roland Ruedenauer: keep before_wiki()'s filter as it was, and instead register cspreport() for all methods so it -- not show_item -- is always the one Werkzeug routes this path to, and have it return 405 itself for anything other than POST.

Adds a regression test.