### PR TITLE
Fix Item History silently dropping revisions from before a rename

### DIFF
--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -588,3 +588,31 @@ def test_diff_includes_revisions_from_before_a_rename(client):
     # the pre-rename revision actually requested must be the one diffed
     # against, not a different one silently substituted for it
     assert b"AAA" in rv.data
+
+
+def test_history_shows_revisions_from_before_a_rename(client):
+    """
+    Regression test: history() built its ALL_REVS query from fqname.query,
+    i.e. the item's current name. A rename does not retroactively update
+    older revisions' indexed NAME, so a name-based query -- the normal case,
+    since that's what every link to this page uses -- only matched
+    revisions from after the rename. The Item History page silently
+    dropped everything before it instead of erroring, so nothing signalled
+    the history was incomplete.
+    """
+    create_user("moin", "Xiwejr622")
+    login(client, "moin", "Xiwejr622")
+
+    old_name = "OldHistoryName"
+    new_name = "NewHistoryName"
+
+    modify_item(client, old_name, make_modify_form_data(old_name, comment="first revision"))
+    modify_item(client, old_name, make_modify_form_data(old_name, comment="before rename"))
+    client.post(url_for("frontend.rename_item", item_name=old_name), data={"target": new_name, "comment": "renamed"})
+    modify_item(client, new_name, make_modify_form_data(new_name, comment="after rename"))
+
+    rv = client.get(url_for("frontend.history", item_name=new_name))
+    assert rv.status_code == 200
+    assert b"first revision" in rv.data
+    assert b"before rename" in rv.data
+    assert b"after rename" in rv.data

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -1930,7 +1930,11 @@ def history(item_name):
         results_per_page = flaskg.user.results_per_page
     else:
         results_per_page = current_app.cfg.results_per_page
-    terms = [Term(term, value) for term, value in fqname.query.items()]
+    # Query by itemid, not by the item's current name: a name-based query only
+    # matches revisions indexed under that name, but renaming an item does not
+    # retroactively update older revisions' indexed NAME. itemid is stable
+    # across renames, so this finds the full history either way.
+    terms = [Term(ITEMID, item.meta[ITEMID])]
     if bookmark_time:
         terms.append(DateRange(MTIME, start=utcfromtimestamp(bookmark_time), end=None))
     query = And(terms)


### PR DESCRIPTION
history() built its ALL_REVS query from fqname.query, i.e. the item's current name. A rename does not retroactively update older revisions' indexed NAME, so a name-based query -- the normal case, since every link to this page uses the item's current name -- only matched revisions from after the rename. The Item History page silently dropped everything before it instead of erroring, so nothing signalled that the history shown was incomplete.

This is the same root cause as 46af8fc75b4a (the atom feed's history-loop crash on renamed items) and the rev_navigation fix for prior/next revision links: itemid is stable across renames, name is not. Query by itemid instead.

Adds a regression test that creates two revisions, renames the item, adds a third revision, and confirms all three show up in the history page -- and confirms it fails without this fix before confirming it passes with it.