### PR TITLE
Fix flask_theme.ThemeManager.refresh() race causing spurious theme Ke…

### DIFF
--- a/src/moin/utils/_tests/test_monkeypatch.py
+++ b/src/moin/utils/_tests/test_monkeypatch.py
@@ -1,0 +1,110 @@
+# Copyright: 2026 MoinMoin Project
+# License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
+
+"""
+MoinMoin - moin.utils.monkeypatch tests.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+
+from flask_theme import ThemeManager
+
+from moin.utils import monkeypatch  # noqa: F401  ensures the patch below is applied
+
+
+def _slow_loader(app):
+    """
+    A fake theme loader that stalls before producing anything, widening
+    the refresh() race window enough to reliably hit it in a test (the
+    real window, scanning the filesystem for theme directories, is
+    normally far too narrow to hit deterministically). time.sleep()
+    releases the GIL, so this also guarantees other threads actually get
+    to run during the window instead of merely making it wider in theory.
+    """
+    time.sleep(0.05)
+    yield SimpleNamespace(application="test-app", identifier="topside")
+    yield SimpleNamespace(application="test-app", identifier="modernized")
+
+
+def _make_manager():
+    return ThemeManager(SimpleNamespace(), "test-app", loaders=[_slow_loader])
+
+
+def test_theme_manager_first_population_is_race_free():
+    """
+    Regression test: on a freshly-started/recycled mod_wsgi process,
+    ThemeManager._themes is None and several threads can take their first
+    request around the same moment. Each thread's first `.themes` access
+    sees `_themes is None` and calls refresh() -- but the original
+    flask_theme implementation reset self._themes to an empty dict before
+    slowly repopulating it, so a second thread's `_themes is None` check
+    (already False, since the first thread already set it to {}) returned
+    the still-empty dict directly, without doing its own refresh --
+    raising a spurious KeyError for a theme (e.g. the configured default)
+    that's about to exist a moment later.
+    """
+    manager = _make_manager()
+    assert manager._themes is None  # nothing populated yet, like a fresh process
+
+    errors = []
+
+    def reader():
+        try:
+            manager.themes["topside"]
+        except KeyError as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=reader) for _ in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"{len(errors)} of {len(threads)} concurrent first-time readers saw a spurious KeyError"
+
+
+def test_theme_manager_concurrent_refresh_is_race_free():
+    """
+    Regression test: moin's get_current_theme() retries a KeyError by
+    forcing current_app.theme_manager.refresh() and looking up the theme
+    again. If another thread is concurrently doing the same thing (or just
+    reading .themes) against an already-populated registry, the original
+    refresh() briefly made even a *previously present* theme disappear,
+    so that retry could itself fail with the same KeyError.
+    """
+    manager = _make_manager()
+    manager.refresh()
+    assert "topside" in manager.themes  # a warm, complete registry, like steady state
+
+    errors = []
+    stop = threading.Event()
+
+    def reader():
+        # loop for as long as the refresher is running, not a fixed count --
+        # a fixed count of fast dict lookups can finish before the refresher
+        # thread is even scheduled, missing the window entirely
+        while not stop.is_set():
+            try:
+                manager.themes["topside"]
+            except KeyError as e:
+                errors.append(e)
+
+    def refresh_then_stop():
+        manager.refresh()
+        stop.set()
+
+    readers = [threading.Thread(target=reader) for _ in range(8)]
+    refresher = threading.Thread(target=refresh_then_stop)
+
+    for t in readers:
+        t.start()
+    refresher.start()
+    refresher.join()
+    for t in readers:
+        t.join()
+
+    assert not errors, f"{len(errors)} reads saw a spurious KeyError during a concurrent refresh"

--- a/src/moin/utils/monkeypatch.py
+++ b/src/moin/utils/monkeypatch.py
@@ -62,3 +62,41 @@ def template_exists(templatename):
 
 
 flask_theme.template_exists = template_exists
+
+# Fix ThemeManager.refresh() not being safe against concurrent readers.
+# The original implementation resets self._themes to an empty dict, then
+# repopulates it in place with no lock:
+#
+#     def refresh(self):
+#         self._themes = {}
+#         for theme in starchain(...):
+#             self.themes[theme.identifier] = theme
+#
+# A reader on another thread (e.g. another thread of the same freshly
+# started/recycled mod_wsgi process, taking its first request around the
+# same moment) can observe self._themes as a real, non-None, but still
+# empty dict during that window, and raise a spurious KeyError for a
+# theme -- including the configured default -- that is about to exist a
+# moment later. This is what's behind "KeyError: 'topside'" (or whatever
+# theme_default is set to) crashes.
+#
+# Build the new mapping in a local variable instead, and only publish it
+# via a single attribute assignment once it's complete. A single
+# attribute assignment is atomic (it's just a pointer write under the
+# GIL), so a concurrent reader only ever sees the old, complete mapping
+# or the new, complete mapping -- never a partial one. Concurrent callers
+# of refresh() may end up redundantly building the same mapping more than
+# once, but that's harmless wasted work, not a correctness issue: the
+# old mapping is reclaimed by normal reference counting once its last
+# reader is done with it, no coordination required.
+
+
+def theme_manager_refresh(self):
+    themes = {}
+    for theme in flask_theme.starchain(loader(self.app) for loader in self.loaders):
+        if self.valid_app_id(theme.application):
+            themes[theme.identifier] = theme
+    self._themes = themes
+
+
+flask_theme.ThemeManager.refresh = theme_manager_refresh


### PR DESCRIPTION
…yErrors

ThemeManager.refresh() resets self._themes to an empty dict, then repopulates it in place with no lock:

    def refresh(self):
        self._themes = {}
        for theme in starchain(...):
            self.themes[theme.identifier] = theme

A reader on another thread -- e.g. another thread of the same freshly started/recycled mod_wsgi process, taking its first request around the same moment -- can observe self._themes as a real, non-None, but still empty dict during that window, and get a KeyError for a theme (including the configured default) that's about to exist a moment later. This is what's behind "KeyError: 'topside'" (or whatever theme_default is set to) crashes in get_current_theme(); its existing retry-after-forced-refresh logic doesn't fully cover it either, since a concurrent thread's own refresh() call can hit the very same race.

flask_theme is a third-party dependency, so this can't be fixed in-tree the normal way. moin.utils.monkeypatch already exists for exactly this kind of situation, and already patches a couple of other flask_theme quirks, so the fix lives there: build the new mapping in a local variable and publish it via a single attribute assignment once complete, instead of clearing and refilling the shared dict in place. A single attribute assignment is atomic (a pointer write under the GIL), so a concurrent reader only ever sees the old, complete mapping or the new, complete mapping, never a partial one. Concurrent refresh() callers may end up redundantly building the same mapping more than once, which is wasted work but not a correctness problem -- the old mapping is reclaimed by normal reference counting once its last reader is done with it.

Adds two regression tests using a fake, deliberately slow theme loader to widen the race window enough to hit it deterministically: one for concurrent first-time population (a fresh ThemeManager, several threads all take their first look at once), one for a concurrent refresh() racing readers of an already-warm registry. Confirmed both reliably reproduce the crash against the original unpatched flask_theme behavior before confirming they pass with this fix.

This is a real bug in flask_theme itself, not just in how moin uses it, so a fix is also being prepared to send upstream to flask-theme separately.