### PR TITLE
Fix 500 on missing archive member in item download

### DIFF
--- a/src/moin/items/_tests/test_Content.py
+++ b/src/moin/items/_tests/test_Content.py
@@ -105,6 +105,37 @@ class TestTarItems:
         item = Item.create(item_name, contenttype="application/x-tar")
         assert item.content.get_member("example1.txt").read() == filecontent
 
+    def test_get_member_missing_raises_keyerror(self):
+        # A member name not present in the archive must raise KeyError
+        # (tarfile.extractfile does) rather than being silently served.
+        item_name = "ContainerItem3"
+        item = Item.create(item_name, itemtype=ITEMTYPE_DEFAULT, contenttype="application/x-tar")
+        filecontent = b"abcdefghij"
+        content_length = len(filecontent)
+        item.content.put_member("example1.txt", filecontent, content_length, True, True)
+
+        item = Item.create(item_name, contenttype="application/x-tar")
+        with pytest.raises(KeyError):
+            item.content.get_member("does-not-exist.txt")
+
+    def test_do_get_missing_member_returns_400(self):
+        # _do_get() must surface a missing archive member as 400 rather
+        # than letting the KeyError from get_member() become a 500.
+        # An absent member name is an invalid request parameter, not a
+        # missing resource.
+        item_name = "ContainerItem4"
+        item = Item.create(item_name, itemtype=ITEMTYPE_DEFAULT, contenttype="application/x-tar")
+        filecontent = b"abcdefghij"
+        content_length = len(filecontent)
+        item.content.put_member("example1.txt", filecontent, content_length, True, True)
+
+        item = Item.create(item_name, contenttype="application/x-tar")
+        from flask import current_app
+
+        with current_app.test_client() as client:
+            resp = client.get(f"/+download/{item_name}?member=does-not-exist.txt")
+            assert resp.status_code == 400
+
 
 @pytest.mark.usefixtures("_req_ctx")
 class TestZipMixin:

--- a/src/moin/items/content.py
+++ b/src/moin/items/content.py
@@ -542,7 +542,13 @@ class Binary(Content):
         if member:  # content = file contained within a archive item revision
             path, filename = os.path.split(member)
             mt = MimeType.from_filename(filename)
-            file_to_send = self.get_member(member)
+            try:
+                file_to_send = self.get_member(member)
+            except KeyError:
+                # member is a user-controlled query param naming a file
+                # inside the archive; a name not present is an invalid
+                # request rather than a missing resource
+                abort(400, f"Archive member {member!r} not found.")
             # force attachment download, so it uses attachment_filename
             # otherwise it will use the itemname from the URL for saving
             force_attachment = True


### PR DESCRIPTION
Fix 500 on missing archive member in item download

When a user requests /+download/<item>?member=<name> where name is not
present in the tar or zip archive, tarfile.extractfile()/zipfile.open()
raise KeyError, which propagates as an unhandled 500. member is a
user-controlled query parameter, so any name is reachable.

Wrap the member extraction in _do_get and surface a missing member as
400 instead. Adds a regression test that the /+download route returns
400 for a member absent from the archive.