### PR TITLE
Fix crash on invalid regex search terms on Python < 3.13

### DIFF
--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -741,3 +741,23 @@ def test_usersettings_ui_with_valid_data_succeeds(client):
     assert rv.status_code == 200
     assert b'name="edit_rows" value="10"' in rv.data
     assert b'name="results_per_page" value="25"' in rv.data
+
+
+def test_search_with_invalid_regex_does_not_crash(client, monkeypatch):
+    """
+    Regression test: search() used to catch re.PatternError for an invalid
+    regex term, but PatternError only exists on Python 3.13+, so on 3.11/3.12
+    the except clause itself raised AttributeError -- seen in production as
+    "module 're' has no attribute 'PatternError'".
+    """
+    import re
+    from whoosh.searching import Searcher
+
+    def fake_search(self, *args, **kwargs):
+        raise re.error("bad regex")
+
+    monkeypatch.setattr(Searcher, "search", fake_search)
+
+    rv = client.get(url_for("frontend.search"), query_string={"q": "test"})
+    assert rv.status_code == 200
+    assert b"invalid regex" in rv.data

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -579,7 +579,10 @@ def search():
             except QueryError:
                 flash(_("""QueryError: invalid search term: {search_term}""").format(search_term=q), "error")
                 return render_template("search.html", query=query, medium_search_form=search_form, item_name=item_name)
-            except re.PatternError:
+            # re.error, not re.PatternError: the latter is only available on Python 3.13+
+            # (a more clearly-named alias for re.error), and moin supports 3.11 and 3.12
+            # too, where referencing it here would itself raise an unhandled AttributeError.
+            except re.error:
                 flash(_("""QueryError: invalid regex in search term: {search_term}""").format(search_term=q), "error")
                 return render_template("search.html", query=query, medium_search_form=search_form, item_name=item_name)
             except TermNotFound:


### PR DESCRIPTION
search() caught re.PatternError for an invalid regex term, but that name only exists on Python 3.13+ (a clearer alias for re.error). On Python 3.11 and 3.12, which moin supports, referencing re.PatternError in the except clause itself raised AttributeError -- seen in production as "module 're' has no attribute 'PatternError'".

Use re.error instead, which has always existed and is kept on 3.13+ as an alias.

Adds a regression test mocking the whoosh searcher to raise re.error as the engine does for an invalid regex.