### PR TITLE
Fix open redirect on login POST via crafted nexturl

### DIFF
--- a/src/moin/apps/_tests/utils.py
+++ b/src/moin/apps/_tests/utils.py
@@ -7,7 +7,7 @@ from typing import Any, TYPE_CHECKING
 
 from flask import url_for
 
-from moin import user
+from moin import current_app, user
 from moin.constants.itemtypes import ITEMTYPE_DEFAULT
 from moin.constants.keys import ITEMID
 
@@ -35,7 +35,10 @@ def create_user(name: str, password: str, pwencoded: bool = False, email: str | 
     user.create_user(name, password, email, is_encrypted=pwencoded)
 
 
-def login(client: FlaskClient, username: str, password: str, next: str = "http://localhost/Home") -> None:
+def login(client: FlaskClient, username: str, password: str, next: str | None = None) -> None:
+    if next is None:
+        # same-origin target derived from the wiki's configured host
+        next = current_app.cfg.interwiki_map["Self"] + "Home"
     response = client.post(
         url_for("frontend.login"),
         follow_redirects=False,

--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -348,17 +348,42 @@ class TestFrontend:
         username = "moin"
         password = "Xiwejr622"
         create_user(username, password)
+        # same-origin target derived from the wiki's own URL, matching the
+        # interwiki_map["Self"] base the test app is configured with
+        nexturl = current_app.cfg.interwiki_map["Self"] + "Home"
         response = self._test_view_post(
             "frontend.login",
             form={
                 "login_username": username,
                 "login_password": password,
-                "login_nexturl": "http://localhost/Home",
+                "login_nexturl": nexturl,
                 "login_submit": "1",
             },
             data=("Redirecting...",),
         )
-        assert response.location == "http://localhost/Home"
+        assert response.location == nexturl
+
+    def test_login_post_open_redirect_blocked(self):
+        # A crafted nexturl pointing off-site must not redirect the freshly
+        # authenticated user away from the wiki; it falls back to the root.
+        username = "moin"
+        password = "Xiwejr622"
+        create_user(username, password)
+        response = self._test_view_post(
+            "frontend.login",
+            form={
+                "login_username": username,
+                "login_password": password,
+                "login_nexturl": "https://evil.example/phish",
+                "login_submit": "1",
+            },
+            data=("Redirecting...",),
+        )
+        # The fallback redirect is root-relative (e.g. "/"), never an
+        # absolute URL, so an off-site host cannot appear in it.
+        assert not response.location.startswith("http")
+        assert "evil.example" not in response.location
+        assert "/+" not in response.location
 
     def test_logout(self):
         self._test_view("frontend.logout", status="302 FOUND", data=["<!doctype html"])

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -2517,8 +2517,14 @@ def login():
         form = LoginForm.from_flat(request.form)
         if form.validate():
             flash(_("You are logged in."), "info")
-            nexturl = form["nexturl"]
-            return redirect(str(nexturl))
+            nexturl = str(form["nexturl"])
+            # nexturl is a hidden form field fed from arbitrary POST data.
+            # Only honour it when it points back into this wiki; a crafted
+            # value would otherwise open-redirect a freshly-authenticated
+            # user off-site after login.
+            if not nexturl.startswith(request.host_url) or "/+" in nexturl:
+                nexturl = url_for(".show_root")
+            return redirect(nexturl)
         # this is executed when login fails due to bad ID or pw - app.py > def setup_user does successful logins
         for msg in flaskg._login_messages:
             # flash the error messages for failed login


### PR DESCRIPTION
Closes the open redirect on the /+login POST handler: a crafted `nexturl` hidden field could redirect a freshly-authenticated user off-site. Applies the same host + control-path validation the GET path and logout() already use, falling back to the wiki root. Adds a regression test.