### PR TITLE
Fix unhandled LockError from concurrent index writes

### DIFF
--- a/src/moin/storage/middleware/_tests/test_indexing.py
+++ b/src/moin/storage/middleware/_tests/test_indexing.py
@@ -163,6 +163,57 @@ class TestIndexingMiddleware(TestIndexingMiddlewareBase):
         assert len(revids) == 1  # we still have the revision, cleared
         assert revid in revids  # it is still same revid
 
+    def test_overwrite_revision_waits_out_concurrent_writer(self, monkeypatch):
+        """
+        Regression test: overwrite=True forces the synchronous (non-async)
+        writer path in index_revision(), and that path used to call
+        ix.writer() with no timeout -- so a writer already holding the
+        index's write lock (e.g. a concurrent login/edit on the same
+        site updating a user profile) made this raise an immediate,
+        unhandled whoosh.index.LockError instead of just waiting
+        briefly, as seen in production via an ERROR email triggered by a
+        real login.
+        """
+        import threading
+        import time
+
+        from moin.storage.middleware import indexing as indexing_module
+
+        monkeypatch.setattr(indexing_module, "INDEXER_TIMEOUT", 2.0)
+
+        item_name = "foo"
+        data = b"bar"
+        newdata = b"baz"
+        item = self.get_item(item_name)
+        meta = {NAME: [item_name], ITEMTYPE: ITEMTYPE_DEFAULT, COMMENT: "spam"}
+        rev = item.store_revision(meta, BytesIO(data), return_rev=True)
+        revid = rev.revid
+
+        # hold the write lock ourselves, simulating a concurrent writer
+        lock = self.imw.ix[ALL_REVS].lock("WRITELOCK")
+        assert lock.acquire()
+
+        def release_soon():
+            time.sleep(0.3)
+            lock.release()
+
+        releaser = threading.Thread(target=release_soon)
+        releaser.start()
+        try:
+            start = time.monotonic()
+            meta = {NAME: [item_name], ITEMTYPE: ITEMTYPE_DEFAULT, COMMENT: "no spam", REVID: revid}
+            item.store_revision(meta, BytesIO(newdata), overwrite=True)
+            elapsed = time.monotonic() - start
+        finally:
+            releaser.join()
+
+        # must have actually waited for the lock, not failed instantly
+        assert elapsed >= 0.25
+        item = self.get_item(item_name)
+        rev = item.get_revision(revid)
+        assert rev.meta[COMMENT] == "no spam"
+        assert rev.data.read() == newdata
+
     def test_destroy_revision(self):
         item, item_name, revid0, revid1, revid2 = self.store_three_revisions()
         query = Term(NAME_EXACT, item_name)

--- a/src/moin/storage/middleware/indexing.py
+++ b/src/moin/storage/middleware/indexing.py
@@ -644,7 +644,9 @@ class IndexingMiddleware:
         if async_:
             writer = AsyncWriter(self.ix[ALL_REVS])
         else:
-            writer = self.ix[ALL_REVS].writer()
+            # default timeout=0 fails instantly on a concurrent writer
+            # instead of waiting it out (e.g. two near-simultaneous logins).
+            writer = self.ix[ALL_REVS].writer(timeout=INDEXER_TIMEOUT)
         with writer as writer:
             writer.update_document(**doc)  # update, because store_revision() may give us an existing revid
         if force_latest:
@@ -663,7 +665,7 @@ class IndexingMiddleware:
                 if async_:
                     writer = AsyncWriter(self.ix[idx_name])
                 else:
-                    writer = self.ix[idx_name].writer()
+                    writer = self.ix[idx_name].writer(timeout=INDEXER_TIMEOUT)
                 with writer as writer:
                     writer.update_document(**doc)
         # the index changed: drop cached searchers so later reads see fresh data
@@ -673,7 +675,7 @@ class IndexingMiddleware:
         if async_:
             writer = AsyncWriter(self.ix[idx_name])
         else:
-            writer = self.ix[idx_name].writer()
+            writer = self.ix[idx_name].writer(timeout=INDEXER_TIMEOUT)
         with writer as writer:
             # find out itemid related to the revid we want to remove:
             with self.ix[idx_name].searcher() as searcher:
@@ -708,7 +710,9 @@ class IndexingMiddleware:
         if async_:
             writer = AsyncWriter(self.ix[ALL_REVS])
         else:
-            writer = self.ix[ALL_REVS].writer()
+            # default timeout=0 fails instantly on a concurrent writer
+            # instead of waiting it out (e.g. two near-simultaneous logins).
+            writer = self.ix[ALL_REVS].writer(timeout=INDEXER_TIMEOUT)
         with writer as writer:
             writer.delete_by_term(REVID, revid)
         for idx_name in [LATEST_REVS, LATEST_META]:


### PR DESCRIPTION
index_revision(), remove_index_revision(), and remove_revision() all fall back to a synchronous (non-async) whoosh writer when async_ is False -- notably always the case for overwrite=True saves (used e.g. by User.save() on every login to update the profile item), since index_revision() forces async_=False whenever force_latest is False.

That synchronous writer() call used no timeout, so whoosh's default (timeout=0) made it raise an immediate, unhandled LockError instead of waiting out a concurrent writer -- reachable in production by two ordinary near-simultaneous requests needing to write to the same site's index (e.g. two logins, or a login racing an edit save).

Pass timeout=INDEXER_TIMEOUT (already used elsewhere in this file for the same class of "indexer delayed under load" tolerance) to all four synchronous writer() calls, so they wait out a transient lock instead of crashing. Adds a regression test that reproduces real lock contention with an actual held write lock on a background thread.