### PR TITLE
Fix crash viewing an old revision of a renamed item

### DIFF
--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -17,6 +17,7 @@ from flask import url_for
 from werkzeug.datastructures import FileStorage
 
 from moin import current_app, flaskg, user
+from moin.constants.keys import CURRENT, REVID
 from moin.apps._tests.utils import (
     create_user,
     login,
@@ -529,3 +530,30 @@ def test_normal_item_404_is_still_themed(client):
     rv = client.get(url_for("frontend.show_item", item_name="DoesNotExist"))
     assert rv.status_code == 404
     assert b"moin-header" in rv.data
+
+
+def test_show_old_revision_of_renamed_item(client):
+    """
+    Regression test: prior_next_revs() used to query the search index by the
+    item's current name to build the revision list it then searches for the
+    requested revid. A rename does not retroactively update older revisions'
+    indexed NAME, so a name-based query only finds revisions from after the
+    rename -- and viewing an older revision by its revid (e.g. from a link
+    or bookmark made before the rename) raised an unhandled
+    ValueError: '<revid>' is not in list.
+    """
+    create_user("moin", "Xiwejr622")
+    login(client, "moin", "Xiwejr622")
+
+    old_name = "OldRevNavName"
+    new_name = "NewRevNavName"
+
+    modify_item(client, old_name, make_modify_form_data(old_name, comment="first revision"))
+    old_revid = flaskg.storage[old_name][CURRENT].meta[REVID]
+
+    modify_item(client, old_name, make_modify_form_data(old_name, comment="before rename"))
+    client.post(url_for("frontend.rename_item", item_name=old_name), data={"target": new_name, "comment": "renamed"})
+
+    rv = client.get(url_for("frontend.show_item", item_name=new_name, rev=old_revid))
+    assert rv.status_code == 200
+    assert b"MoinMoin feels unhappy" not in rv.data

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -761,7 +761,7 @@ def indexable(item_name, rev):
 
 @presenter("highlight")
 def highlight_item(item):
-    rev_navigation_ids_dates = rev_navigation.prior_next_revs(request.view_args["rev"], item.fqname)
+    rev_navigation_ids_dates = rev_navigation.prior_next_revs(request.view_args["rev"], item.meta[ITEMID])
     item_is_deleted = flash_if_item_deleted(item.fqname.fullname, item.rev.meta[REVID], item)
     item_may = get_item_permissions(item.fqname, item)
     try:
@@ -785,7 +785,7 @@ def highlight_item(item):
 
 @presenter("meta", add_trail=True)
 def show_item_meta(item):
-    rev_navigation_ids_dates = rev_navigation.prior_next_revs(request.view_args["rev"], item.fqname)
+    rev_navigation_ids_dates = rev_navigation.prior_next_revs(request.view_args["rev"], item.meta[ITEMID])
     item_is_deleted = flash_if_item_deleted(item.fqname.fullname, item.rev.meta[REVID], item)
     item_may = get_item_permissions(item.fqname, item)
     ret = render_template(

--- a/src/moin/items/__init__.py
+++ b/src/moin/items/__init__.py
@@ -1526,7 +1526,7 @@ class Default(Contentful):
         Display an item. If this is not the current revision, page content will be
         prefaced with links to the next-rev and prior-rev.
         """
-        rev_navigation_ids_dates = rev_navigation.prior_next_revs(revid, self.fqname)
+        rev_navigation_ids_dates = rev_navigation.prior_next_revs(revid, self.meta[ITEMID])
         # create extra meta tags for use by web crawlers
         html_head_meta = {}
         if TAGS in self.meta and self.meta[TAGS]:

--- a/src/moin/utils/rev_navigation.py
+++ b/src/moin/utils/rev_navigation.py
@@ -6,12 +6,12 @@ Helper to get prior, current, and next revisions and modification times.
 """
 
 from flask import request
-from whoosh.query import Term, And
+from whoosh.query import Term
 from moin import flaskg
-from moin.constants.keys import ALL_REVS, CURRENT, MTIME
+from moin.constants.keys import ALL_REVS, CURRENT, ITEMID, MTIME
 
 
-def prior_next_revs(revid, fqname):
+def prior_next_revs(revid, itemid):
     """
     If viewing a revision other than the current revision,
     return prior, current, and next revision IDs and timestamps; otherwise return None * 6.
@@ -22,8 +22,11 @@ def prior_next_revs(revid, fqname):
         # maintenance scripts, such as dump-html, have request.view_args == {}
         show_revision = False
     if show_revision:
-        terms = [Term(term, value) for term, value in fqname.query.items()]
-        query = And(terms)
+        # Query by itemid, not by the item's current name: a name-based query only
+        # matches revisions indexed under that name, but renaming an item does not
+        # retroactively update older revisions' indexed NAME. itemid is stable
+        # across renames, so this finds the full history either way.
+        query = Term(ITEMID, itemid)
         revs = flaskg.storage.search(query, idx_name=ALL_REVS, sortedby=[MTIME], reverse=True, limit=None)
         rev_ids = []
         mtimes = []


### PR DESCRIPTION
Viewing an item's older revision by revid raises an unhandled ValueError when the item has since been renamed:

    ValueError: 'edd5c77b6c1b4a178019cf6381a732ce' is not in list
      File "src/moin/apps/frontend/views.py", line 712, in show_item
        result = item.do_show(rev, item_is_deleted=item_is_deleted, item_may=item_may)
      File "src/moin/items/__init__.py", line 1539, in do_show
        rev_navigation_ids_dates = rev_navigation.prior_next_revs(revid, self.fqname)
      File "src/moin/utils/rev_navigation.py", line 34, in prior_next_revs
        current_idx = rev_ids.index(revid)
    ValueError: 'edd5c77b6c1b4a178019cf6381a732ce' is not in list

prior_next_revs() builds the revision list to search by querying the index for the item's current name, then looks up the requested revid in that list. A rename does not retroactively update older revisions' indexed NAME, so a name-based query only returns revisions from after the rename. Following a link or bookmark to a pre-rename revision lands on a revid the query never finds, and index() raises instead of returning -1.

This is the same root cause as 46af8fc75b4a (the atom feed's history-loop crash on renamed items): itemid is stable across renames, name is not. Query by itemid instead, threading it through from each of the three call sites' item.meta[ITEMID] rather than item.fqname.

Adds a regression test that reproduces the traceback above end to end (create, revise, rename, then view the pre-rename revid) and confirms it fails without this fix before confirming it passes with it.