### PR TITLE
Confirm before discarding unsaved edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
       run: |
         pip install tox
         tox -e ruff
+    - name: Test JavaScript
+      run: node --test src/moin/static/js/_tests/test_common.js
 
   pytest:
 

--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -260,6 +260,11 @@ class TestFrontend:
         cancel_buttons = document.xpath('//*[@id="moin-cancel-text-button"]')
         assert len(cancel_buttons) == 1
         assert "onclick" not in cancel_buttons[0].attrib
+        if theme_name == "topside":
+            proxy_buttons = document.xpath(
+                "//button[@onclick=\"document.getElementById('moin-cancel-text-button').click()\"]"
+            )
+            assert len(proxy_buttons) == 1
 
     def test_modify_item_show_preview(self):
 

--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -14,6 +14,7 @@ import json
 import pytest
 
 from flask import url_for
+from lxml import etree
 from werkzeug.datastructures import FileStorage
 
 from moin import current_app, flaskg, user
@@ -244,6 +245,21 @@ class TestFrontend:
 
     def test_modify_item(self):
         self._test_view("frontend.modify_item", status="200 OK", viewargs=dict(item_name="DoesntExist"))
+
+    @pytest.mark.parametrize("theme_name", ["topside", "focus", "basic"])
+    def test_modify_item_cancel_preserves_changed_state(self, monkeypatch, theme_name):
+        monkeypatch.setattr(current_app.cfg, "theme_default", theme_name)
+        with current_app.test_client() as client:
+            response = client.get(
+                url_for("frontend.modify_item", item_name="DoesntExist"),
+                query_string={"itemtype": "default", "contenttype": "text/x.moin.wiki;charset=utf-8"},
+                follow_redirects=True,
+            )
+        assert response.status == "200 OK"
+        document = etree.HTML(response.data)
+        cancel_buttons = document.xpath('//*[@id="moin-cancel-text-button"]')
+        assert len(cancel_buttons) == 1
+        assert "onclick" not in cancel_buttons[0].attrib
 
     def test_modify_item_show_preview(self):
 

--- a/src/moin/static/js/_tests/test_common.js
+++ b/src/moin/static/js/_tests/test_common.js
@@ -1,0 +1,176 @@
+// Copyright: 2026 NOQT
+// License: GNU GPL v2 (or any later version), see LICENSE.txt for details.
+
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const commonPath = path.join(__dirname, "..", "common.js");
+const commonSource = fs.readFileSync(commonPath, "utf8");
+
+function cancelScenario({changed, cancelClass = false, confirmResult = true}) {
+    const state = {
+        changed,
+        confirmCalls: 0,
+        confirmMessage: null,
+        handler: null,
+        prevented: false,
+    };
+
+    const cancelButton = {
+        click(handler) {
+            if (handler) {
+                state.handler = handler;
+            } else {
+                state.handler.call(cancelButton, {
+                    preventDefault() {
+                        state.prevented = true;
+                    },
+                });
+            }
+            return cancelButton;
+        },
+        hasClass(className) {
+            return className === "moin-cancel" && cancelClass;
+        },
+    };
+    const modifyForm = {
+        hasClass(className) {
+            return className === "moin-changed-input" && state.changed;
+        },
+        removeClass(className) {
+            if (className === "moin-changed-input") {
+                state.changed = false;
+            }
+            return modifyForm;
+        },
+    };
+    const document = {
+        getElementById(id) {
+            assert.equal(id, "moin-cancel-text-button");
+            return cancelButton;
+        },
+    };
+    const window = {
+        confirm(message) {
+            state.confirmCalls += 1;
+            state.confirmMessage = message;
+            return confirmResult;
+        },
+        location: "unchanged",
+        trustedTypes: undefined,
+    };
+
+    function $(selector) {
+        if (selector === document) {
+            return {ready() {}};
+        }
+        if (selector === cancelButton || selector === "#moin-cancel-text-button") {
+            return cancelButton;
+        }
+        if (selector === "#moin-modify") {
+            return modifyForm;
+        }
+        if (selector === "#moin-wiki-root") {
+            return {val: () => "/wiki"};
+        }
+        if (selector === "#moin-item-name") {
+            return {val: () => "Example"};
+        }
+        throw new Error(`Unexpected selector: ${selector}`);
+    }
+    $.i18n = {_: (message) => message};
+
+    const context = {document, $, window};
+    vm.runInNewContext(commonSource, context, {filename: commonPath});
+    context.cancelEdit();
+
+    function result() {
+        return {
+            changed: state.changed,
+            confirmCalls: state.confirmCalls,
+            confirmMessage: state.confirmMessage,
+            nativeNavigation: !state.prevented && !cancelClass,
+            prevented: state.prevented,
+            windowLocation: window.location,
+        };
+    }
+
+    function click() {
+        state.prevented = false;
+        cancelButton.click();
+        return result();
+    }
+
+    return {click, context, result};
+}
+
+test("rejecting discard keeps changed content on the form", () => {
+    const scenario = cancelScenario({changed: true, confirmResult: false});
+    assert.deepEqual(scenario.click(), {
+        changed: true,
+        confirmCalls: 1,
+        confirmMessage: "All changes will be discarded!",
+        nativeNavigation: false,
+        prevented: true,
+        windowLocation: "unchanged",
+    });
+});
+
+test("accepting discard allows the themed form submission to leave", () => {
+    const scenario = cancelScenario({changed: true});
+    assert.deepEqual(scenario.click(), {
+        changed: false,
+        confirmCalls: 1,
+        confirmMessage: "All changes will be discarded!",
+        nativeNavigation: true,
+        prevented: false,
+        windowLocation: "unchanged",
+    });
+});
+
+test("an unchanged themed form leaves without a dialog", () => {
+    const scenario = cancelScenario({changed: false});
+    assert.deepEqual(scenario.click(), {
+        changed: false,
+        confirmCalls: 0,
+        confirmMessage: null,
+        nativeNavigation: true,
+        prevented: false,
+        windowLocation: "unchanged",
+    });
+});
+
+test("Basic theme Cancel navigates directly after confirmation", () => {
+    const scenario = cancelScenario({changed: true, cancelClass: true});
+    assert.deepEqual(scenario.click(), {
+        changed: false,
+        confirmCalls: 1,
+        confirmMessage: "All changes will be discarded!",
+        nativeNavigation: false,
+        prevented: true,
+        windowLocation: "/wiki/Example",
+    });
+});
+
+test("Topside proxy dispatches the hidden Cancel control", () => {
+    const layoutPath = path.join(__dirname, "..", "..", "..", "themes", "topside", "templates", "layout.html");
+    const layout = fs.readFileSync(layoutPath, "utf8");
+    const proxyAction = layout.match(/<button class="moin-button" onclick="([^"]+)">Cancel<\/button>/)[1];
+    const scenario = cancelScenario({changed: true, confirmResult: false});
+
+    vm.runInNewContext(proxyAction, scenario.context);
+
+    assert.deepEqual(scenario.result(), {
+        changed: true,
+        confirmCalls: 1,
+        confirmMessage: "All changes will be discarded!",
+        nativeNavigation: false,
+        prevented: true,
+        windowLocation: "unchanged",
+    });
+});

