### PR TITLE
Fix IndexError in wiki_matches() on empty item name

### DIFF
--- a/src/moin/items/__init__.py
+++ b/src/moin/items/__init__.py
@@ -204,14 +204,21 @@ def wiki_matches(fq_name, fq_names, start_re=None, end_re=None):
     match = start_re.match(item_name)
     if match:
         start = match.group(1)
-    else:
+    elif words:
         start = words[0]
+    else:
+        # item_name is empty or whitespace-only (e.g. a namespace root with
+        # no item name, such as /+similar_names/help-common) -- nothing to
+        # extract a first word from.
+        start = item_name
 
     match = end_re.search(item_name)
     if match:
         end = match.group(1)
-    else:
+    elif words:
         end = words[-1]
+    else:
+        end = item_name
 
     matches = {}
     subitem = item_name + "/"

--- a/src/moin/items/_tests/test_Item.py
+++ b/src/moin/items/_tests/test_Item.py
@@ -9,7 +9,7 @@ MoinMoin - Tests for moin.items
 import pytest
 
 from moin._tests import become_trusted, update_item
-from moin.items import Item, NonExistent, IndexEntry, MixedIndexEntry, _build_contenttype_query
+from moin.items import Item, NonExistent, IndexEntry, MixedIndexEntry, _build_contenttype_query, wiki_matches
 from moin.utils.names import CompositeName
 from moin.constants.keys import (
     ITEMTYPE,
@@ -554,6 +554,21 @@ def test_build_contenttype_query_skips_unknown_group():
     # should not raise, even though None and an unknown name are not real groups
     query = _build_contenttype_query([None, "not-a-real-group"])
     assert query is not None
+
+
+def test_wiki_matches_empty_item_name():
+    """
+    An empty item_name (e.g. a namespace root with no item name of its
+    own, such as /+similar_names/help-common) used to crash with
+    IndexError: list index out of range -- wiki_matches() fell back to
+    words[0]/words[-1] without checking the word list from splitting the
+    (empty) item name was actually non-empty.
+    """
+    fq_name = CompositeName("", NAME_EXACT, "")
+    start, end, matches = wiki_matches(fq_name, set())
+    assert start == ""
+    assert end == ""
+    assert matches == {}
 
 
 coverage_modules = ["moin.items"]


### PR DESCRIPTION
wiki_matches() fell back to words[0]/words[-1] (from splitting the item name on whitespace) whenever the wiki-word regexes didn't match, without checking that split() had actually produced any words. An empty item name -- e.g. a namespace root with nothing after it, such as /+similar_names/help-common -- produces an empty word list, so this crashed with IndexError: list index out of range.

Fall back to the item name itself (empty string) when there are no words to index into. Adds a regression test.