### PR TITLE
Render newest nested page trail item as one link

### DIFF
--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -16,7 +16,7 @@ import pytest
 from flask import url_for
 from werkzeug.datastructures import FileStorage
 
-from moin import current_app, flaskg, user
+from moin import current_app, flaskg, themes, user
 from moin.constants.keys import CURRENT, REVID
 from moin.apps._tests.utils import (
     create_user,
@@ -555,6 +555,31 @@ def test_normal_item_404_is_still_themed(client):
     rv = client.get(url_for("frontend.show_item", item_name="DoesNotExist"))
     assert rv.status_code == 404
     assert b"moin-header" in rv.data
+
+
+@pytest.mark.parametrize("theme_name", ["topside", "focus"])
+def test_last_nested_trail_item_is_one_link(client, monkeypatch, theme_name):
+    """The newest nested trail item is one link, not one link per path segment."""
+    theme = current_app.theme_manager.themes[theme_name]
+    monkeypatch.setattr(themes, "get_current_theme", lambda: theme)
+    with client.session_transaction() as session:
+        session["trail"] = [("MoinTest/Home/test/sub", [])]
+
+    rv = client.get(url_for("frontend.show_item", item_name="Home/test/sub"))
+    assert rv.status_code == 404
+
+    html = rv.get_data(as_text=True)
+    marker = '<div class="moin-breadcrumb">' if theme_name == "focus" else '<ul class="moin-breadcrumb">'
+    end_marker = "<!-- Breadcrumb - End -->" if theme_name == "focus" else "</ul>"
+    start = html.index(marker)
+    end = html.index(end_marker, start)
+    breadcrumb = html[start:end]
+
+    assert 'href="/Home/test/sub"' in breadcrumb
+    assert 'href="/Home"' not in breadcrumb
+    assert 'href="/Home/test"' not in breadcrumb
+    if theme_name == "focus":
+        assert 'class="moin-nonexistent"' in breadcrumb
 
 
 def test_show_old_revision_of_renamed_item(client):

--- a/src/moin/templates/utils.html
+++ b/src/moin/templates/utils.html
@@ -272,7 +272,7 @@ nonce="{{ csp_nonce() }}"
     and an optional title_name (means current view is a Navigation Link: History, Index, Tags...).
         - if an item has alias names, all alias names must be provided (themes can show, suppress or provide a rollover action)
         - if an item is not in the default namespace, the namespace will be prefixed to the item name
-        - last item on page trail must show individual links to all parent items
+        - the last item on the page trail is one link to the complete item name
     #}
     <ul class="moin-breadcrumb">
         <li class="moin-panel-heading">{{ _('Page Trail') }}</li>
@@ -289,17 +289,7 @@ nonce="{{ csp_nonce() }}"
                 {%- if loop.last %}
                     <li>
                         <span class="moin-big">
-                            {%- for segment_name, segment_path in theme_supp.location_breadcrumbs(fqname) -%}
-                                {%- if not loop.last %}
-                                    <a href="{{ url_for('frontend.show_item', item_name=segment_path) }}">
-                                        {{ segment_name|shorten_fqname }}
-                                    </a>
-                                {%- else %}
-                                    <a href="{{ url_for('frontend.show_item', item_name=segment_path) }}">
-                                        {{ segment_name|shorten_fqname }}
-                                    </a>
-                                {%- endif %}
-                            {%- endfor %}
+                            {{ page_trail_link(wiki_name, fqname) }}
                         </span>
                         {{ alias_list(aliases) }}
                     </li>

--- a/src/moin/themes/focus/templates/layout.html
+++ b/src/moin/themes/focus/templates/layout.html
@@ -88,7 +88,7 @@
                 and an optional title_name (means current view is a Navigation Link: History, Index, Tags...).
                     - if an item has alias names, all alias names must be provided (themes can show, suppress or provide a rollover action)
                     - if an item is not in the default namespace, the namespace will be prefixed to the item name
-                    - last item on page trail must show individual links to all parent items
+                    - the last item on the page trail is one link to the complete item name
                 #}
                 <div class="moin-breadcrumb">
                     <div class="moin-panel-heading"><i>{{ _('Page Trail') }}</i></div>
@@ -104,17 +104,9 @@
                                 {%- endif %}
                                 {%- if loop.last %}
                                     <li>
-                                        {%- for segment_name, segment_path in theme_supp.location_breadcrumbs(fqname) -%}
-                                            {%- if not loop.last %}
-                                                <a href="{{ url_for('frontend.show_item', item_name=segment_path) }}" {%- if not exists -%}class="moin-nonexistent"{%- endif -%}>
-                                                    {{ segment_name|shorten_fqname }}
-                                                </a>
-                                            {%- else %}
-                                                <a href="{{ url_for('frontend.show_item', item_name=segment_path) }}" {% if not exists %}class="moin-nonexistent"{% endif %}>
-                                                    {{ segment_name|shorten_fqname }}
-                                                </a>
-                                            {%- endif %}
-                                        {%- endfor %}
+                                        <a href="{{ url_for('frontend.show_item', item_name=fqname) }}" {% if not exists %}class="moin-nonexistent"{% endif %}>
+                                            {{ fqname|shorten_fqname }}
+                                        </a>
                                         {{ utils.alias_list(aliases) }}
                                     </li>
                                     {%- if title_name %}


### PR DESCRIPTION
The newest nested page in the trail currently gets split into a separate link for every path segment. That makes `Home/test/sub` look like three different trail actions even though it's one history entry.

This keeps the newest entry as one complete link in the shared breadcrumb template and the Focus theme. Older trail entries and aliases are unchanged, and Focus still marks missing pages.

Tests:
- `pytest src/moin/apps/frontend/_tests src/moin/themes/_tests -q` (77 passed)
- focused Topside and Focus regression (2 passed)
- Black, Ruff, and `git diff --check`

Built and submitted by NOQT. Fixes #1910.