### PR TITLE
Fix diff() silently substituting a different revision after a rename

### DIFF
--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -557,3 +557,34 @@ def test_show_old_revision_of_renamed_item(client):
     rv = client.get(url_for("frontend.show_item", item_name=new_name, rev=old_revid))
     assert rv.status_code == 200
     assert b"MoinMoin feels unhappy" not in rv.data
+
+
+def test_diff_includes_revisions_from_before_a_rename(client):
+    """
+    Regression test: diff() built its ALL_REVS query from fqname.query, i.e.
+    the item's current name. A rename does not retroactively update older
+    revisions' indexed NAME, so a name-based query -- the normal case, since
+    that's what every link to this page uses -- only matched revisions from
+    after the rename. rev_ids then never contained a pre-rename revid, so
+    requesting a diff against one silently fell through to a different,
+    unrequested revision instead of erroring or honoring the request.
+    """
+    create_user("moin", "Xiwejr622")
+    login(client, "moin", "Xiwejr622")
+
+    old_name = "OldDiffName"
+    new_name = "NewDiffName"
+
+    modify_item(client, old_name, make_modify_form_data(old_name, content="AAA\n", comment="first revision"))
+    old_revid = flaskg.storage[old_name][CURRENT].meta[REVID]
+
+    modify_item(client, old_name, make_modify_form_data(old_name, content="BBB\n", comment="before rename"))
+    client.post(url_for("frontend.rename_item", item_name=old_name), data={"target": new_name, "comment": "renamed"})
+    modify_item(client, new_name, make_modify_form_data(new_name, content="CCC\n", comment="after rename"))
+    new_revid = flaskg.storage[new_name][CURRENT].meta[REVID]
+
+    rv = client.get(url_for("frontend.diff", item_name=new_name, rev1=old_revid, rev2=new_revid))
+    assert rv.status_code == 200
+    # the pre-rename revision actually requested must be the one diffed
+    # against, not a different one silently substituted for it
+    assert b"AAA" in rv.data

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -2953,10 +2953,9 @@ def diff(item_name):
     Item History or from a Diff display then the two revision IDs selected by the user
     will be processed.
 
-    If the call is made from Item History, then there may be a difference in the
-    display based upon whether the call is made based upon Item Name or
-    Item ID. Calls based on Item IDs will include revisions prior to an item
-    rename and revisions created by Item delete.
+    The revision list used for this diff is looked up by itemid, so it
+    includes history from before an item rename regardless of whether
+    item_name in the URL is a name or an "@itemid/..." reference.
     """
     fqname = split_fqname(item_name)
     try:
@@ -2969,8 +2968,11 @@ def diff(item_name):
     offset = request.values.get("offset", 0)
     offset = max(int(offset), 0)
     bookmark_time = int(request.values.get("bookmark", 0))
-    terms = [Term(term, value) for term, value in fqname.query.items()]
-    query = And(terms)
+    # Query by itemid, not by the item's current name: a name-based query only
+    # matches revisions indexed under that name, but renaming an item does not
+    # retroactively update older revisions' indexed NAME. itemid is stable
+    # across renames, so this finds the full history either way.
+    query = Term(ITEMID, item.meta[ITEMID])
     metas = flaskg.storage.search_meta(query, idx_name=ALL_REVS, sortedby=[MTIME, REV_NUMBER], reverse=True, limit=None)
     close_file(item.rev.data)
     item = flaskg.storage.get_item(**fqname.query)


### PR DESCRIPTION
diff() built its ALL_REVS query from fqname.query, i.e. the item's current name. A rename does not retroactively update older revisions' indexed NAME, so a name-based query -- the normal case, since every link to this page uses the item's current name -- only matched revisions from after the rename. rev_ids then never contained a pre-rename revid, so requesting a diff against one (e.g. from an old bookmark or an Item History link made before the rename) silently fell through to the "not in rev_ids" fallback and diffed a different, unrequested revision instead -- no error, just the wrong answer.

This is the same root cause as 46af8fc75b4a (the atom feed's history-loop crash on renamed items) and the Item History fix (history() had the identical fqname.query-against-ALL_REVS pattern): itemid is stable across renames, name is not. Query by itemid instead. The docstring's existing caveat about Item Name vs Item ID calls producing different results no longer applies, so it's updated to describe the new, uniform behavior.

Adds a regression test that creates a revision, renames the item, adds another revision, and requests a diff between the pre- and post-rename revisions by revid -- and confirms it fails (diffs the wrong pair) without this fix before confirming it passes with it.