### PR TITLE
Fix 500 on /+dispatch with missing or unknown endpoint

### DIFF
--- a/src/moin/apps/frontend/_tests/test_frontend.py
+++ b/src/moin/apps/frontend/_tests/test_frontend.py
@@ -283,6 +283,16 @@ class TestFrontend:
         # TODO: Add another test with valid rev1 and rev2 URL args and an existing item.
         self._test_view("frontend.diff", status="404 NOT FOUND", viewargs=dict(item_name="DoesntExist"))
 
+    def test_dispatch_missing_or_unknown_endpoint_returns_400(self):
+        # A missing or unknown endpoint query param must return 400, not
+        # raise KeyError/BuildError as an unhandled 500.
+        with current_app.test_client() as client:
+            assert client.get("/+dispatch").status_code == 400
+            assert client.get("/+dispatch?endpoint=not-a-real-endpoint").status_code == 400
+            # a valid endpoint still forwards
+            rv = client.get("/+dispatch?endpoint=frontend.show_root")
+            assert rv.status_code == 302
+
     def test_similar_names(self):
         self._test_view("frontend.similar_names", viewargs=dict(item_name="DoesntExist"))
 

--- a/src/moin/apps/frontend/views.py
+++ b/src/moin/apps/frontend/views.py
@@ -136,7 +136,10 @@ frontend = Blueprint("frontend", __name__)
 @frontend.route("/+dispatch", methods=["GET"])
 def dispatch():
     args = request.values.to_dict()
-    endpoint = str(args.pop("endpoint"))
+    endpoint = str(args.pop("endpoint", ""))
+    # endpoint is user-supplied; a missing or unknown one returns 400
+    if not endpoint or endpoint not in current_app.url_map._rules_by_endpoint:
+        abort(400)
     # filter args given to url_for, so that no unneeded args end up in query string:
     args = {k: args[k] for k in args if current_app.url_map.is_endpoint_expecting(endpoint, k)}
     return redirect(url_for(endpoint, **args))


### PR DESCRIPTION
Fix 500 on /+dispatch with missing or unknown endpoint

When a user requests /+dispatch without an endpoint query param, or with
one naming a view that doesn't exist, args.pop("endpoint") or
is_endpoint_expecting() raises KeyError, which propagates as an
unhandled 500. Both are user-controlled inputs, so either is reachable.

Validate that endpoint is present and names a registered view before
forwarding, surfacing missing or unknown endpoints as 400. Adds a
regression test covering the missing, unknown, and valid-endpoint cases.