--- a/src/moin/static/js/common.js
+++ b/src/moin/static/js/common.js
@@ -51,10 +51,17 @@ function localStorageAvailable() {
 // executed on page ready, if this is a modify view add action to Cancel button
 function cancelEdit() {
     "use strict";
-    $('.moin-cancel').click(function () {
-        // do not ask to leave page; any edits will be lost, but browser back button may restore edits
+    $('#moin-cancel-text-button').click(function (event) {
+        if ($('#moin-modify').hasClass('moin-changed-input') &&
+            !window.confirm(_("All changes will be discarded!"))) {
+            event.preventDefault();
+            return;
+        }
         $('#moin-modify').removeClass('moin-changed-input');
-        window.location = $('#moin-wiki-root').val() + '/' + $('#moin-item-name').val();
+        if ($(this).hasClass('moin-cancel')) {
+            event.preventDefault();
+            window.location = $('#moin-wiki-root').val() + '/' + $('#moin-item-name').val();
+        }
     });
 }
 

--- a/src/moin/templates/modify.html
+++ b/src/moin/templates/modify.html
@@ -98,7 +98,6 @@
                     {% set warning = "" %}
                     {{ gen.input(type='submit', id='moin-cancel-text-button', name='cancel', value=form.cancel_label,
                         class='moin-button moin-modify-submit',
-                        onclick="$('#moin-modify').removeClass('moin-changed-input')",
                         title=warning) }}
                     {% set disabled = {} if preview_supported else { 'disabled': 'disabled' } %}
                     {{ gen.input(type='submit', id='moin-preview-text-button', name='preview', value=form.preview_label,

--- a/src/moin/themes/basic/templates/modify.html
+++ b/src/moin/themes/basic/templates/modify.html
@@ -112,7 +112,6 @@
                         title=warning, **disabled) }}
                     {{ gen.input(type='submit', id='moin-cancel-text-button', name='cancel', value=form.cancel_label,
                         class='moin-button moin-cancel',
-                        onclick="$('#moin-modify').removeClass('moin-changed-input')",
                         title=warning) }}
                 </div>
             {% endif %}

--- a/src/moin/themes/focus/templates/modify.html
+++ b/src/moin/themes/focus/templates/modify.html
@@ -82,7 +82,6 @@
                         title=warning, **disabled) }}
                     {{ gen.input(type='submit', id='moin-cancel-text-button', name='cancel', value=form.cancel_label,
                         class='moin-button moin-modify-submit negative',
-                        onclick="$('#moin-modify').removeClass('moin-changed-input')",
                         title=warning) }}
                 </div>
 


### PR DESCRIPTION
Cancel could discard an editor's unsaved work without warning because each theme cleared the form's changed state before leaving.

This keeps that state until the user chooses what to do. Cancel now asks for confirmation after a real form change, while an unchanged form still closes immediately. The shared handler covers Topside, Focus, and Basic and preserves Basic's existing return-to-item behavior.

The regression suite executes the real shared JavaScript handler and covers rejecting the dialog, accepting it, unchanged forms, Basic navigation, and the Topside proxy button. CI now runs that dependency-free JavaScript test.

Tests:

- 5 JavaScript behavior tests passed
- 78 frontend and theme tests passed
- Black, Ruff, Bandit, and git diff --check passed

Fixes #1564

Built and submitted by NOQT.