### PR TITLE
Keep utility views out of the page trail

### DIFF
--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -16,7 +16,7 @@ import pytest
 from flask import url_for
 from werkzeug.datastructures import FileStorage
 
-from moin import current_app, flaskg, user
+from moin import current_app, flaskg, themes, user
 from moin.constants.keys import CURRENT, REVID
 from moin.apps._tests.utils import (
     create_user,
@@ -555,6 +555,38 @@ def test_normal_item_404_is_still_themed(client):
     rv = client.get(url_for("frontend.show_item", item_name="DoesNotExist"))
     assert rv.status_code == 404
     assert b"moin-header" in rv.data
+
+
+@pytest.mark.parametrize("theme_name", ["topside", "focus"])
+@pytest.mark.parametrize(
+    ("view_name", "special_view_title"),
+    [
+        ("frontend.global_history", "Global History"),
+        ("frontend.index", "Global Index"),
+        ("frontend.global_tags", "Global Tags"),
+    ],
+)
+def test_special_view_title_is_not_appended_to_page_trail(
+    client, monkeypatch, theme_name, view_name, special_view_title
+):
+    """Utility-view titles do not become an extra entry in the item trail."""
+    theme = current_app.theme_manager.themes[theme_name]
+    monkeypatch.setattr(themes, "get_current_theme", lambda: theme)
+    with client.session_transaction() as session:
+        session["trail"] = [("MoinTest/Home", [])]
+
+    rv = client.get(url_for(view_name))
+    assert rv.status_code == 200
+
+    html = rv.get_data(as_text=True)
+    marker = '<div class="moin-breadcrumb">' if theme_name == "focus" else '<ul class="moin-breadcrumb">'
+    end_marker = "<!-- Breadcrumb - End -->" if theme_name == "focus" else "</ul>"
+    start = html.index(marker)
+    end = html.index(end_marker, start)
+    breadcrumb = html[start:end]
+
+    assert 'href="/Home"' in breadcrumb
+    assert special_view_title not in breadcrumb
 
 
 def test_show_old_revision_of_renamed_item(client):

--- a/src/moin/templates/utils.html
+++ b/src/moin/templates/utils.html
@@ -268,8 +268,9 @@ nonce="{{ csp_nonce() }}"
 
 {% macro breadcrumbs(breadcrumbs, title_name) %}
     {#
-    Produce a page trail given a list of recently visited items,
-    and an optional title_name (means current view is a Navigation Link: History, Index, Tags...).
+    Produce a page trail given a list of recently visited items.
+    title_name remains an accepted argument for theme compatibility, but utility-view
+    titles such as History, Index, and Tags are not page-trail entries.
         - if an item has alias names, all alias names must be provided (themes can show, suppress or provide a rollover action)
         - if an item is not in the default namespace, the namespace will be prefixed to the item name
         - last item on page trail must show individual links to all parent items
@@ -303,12 +304,6 @@ nonce="{{ csp_nonce() }}"
                         </span>
                         {{ alias_list(aliases) }}
                     </li>
-                    {%- if title_name %}
-                        <li>
-                            <i class="fa fa-angle-double-right fa-fw"></i>
-                            {{ title_name }}
-                        </li>
-                    {%- endif %}
                 {%- endif %}
             {%- endfor %}
         {%- endif %}

--- a/src/moin/themes/focus/templates/layout.html
+++ b/src/moin/themes/focus/templates/layout.html
@@ -84,8 +84,8 @@
 
                 <!-- Breadcrumb - Start -->
                 {#
-                Produce a page trail given a list of recently visited items,
-                and an optional title_name (means current view is a Navigation Link: History, Index, Tags...).
+                Produce a page trail given a list of recently visited items.
+                Utility-view titles such as History, Index, and Tags are not page-trail entries.
                     - if an item has alias names, all alias names must be provided (themes can show, suppress or provide a rollover action)
                     - if an item is not in the default namespace, the namespace will be prefixed to the item name
                     - last item on page trail must show individual links to all parent items
@@ -117,11 +117,6 @@
                                         {%- endfor %}
                                         {{ utils.alias_list(aliases) }}
                                     </li>
-                                    {%- if title_name %}
-                                        <div>
-                                            {{ title_name }}
-                                        </div>
-                                    {%- endif %}
                                 {%- endif %}
                             {%- endfor %}
                         </ul>


### PR DESCRIPTION
The page trail is meant to help people jump back to recently visited wiki items. Utility views such as Global History, Global Index, and Global Tags currently get appended as an extra, non-clickable trail entry even though those views already have their own navigation links.

This removes only those appended utility labels. The real item trail stays intact in the shared templates and the separate Focus layout.

Tests:
- rendered History, Index, and Tags checks in Topside and Focus (6 passed)
- `pytest src/moin/apps/frontend/_tests src/moin/themes/_tests -q` (81 passed)
- Black, Ruff, and `git diff --check`

Built and submitted by NOQT. Fixes #1549.