### PR TITLE
Fix 500 crash on missing /+template/<filename>, and the themed 404 ha…

### DIFF
--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -498,3 +498,34 @@ def test_cspreport_get_does_not_crash(client):
         content_type="application/csp-report",
     )
     assert rv.status_code == 204
+
+
+def test_template_missing_file_returns_404(client):
+    """
+    Regression test: /+template/<filename> passed its filename straight
+    to render_template() with no handling for a template that doesn't
+    exist, crashing with an unhandled TemplateNotFound -- e.g. a browser
+    speculatively probing for a nonexistent *.js.map next to a served
+    .js file. Fixing that exposed a second bug: is_static_content() paths
+    (which /+template/ is one of) skip the before_wiki() setup that
+    injects cfg into the template context, so page_not_found()'s themed
+    404.html crashed too (UndefinedError: 'cfg' is undefined) trying to
+    render the error page itself.
+    """
+    rv = client.get(url_for("frontend.template", filename="does-not-exist.js.map"))
+    assert rv.status_code == 404
+
+    # a real template must still work
+    rv = client.get(url_for("frontend.template", filename="dictionary.js"))
+    assert rv.status_code == 200
+
+
+def test_normal_item_404_is_still_themed(client):
+    """
+    page_not_found()'s plain-response fallback is scoped to
+    is_static_content() paths only -- an ordinary missing item must still
+    get the normal themed 404 page.
+    """
+    rv = client.get(url_for("frontend.show_item", item_name="DoesNotExist"))
+    assert rv.status_code == 404
+    assert b"moin-header" in rv.data

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -49,6 +49,8 @@ from flask_theme import get_themes_list
 from flatland import Form
 from flatland.validation import Validator
 
+from jinja2 import TemplateNotFound
+
 from markupsafe import Markup
 
 import pytz
@@ -3315,7 +3317,12 @@ def template(filename):
 
     used for (but not limited to) translation of javascript / css / html
     """
-    content = render_template(filename)
+    try:
+        content = render_template(filename)
+    except TemplateNotFound:
+        # filename is unvalidated caller input, e.g. a browser probing
+        # for a nonexistent *.js.map.
+        abort(404)
     ct, enc = mimetypes.guess_type(filename)
     response = make_response((content, 200, {"content-type": ct or "text/plain;charset=utf-8"}))
     if ct in ["application/javascript", "text/css", "text/html"]:
@@ -3358,4 +3365,8 @@ def bad_request(error):
 
 @frontend.errorhandler(404)
 def page_not_found(e):
+    if getattr(flaskg, "no_variable_injection", False):
+        # is_static_content() paths skip cfg setup, so the themed
+        # 404.html would itself crash rendering.
+        return e.get_response()
     return render_template("404.html", path=request.path, item_name=e.description), 404


### PR DESCRIPTION
…ndler crash it exposed

/+template/<filename> passed its caller-supplied filename straight to render_template() with no handling for a template that doesn't exist, crashing with an unhandled TemplateNotFound -- e.g. a browser speculatively probing for a nonexistent *.js.map next to a served .js file, or a scanner checking for exposed source maps. Catch it and return a plain 404 instead.

That then exposed a second, previously-latent bug: is_static_content() paths (/static/, /+serve/, /+template/, /_themes/) skip the before_wiki() setup that injects cfg into the template context, on the assumption they're serving a real file and never need it. A 404 from one of those routes crashed rendering page_not_found()'s themed 404.html itself (UndefinedError: 'cfg' is undefined) instead of returning a 404. Fall back to a plain, unthemed response in that case; ordinary item 404s are unaffected and keep the normal themed page.

Adds regression tests for both.