### PR TITLE
Create missing filesystem stores when they open

### DIFF
--- a/src/moin/storage/backends/_tests/test_stores.py
+++ b/src/moin/storage/backends/_tests/test_stores.py
@@ -61,6 +61,18 @@ def test_open_creates_missing_fs_backend_directories(tmp_path):
     backend.close()
 
 
+def test_open_read_only_fs_backend_does_not_create_missing_directories(tmp_path):
+    meta_path = tmp_path / "meta"
+    data_path = tmp_path / "data"
+    backend = Backend(FSBytesStore(str(meta_path)), FSFileStore(str(data_path)), read_only=True)
+
+    backend.open()
+
+    assert not meta_path.exists()
+    assert not data_path.exists()
+    backend.close()
+
+
 class TestSQLABackend(MutableBackendTestBase):
     def setup_method(self, method):
         meta_path = tempfile.mktemp()

--- a/src/moin/storage/backends/_tests/test_stores.py
+++ b/src/moin/storage/backends/_tests/test_stores.py
@@ -10,6 +10,7 @@ both a file system store and a memory store.
 
 import os
 import tempfile
+from io import BytesIO
 
 from moin.storage.backends.stores import Backend
 from moin.storage.stores.memory import BytesStore as MemoryBytesStore
@@ -42,6 +43,22 @@ class TestFSBackend(MutableBackendTestBase):
         self.be = Backend(meta_store, data_store)
         self.be.create()
         self.be.open()
+
+
+def test_open_creates_missing_fs_backend_directories(tmp_path):
+    meta_path = tmp_path / "meta"
+    data_path = tmp_path / "data"
+    backend = Backend(FSBytesStore(str(meta_path)), FSFileStore(str(data_path)))
+
+    backend.open()
+    metaid = backend.store({"name": "Home"}, BytesIO(b"content"))
+    _, stored_data = backend.retrieve(metaid)
+
+    assert stored_data.read() == b"content"
+    assert meta_path.is_dir()
+    assert data_path.is_dir()
+    stored_data.close()
+    backend.close()
 
 
 class TestSQLABackend(MutableBackendTestBase):

--- a/src/moin/storage/backends/stores.py
+++ b/src/moin/storage/backends/stores.py
@@ -29,6 +29,7 @@ from moin import log
 from moin.constants.keys import REVID, DATAID, SIZE, HASH_ALGORITHM, NAME, NAMESPACE
 from moin.storage.error import ReadOnlyBackendError
 from moin.storage.stores import BytesStoreBase, FileStoreBase
+from moin.storage.stores.fs import FileStoreMixin
 from moin.storage.types import MetaData
 from moin.utils.crypto import make_uuid
 
@@ -99,6 +100,10 @@ class Backend(BackendBase):
 
     @override
     def open(self) -> None:
+        if not self.read_only:
+            for store in (self.meta_store, self.data_store):
+                if isinstance(store, FileStoreMixin):
+                    store.create()
         self.meta_store.open()
         self.data_store.open()
 

--- a/src/moin/storage/stores/fs.py
+++ b/src/moin/storage/stores/fs.py
@@ -40,6 +40,11 @@ class FileStoreMixin:
             if e.errno != errno.EEXIST:
                 raise
 
+    def open(self) -> None:
+        # A configured filesystem backend may be added after the wiki instance
+        # was created. Ensure its store directory exists before the first write.
+        self.create()
+
     def destroy(self) -> None:
         shutil.rmtree(self.path)
 

--- a/src/moin/storage/stores/fs.py
+++ b/src/moin/storage/stores/fs.py
@@ -40,11 +40,6 @@ class FileStoreMixin:
             if e.errno != errno.EEXIST:
                 raise
 
-    def open(self) -> None:
-        # A configured filesystem backend may be added after the wiki instance
-        # was created. Ensure its store directory exists before the first write.
-        self.create()
-
     def destroy(self) -> None:
         shutil.rmtree(self.path)
 


### PR DESCRIPTION
A newly configured filesystem namespace currently can't save its first page until its `data` and `meta` directories are created by hand.

This change makes a writable store-backed filesystem backend ensure those paths exist when it opens. Directory creation remains idempotent, existing stores are left alone, and read-only backends never create missing paths. Memory and database stores are unchanged.

The regressions cover both sides of the boundary: a writable backend can store and retrieve its first page from absent paths, while a read-only backend opened with absent paths creates neither directory.

Tests:
- focused writable/read-only regressions pass
- full storage suite: 108 passed, 12 skipped
- Black, Ruff, Bandit, and diff checks pass
- independent exact-head review: accepted

Built and reviewed by NOQT.

Fixes #1998
