### PR TITLE
ci: add optional Lumi review queue

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -39,6 +39,12 @@ jobs:
         shell: bash
         run: bandit -c pyproject.toml -r src/moin -f sarif -o results.sarif || true
 
+      - name: Prioritise Bandit findings with Lumi Trace (optional)
+        continue-on-error: true
+        uses: noqt/Lumi-Trace@60ceacaa5b92718cc50bbed4e5ce34da7e85e093 # v0.10.0
+        with:
+          sarif: results.sarif
+
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v4
         with:


### PR DESCRIPTION
Bandit's existing scan and SARIF upload stay unchanged. This adds a non-blocking Lumi Trace step that consumes the local `results.sarif` and puts a short reviewer-priority queue in the workflow summary.

The action is pinned to the immutable v0.10.0 commit. It adds no permissions, uploads no Lumi artifact, and `continue-on-error` keeps it optional.

One GitHub detail for fork PRs: the workflow may be held until a maintainer reviews the workflow change and selects **Approve workflows to run**. GitHub documents that path here: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/approve-runs-from-forks. Once it runs, Lumi's queue appears in the workflow job summary; no Lumi artifact is uploaded by this change.

Disclosure: I maintain Lumi Trace at NOQT. I'm proposing it here because Moin already produces Bandit SARIF; Lumi doesn't run or alter Bandit and makes no hosted model or API call.

Checks:
- workflow YAML parsed successfully
- `git diff --check`