### PR TITLE
Fix crash on /+usersettings (ui tab) when a Natural field is missing

### DIFF
--- a/src/moin/_tests/test_forms.py
+++ b/src/moin/_tests/test_forms.py
@@ -13,7 +13,7 @@ from calendar import timegm
 
 from moin import current_app
 from moin.constants.itemtypes import ITEMTYPE_DEFAULT
-from moin.forms import DateTimeUNIX, Email, JSON, Names
+from moin.forms import DateTimeUNIX, Email, JSON, Names, Natural
 from moin.utils.names import CompositeName
 from moin.items import Item
 from moin._tests import become_trusted
@@ -124,3 +124,36 @@ def test_email():
     # a boring, ordinary valid address
     valid = Email("someone@example.org")
     assert valid.validate() is True
+
+
+def test_natural():
+    """
+    Regression test: Natural = AnyInteger.validated_by(ValueAtLeast(0))
+    silently dropped AnyInteger's inherited Converted() validator --
+    .validated_by() replaces a class's validator list rather than
+    appending to it. Without Converted() to catch it first, a
+    missing/blank field reached ValueAtLeast(0) with element.value of
+    None, and "None >= 0" raised an unhandled TypeError instead of
+    failing validation normally. Converted() now runs first, so
+    ValueAtLeast(0) never even runs on a missing/blank value.
+    """
+    # missing entirely, e.g. the field wasn't in the POST body at all
+    missing = Natural(None)
+    assert missing.value is None
+    assert missing.validate() is False
+
+    # present but blank, e.g. an empty input box
+    blank = Natural("")
+    assert blank.validate() is False
+
+    # present, but not a valid non-negative integer -- Converted() passes
+    # this through to ValueAtLeast(0), which must still reject it,
+    # without crashing
+    negative = Natural(-1)
+    assert negative.validate() is False
+
+    # zero and positive integers are both fine
+    zero = Natural(0)
+    assert zero.validate() is True
+    positive = Natural(5)
+    assert positive.validate() is True

--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -665,3 +665,54 @@ def test_register_with_valid_data_succeeds(client):
         },
     )
     assert rv.status_code == 302
+
+
+def test_usersettings_ui_without_natural_fields_does_not_crash(client):
+    """
+    Regression test: Natural = AnyInteger.validated_by(ValueAtLeast(0))
+    silently dropped AnyInteger's inherited Converted() validator, since
+    .validated_by() replaces a validator list rather than appending to
+    it. edit_rows and results_per_page (both Natural, neither optional)
+    had no guard left to catch a missing value before ValueAtLeast(0),
+    so a POST that omits them reached it with a None value and crashed
+    with an unhandled TypeError instead of failing validation normally.
+    """
+    create_user("moin", "Xiwejr622")
+    login(client, "moin", "Xiwejr622")
+
+    rv = client.post(url_for("frontend.usersettings"), data={"part": "ui", "css_file": ""})
+    assert rv.status_code == 200
+    assert b"is not correct" in rv.data
+
+
+def test_usersettings_ui_with_negative_value_is_rejected_not_crashed(client):
+    """
+    A present but invalid (negative) value must still be rejected
+    normally -- only the missing/blank case was ever at risk of
+    crashing.
+    """
+    create_user("moin", "Xiwejr622")
+    login(client, "moin", "Xiwejr622")
+
+    rv = client.post(
+        url_for("frontend.usersettings"),
+        data={"part": "ui", "css_file": "", "edit_rows": "-1", "results_per_page": "50"},
+    )
+    assert rv.status_code == 200
+    assert b"must be greater than or equal to 0" in rv.data
+
+
+def test_usersettings_ui_with_valid_data_succeeds(client):
+    """
+    A normal, fully valid settings update must still work.
+    """
+    create_user("moin", "Xiwejr622")
+    login(client, "moin", "Xiwejr622")
+
+    rv = client.post(
+        url_for("frontend.usersettings"),
+        data={"part": "ui", "css_file": "", "edit_rows": "10", "results_per_page": "25"},
+    )
+    assert rv.status_code == 200
+    assert b'name="edit_rows" value="10"' in rv.data
+    assert b'name="results_per_page" value="25"' in rv.data

--- a/src/moin/forms.py
+++ b/src/moin/forms.py
@@ -345,7 +345,10 @@ _Integer = Integer.validated_by(Converted())
 
 AnyInteger = _Integer.with_properties(widget=WIDGET_ANY_INTEGER)
 
-Natural = AnyInteger.validated_by(ValueAtLeast(0))
+# Converted() must come first: .validated_by() replaces rather than
+# appends, so it would otherwise drop AnyInteger's inherited None-guard
+# and let a missing field crash ValueAtLeast(0) instead of failing normally.
+Natural = AnyInteger.validated_by(Converted(), ValueAtLeast(0))
 
 SmallNatural = _Integer.with_properties(widget=WIDGET_SMALL_NATURAL)
 


### PR DESCRIPTION
Same bug as the /+register crash (abcf04074d24), different mechanism: .validated_by() replaces a class's validators rather than appending, so Natural = AnyInteger.validated_by(ValueAtLeast(0)) silently dropped the Converted() that AnyInteger inherits from _Integer. Without it, a missing edit_rows/results_per_page (both Natural, neither optional on UserSettingsUIForm) reached ValueAtLeast(0) with value=None, and "None >= 0" crashed with an unhandled TypeError.

Add Converted() back in front of ValueAtLeast(0) -- flatland's validator chain stops at the first failure, so a missing value never reaches ValueAtLeast(0) now. A present-but-invalid value (e.g. -1) still reaches it and is rejected normally. SmallNatural is unaffected: it's built via .with_properties(), which doesn't touch validators.

Adds a field-level unit test for Natural (missing/blank/negative/zero/ positive) plus integration tests posting to /+usersettings (ui tab). Confirmed the two crash-reproducing tests fail against the unpatched code and pass with this fix; the other two are unaffected either way.