### PR TITLE
Wrap single-line syntax-highlight views

### DIFF
--- a/src/moin/converters/_tests/test_pygments_in.py
+++ b/src/moin/converters/_tests/test_pygments_in.py
@@ -1,0 +1,25 @@
+# Copyright: 2026 NOQT
+# License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
+
+"""Tests for the Pygments input converter."""
+
+import pytest
+
+from moin.converters.pygments_in import Converter
+from moin.utils.tree import moin_page
+
+
+@pytest.mark.parametrize(
+    "text, expected_class",
+    [
+        ("<article>one line</article>", "highlight wrap"),
+        ("<article>one line</article>\n", "highlight wrap"),
+        ("<article>\n    <para>indented</para>\n</article>\n", "highlight"),
+    ],
+)
+def test_wrap_class_for_single_line_content(text, expected_class):
+    doc = Converter(contenttype="application/docbook+xml")(text)
+
+    blockcode = doc[0][0]
+
+    assert blockcode.get(moin_page.class_) == expected_class

--- a/src/moin/converters/pygments_in.py
+++ b/src/moin/converters/pygments_in.py
@@ -33,7 +33,6 @@ logger = getLogger(__name__)
 if pygments:
 
     class TreeFormatter(pygments.formatter.Formatter):
-
         def _append(self, type, value, element):
             class_ = STANDARD_TYPES.get(type)
             if class_:
@@ -59,7 +58,6 @@ if pygments:
                 self._append(lasttype, lastval, element)
 
     class Converter(ConverterBase):
-
         @classmethod
         def _factory(cls, type_input: Type, type_output: Type, **kwargs: Any) -> Self | None:
             pygments_name: str | None = None
@@ -129,7 +127,10 @@ if pygments:
             text = decode_data(data, contenttype)
             content = normalize_split_text(text)
             content = "\n".join(content)
-            blockcode = moin_page.blockcode(attrib={moin_page.class_: "highlight"})
+            text_without_trailing_newlines = text.rstrip("\r\n")
+            is_single_line = "\n" not in text_without_trailing_newlines and "\r" not in text_without_trailing_newlines
+            class_ = "highlight wrap" if is_single_line else "highlight"
+            blockcode = moin_page.blockcode(attrib={moin_page.class_: class_})
             pygments.highlight(content, self.lexer, TreeFormatter(), blockcode)
             body = moin_page.body(children=(blockcode,))
             return moin_page.page(children=(body,))
@@ -143,7 +144,6 @@ if pygments:
 else:
     # we have no Pygments, minimal Converter replacement, so highlight view does not crash
     class Converter(ConverterBase):
-
         def __init__(self, lexer: Any | None = None, contenttype: str | None = None, **kwargs: Any) -> None:
             super().__init__(**kwargs)
 


### PR DESCRIPTION
This makes converted one-line DocBook readable without changing the normal code view.

What changed:
- highlighted content with one logical line gets Moin's existing `wrap` class
- multiline and indentation-sensitive content stays preformatted
- regression coverage includes no trailing newline, one trailing newline, and multiline indented XML

Validation:
- 1,298 converter tests passed
- 4 focused highlight tests passed
- Black, Ruff, Bandit, and `git diff --check` passed

Fixes #2112

I'm contributing this from NOQT; our earlier Lumi/Moin integration work put this view back in front of us.