### PR TITLE
Fix MIME type for .svg (and .cfg, .md) clobbered by Pygments lexers

### DIFF
--- a/src/moin/utils/mimetype.py
+++ b/src/moin/utils/mimetype.py
@@ -68,6 +68,9 @@ MIMETYPES_MORE = {
     ".targz": "application/x-gtar",
 }
 
+# Extensions we deliberately assigned a MIME type to above; Pygments must not override these.
+_MIMETYPES_EXPLICIT = frozenset(MIMETYPES_MORE)
+
 # Add all MIME type patterns from Pygments
 for name, short, patterns, mime in pygments.lexers.get_all_lexers():
     for pattern in patterns:
@@ -75,7 +78,12 @@ for name, short, patterns, mime in pygments.lexers.get_all_lexers():
             if pattern in ("*.txt",):
                 # Some Pygments lexers claim *.txt for types other than text/plain; skip those.
                 continue
-            MIMETYPES_MORE[pattern[1:]] = mime[0]
+            ext = pattern[1:]
+            if ext in _MIMETYPES_EXPLICIT:
+                # Don't let a Pygments lexer override a MIME type we picked deliberately,
+                # e.g. pygments/pygments#3093 made the XML lexer claim *.svg.
+                continue
+            MIMETYPES_MORE[ext] = mime[0]
 
 for ext, mimetype in sorted(MIMETYPES_MORE.items()):
     mimetypes.add_type(mimetype, ext, True)


### PR DESCRIPTION
MimeType.from_filename() returns text/xml for .svg files (should be image/svg+xml), because Pygments 2.21.0 makes the XML lexer claim the *.svg pattern for the first time (pygments/pygments#3093). Two other extensions moin sets deliberately, .cfg and .md/.markdown, are silently wrong the same way already, independent of this Pygments release.

    AssertionError: assert 'text/xml' == 'image/svg+xml'

The loop at the bottom of mimetype.py registers a MIME type for every filename pattern every Pygments lexer declares, unconditionally overwriting MIMETYPES_MORE, including the entries moin sets on purpose a few lines above. Whichever lexer runs last for a given extension wins, so a Pygments release adding or moving a pattern silently changes what moin serves.

Fix it by recording which extensions MIMETYPES_MORE sets explicitly before the Pygments loop runs, and skipping any Pygments pattern that would touch one of them. Extensions Pygments claims for the first time still get registered exactly as before.

Confirmed image/svg+xml, text/plain and text/x.markdown are served again for .svg/.cfg/.md with Pygments 2.20.0 and 2.21.0 both installed, and the full test_mimetype.py suite passes on each.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Fixes #2357