### PR TITLE
Fix KeyError crash in _build_contenttype_query on invalid group value

### DIFF
--- a/src/moin/items/__init__.py
+++ b/src/moin/items/__init__.py
@@ -647,6 +647,9 @@ def _build_contenttype_query(groups: list[str]) -> Query:
     """
     queries = []
     for g in groups:
+        # skip invalid group values (e.g. None) instead of raising KeyError
+        if g not in content_registry.groups:
+            continue
         for e in content_registry.groups[g]:
             ct_unicode = str(e.content_type)
             queries.append(Term(CONTENTTYPE, ct_unicode))

--- a/src/moin/items/_tests/test_Item.py
+++ b/src/moin/items/_tests/test_Item.py
@@ -9,7 +9,7 @@ MoinMoin - Tests for moin.items
 import pytest
 
 from moin._tests import become_trusted, update_item
-from moin.items import Item, NonExistent, IndexEntry, MixedIndexEntry
+from moin.items import Item, NonExistent, IndexEntry, MixedIndexEntry, _build_contenttype_query
 from moin.utils.names import CompositeName
 from moin.constants.keys import (
     ITEMTYPE,
@@ -542,6 +542,18 @@ class TestItem:
         item.delete("Moving item to trash.")
         item = Item.create(new_name)
         assert item.meta[TRASH]
+
+
+def test_build_contenttype_query_skips_unknown_group():
+    """
+    A selected_groups value that isn't a real content_registry key (e.g. None,
+    from a form submission with no contenttype selected) must be skipped
+    rather than raising a KeyError. Regression test for a crash reachable via
+    a plain POST to /+index/<item>/ with a blank/invalid contenttype field.
+    """
+    # should not raise, even though None and an unknown name are not real groups
+    query = _build_contenttype_query([None, "not-a-real-group"])
+    assert query is not None
 
 
 coverage_modules = ["moin.items"]


### PR DESCRIPTION
A selected_groups entry that isn't a real content_registry key (e.g. None, produced by a form submission with no contenttype selected) caused an unhandled KeyError, returning a 500 for any request that triggered it -- reachable via a plain POST to /+index/<item>/ with a blank or malformed contenttype field.

Skip values that aren't real content_registry keys instead of indexing into the dict directly. Adds a regression test.