### PR TITLE
Fix KeyError crash when the theme registry is incomplete

### DIFF
--- a/src/moin/themes/__init__.py
+++ b/src/moin/themes/__init__.py
@@ -61,7 +61,19 @@ def get_current_theme():
             f"Theme {theme_name!r} was not found; using default of {current_app.cfg.theme_default!r} instead."
         )
         theme_name = current_app.cfg.theme_default
-        return get_theme(theme_name)
+        try:
+            return get_theme(theme_name)
+        except KeyError:
+            # theme_name is already the configured default, so this isn't
+            # a bad per-user theme choice -- the registry itself is
+            # incomplete, e.g. flask_theme's ThemeManager.refresh() isn't
+            # thread-safe against concurrent callers (one thread's
+            # `self._themes = {}` can orphan another thread's in-progress
+            # population), which mass worker recycling on an httpd reload
+            # can trigger. Force a rescan and retry once before giving up.
+            logging.warning(f"Default theme {theme_name!r} also not found; forcing a theme registry refresh.")
+            current_app.theme_manager.refresh()
+            return get_theme(theme_name)
 
 
 def render_template(template, **context) -> str:

--- a/src/moin/themes/_tests/test_theme_support.py
+++ b/src/moin/themes/_tests/test_theme_support.py
@@ -4,7 +4,7 @@
 import pytest
 
 from moin import current_app, flaskg
-from moin.themes import ThemeSupport
+from moin.themes import ThemeSupport, get_current_theme
 from moin.user import User
 
 from moin._tests import wikiconfig
@@ -38,3 +38,28 @@ def test_get_user_home(_test_user, theme_supp):
     assert display_name == "lemmy"
     assert title == "lemmy @ Self"
     assert not exists
+
+
+@pytest.mark.usefixtures("_req_ctx")
+def test_get_current_theme_recovers_from_incomplete_registry():
+    """
+    Regression test: if flask_theme's ThemeManager.themes is incomplete
+    (e.g. a race in its own refresh() during mass worker recycling on an
+    httpd reload -- one thread's `self._themes = {}` can orphan another
+    thread's in-progress population), get_current_theme()'s existing
+    fallback retried the *same* lookup for the already-default theme and
+    crashed identically with an unhandled KeyError. It should instead
+    force a registry refresh and retry once more before giving up.
+    """
+    default_theme = current_app.cfg.theme_default
+    assert default_theme in current_app.theme_manager.themes
+
+    # simulate the race: the registry looks populated, but is missing
+    # every entry, including the default theme's
+    current_app.theme_manager._themes = {}
+
+    theme = get_current_theme()
+    assert theme.identifier == default_theme
+    # the forced refresh should have restored the full registry, not
+    # just papered over the one lookup
+    assert default_theme in current_app.theme_manager.themes


### PR DESCRIPTION
get_current_theme() already had a fallback for a KeyError from
get_theme(): retry with the configured default theme. But if the
*default* theme itself is missing from the registry, that fallback
retries the exact same lookup that just failed, and crashes
identically with an unhandled KeyError.

This is reachable in practice: flask_theme's ThemeManager.refresh()
isn't thread-safe against concurrent callers (one thread's
`self._themes = {}` can orphan another thread's in-progress
population), and mod_wsgi mass-recycling all worker processes on an
httpd reload (e.g. a logrotate-triggered one, hours into otherwise
stable operation) can trigger exactly that race.

Force a registry refresh and retry once more before giving up. Adds a
regression test that simulates an incomplete registry directly rather
than trying to reproduce the underlying threading race.